### PR TITLE
fix(release): align release-please PR title parsing

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,8 @@
   "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": true,
   "include-component-in-tag": false,
-  "pull-request-title-pattern": "chore: release ${component} ${version}",
+  "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
+  "group-pull-request-title-pattern": "chore${scope}: release${component} ${version}",
   "separate-pull-requests": false,
   "changelog-sections": [
     { "type": "feat", "section": "Features" },


### PR DESCRIPTION
Make manifest/group release PR titles parseable by release-please so merged release PRs can create tags automatically again.