### PR TITLE
fix(release): simplify single-package title parsing

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
   "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": true,
   "include-component-in-tag": false,
-  "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
+  "pull-request-title-pattern": "chore${scope}: release ${version}",
   "separate-pull-requests": true,
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
@@ -22,7 +22,6 @@
   "packages": {
     ".": {
       "package-name": "easy-nats",
-      "component": "easy-nats",
       "extra-files": [
         {
           "type": "generic",


### PR DESCRIPTION
Remove the explicit component from the single-package release-please manifest config and use a title pattern that only encodes scope and version, so merged release PRs can be parsed consistently for automatic tagging.