### PR TITLE
fix(release): avoid grouped release PR parsing

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,8 +6,7 @@
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
-  "group-pull-request-title-pattern": "chore${scope}: release${component} ${version}",
-  "separate-pull-requests": false,
+  "separate-pull-requests": true,
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
Switch the single-package manifest config away from grouped release PR mode, which has upstream parsing bugs for merged release PRs and blocks automatic tagging.