### PR TITLE
Use typed backend domain models

### DIFF
--- a/assets/i18n/consumer.yaml
+++ b/assets/i18n/consumer.yaml
@@ -80,6 +80,21 @@ policy_last:
 policy_new:
   en: "New"
   zh: "新消息"
+policy_by_start_sequence:
+  en: "By start sequence"
+  zh: "按起始序列"
+policy_by_start_time:
+  en: "By start time"
+  zh: "按起始时间"
+policy_last_per_subject:
+  en: "Last per subject"
+  zh: "每个主题最新"
+start_sequence:
+  en: "Start sequence:"
+  zh: "起始序列:"
+start_time:
+  en: "Start time (RFC3339):"
+  zh: "起始时间 (RFC3339):"
 ack_explicit:
   en: "Explicit"
   zh: "显式"

--- a/assets/i18n/kv.yaml
+++ b/assets/i18n/kv.yaml
@@ -20,9 +20,12 @@ delete_bucket_confirm_prompt:
 bucket:
   en: "Bucket:"
   zh: "存储桶:"
-values:
-  en: "Values:"
-  zh: "键值对数:"
+current_keys:
+  en: "Current keys:"
+  zh: "当前键数:"
+values_stored:
+  en: "Values stored:"
+  zh: "历史消息数:"
 history_depth:
   en: "History depth:"
   zh: "历史深度:"

--- a/crates/app/src/app/actions.rs
+++ b/crates/app/src/app/actions.rs
@@ -1,5 +1,11 @@
+use std::time::Duration;
+
 use eframe::egui;
-use nats_backend::{AuthMethod, BackendCommand, ConnectionConfig, MonitoringConfig};
+use nats_backend::{
+    AuthMethod, BackendCommand, ConnectionConfig, ConsumerAckPolicyKind, ConsumerConfigInput,
+    ConsumerDeliverPolicyKind, KvBucketConfigInput, MonitoringConfig, StorageKind,
+    StreamConfigInput, StreamRetentionKind,
+};
 use tokio_util::sync::CancellationToken;
 
 use crate::schema::kv_subject;
@@ -303,42 +309,19 @@ impl EasyNatsApp {
             .filter(|s| !s.is_empty())
             .collect();
 
-        let storage = match self.stream_editor.storage {
-            super::editors::StorageSelection::File => "file",
-            super::editors::StorageSelection::Memory => "memory",
-        };
-        let retention = match self.stream_editor.retention {
-            super::editors::RetentionSelection::Limits => "limits",
-            super::editors::RetentionSelection::Interest => "interest",
-            super::editors::RetentionSelection::WorkQueue => "workqueue",
-        };
-
-        let mut config = serde_json::json!({
-            "name": self.stream_editor.name.trim(),
-            "subjects": subjects,
-            "storage": storage,
-            "retention": retention,
-        });
-
-        if let Ok(v) = self.stream_editor.max_messages.parse::<i64>() {
-            config["max_msgs"] = serde_json::json!(v);
-        }
-        if let Ok(v) = self.stream_editor.max_bytes.parse::<i64>() {
-            config["max_bytes"] = serde_json::json!(v);
-        }
-        if let Ok(secs) = self.stream_editor.max_age_secs.parse::<u64>() {
-            config["max_age"] = serde_json::json!(secs * 1_000_000_000_u64);
-        }
-        if let Ok(v) = self.stream_editor.num_replicas.parse::<usize>() {
-            config["num_replicas"] = serde_json::json!(v);
-        }
-        if !self.stream_editor.description.trim().is_empty() {
-            config["description"] = serde_json::json!(self.stream_editor.description.trim());
-        }
-
         self.backend.send(BackendCommand::CreateStream {
             connection_id: self.stream_editor.connection_id,
-            config,
+            config: StreamConfigInput {
+                name: self.stream_editor.name.trim().to_string(),
+                subjects,
+                storage: storage_kind(self.stream_editor.storage),
+                retention: retention_kind(self.stream_editor.retention),
+                max_messages: parse_optional(&self.stream_editor.max_messages),
+                max_bytes: parse_optional(&self.stream_editor.max_bytes),
+                max_age: parse_seconds(&self.stream_editor.max_age_secs),
+                num_replicas: parse_optional(&self.stream_editor.num_replicas),
+                description: trimmed_optional(&self.stream_editor.description),
+            },
         });
         self.stream_editor.visible = false;
     }
@@ -366,117 +349,75 @@ impl EasyNatsApp {
     }
 
     pub(crate) fn save_consumer_editor(&mut self) {
-        let mut config = serde_json::json!({
-            "name": self.consumer_editor.name.trim(),
-            "deliver_policy": self.consumer_editor.deliver_policy.as_wire(),
-            "ack_policy": self.consumer_editor.ack_policy.as_wire(),
-        });
-
-        if self.consumer_editor.durable {
-            config["durable_name"] = serde_json::json!(self.consumer_editor.name.trim());
-        }
-        if !self.consumer_editor.filter_subject.trim().is_empty() {
-            config["filter_subject"] =
-                serde_json::json!(self.consumer_editor.filter_subject.trim());
-        }
-        if let Ok(v) = self.consumer_editor.max_deliver.parse::<i64>() {
-            config["max_deliver"] = serde_json::json!(v);
-        }
-        if let Ok(v) = self.consumer_editor.max_ack_pending.parse::<i64>() {
-            config["max_ack_pending"] = serde_json::json!(v);
-        }
-        if !self.consumer_editor.description.trim().is_empty() {
-            config["description"] = serde_json::json!(self.consumer_editor.description.trim());
-        }
-
+        let name = self.consumer_editor.name.trim().to_string();
         self.backend.send(BackendCommand::CreateConsumer {
             connection_id: self.consumer_editor.connection_id,
             stream: self.consumer_editor.stream_name.clone(),
-            config,
+            config: ConsumerConfigInput {
+                name: name.clone(),
+                durable_name: self.consumer_editor.durable.then_some(name),
+                filter_subject: trimmed_optional(&self.consumer_editor.filter_subject),
+                deliver_policy: deliver_policy_kind(self.consumer_editor.deliver_policy),
+                ack_policy: ack_policy_kind(self.consumer_editor.ack_policy),
+                max_deliver: parse_optional(&self.consumer_editor.max_deliver),
+                max_ack_pending: parse_optional(&self.consumer_editor.max_ack_pending),
+                description: trimmed_optional(&self.consumer_editor.description),
+            },
         });
         self.consumer_editor.visible = false;
     }
 
     pub(crate) fn save_kv_bucket_editor(&mut self) {
-        let storage = match self.kv_bucket_editor.storage {
-            super::editors::StorageSelection::File => "file",
-            super::editors::StorageSelection::Memory => "memory",
-        };
-
-        let mut config = serde_json::json!({
-            "bucket": self.kv_bucket_editor.bucket.trim(),
-            "history": self.kv_bucket_editor.history.parse::<i64>().unwrap_or(1),
-            "storage": storage,
-        });
-
-        if let Ok(v) = self.kv_bucket_editor.max_value_size.parse::<i32>() {
-            config["max_value_size"] = serde_json::json!(v);
-        }
-        if let Ok(v) = self.kv_bucket_editor.max_bytes.parse::<i64>() {
-            config["max_bytes"] = serde_json::json!(v);
-        }
-        if let Ok(secs) = self.kv_bucket_editor.max_age_secs.parse::<u64>() {
-            config["max_age"] = serde_json::json!(secs * 1_000_000_000_u64);
-        }
-        if let Ok(v) = self.kv_bucket_editor.num_replicas.parse::<usize>() {
-            config["num_replicas"] = serde_json::json!(v);
-        }
-        if !self.kv_bucket_editor.description.trim().is_empty() {
-            config["description"] = serde_json::json!(self.kv_bucket_editor.description.trim());
-        }
-
         self.backend.send(BackendCommand::CreateKvBucket {
             connection_id: self.kv_bucket_editor.connection_id,
-            config,
+            config: KvBucketConfigInput {
+                bucket: self.kv_bucket_editor.bucket.trim().to_string(),
+                history: self.kv_bucket_editor.history.parse::<i64>().unwrap_or(1),
+                storage: storage_kind(self.kv_bucket_editor.storage),
+                max_value_size: parse_optional(&self.kv_bucket_editor.max_value_size),
+                max_bytes: parse_optional(&self.kv_bucket_editor.max_bytes),
+                max_age: parse_seconds(&self.kv_bucket_editor.max_age_secs),
+                num_replicas: parse_optional(&self.kv_bucket_editor.num_replicas),
+                description: trimmed_optional(&self.kv_bucket_editor.description),
+            },
         });
         self.kv_bucket_editor.visible = false;
     }
 
     pub(crate) fn save_consumer_edit_editor(&mut self) {
-        let mut config = self.consumer_edit_editor.original_config["config"].clone();
-        config["description"] = serde_json::json!(self.consumer_edit_editor.description.trim());
-        if let Ok(v) = self.consumer_edit_editor.max_deliver.parse::<i64>() {
-            config["max_deliver"] = serde_json::json!(v);
-        }
-        if let Ok(v) = self.consumer_edit_editor.max_ack_pending.parse::<i64>() {
-            config["max_ack_pending"] = serde_json::json!(v);
-        }
-
+        let original = &self.consumer_edit_editor.original_config;
         self.backend.send(BackendCommand::UpdateConsumer {
             connection_id: self.consumer_edit_editor.connection_id,
             stream: self.consumer_edit_editor.stream_name.clone(),
-            config,
+            config: ConsumerConfigInput {
+                name: original.name.clone(),
+                durable_name: original.durable_name.clone(),
+                filter_subject: original.filter_subject.clone(),
+                deliver_policy: original.deliver_policy,
+                ack_policy: original.ack_policy,
+                max_deliver: parse_optional(&self.consumer_edit_editor.max_deliver),
+                max_ack_pending: parse_optional(&self.consumer_edit_editor.max_ack_pending),
+                description: trimmed_optional(&self.consumer_edit_editor.description),
+            },
         });
         self.consumer_edit_editor.visible = false;
     }
 
     pub(crate) fn save_kv_bucket_edit_editor(&mut self) {
         let ed = &self.kv_bucket_edit_editor;
-        let mut config = serde_json::json!({
-            "bucket": ed.bucket,
-            "history": ed.history.parse::<i64>().unwrap_or(1),
-        });
-
-        if let Ok(v) = ed.max_value_size.parse::<i32>() {
-            config["max_value_size"] = serde_json::json!(v);
-        }
-        if let Ok(v) = ed.max_bytes.parse::<i64>() {
-            config["max_bytes"] = serde_json::json!(v);
-        }
-        if let Ok(secs) = ed.max_age_secs.parse::<u64>() {
-            config["max_age"] = serde_json::json!(secs * 1_000_000_000_u64);
-        }
-        if let Ok(v) = ed.num_replicas.parse::<usize>() {
-            config["num_replicas"] = serde_json::json!(v);
-        }
-        if !ed.description.trim().is_empty() {
-            config["description"] = serde_json::json!(ed.description.trim());
-        }
-
         let connection_id = ed.connection_id;
         self.backend.send(BackendCommand::UpdateKvBucket {
             connection_id,
-            config,
+            config: KvBucketConfigInput {
+                bucket: ed.bucket.clone(),
+                history: ed.history.parse::<i64>().unwrap_or(1),
+                storage: ed.storage,
+                max_value_size: parse_optional(&ed.max_value_size),
+                max_bytes: parse_optional(&ed.max_bytes),
+                max_age: parse_seconds(&ed.max_age_secs),
+                num_replicas: parse_optional(&ed.num_replicas),
+                description: trimmed_optional(&ed.description),
+            },
         });
         self.kv_bucket_edit_editor.visible = false;
     }
@@ -675,6 +616,52 @@ fn collect_non_empty_headers(headers: &[(String, String)]) -> Option<Vec<(String
     }
 }
 
+fn parse_optional<T: std::str::FromStr>(value: &str) -> Option<T> {
+    value.trim().parse::<T>().ok()
+}
+
+fn parse_seconds(value: &str) -> Option<Duration> {
+    parse_optional::<u64>(value).map(Duration::from_secs)
+}
+
+fn trimmed_optional(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+fn storage_kind(selection: super::editors::StorageSelection) -> StorageKind {
+    match selection {
+        super::editors::StorageSelection::File => StorageKind::File,
+        super::editors::StorageSelection::Memory => StorageKind::Memory,
+    }
+}
+
+fn retention_kind(selection: super::editors::RetentionSelection) -> StreamRetentionKind {
+    match selection {
+        super::editors::RetentionSelection::Limits => StreamRetentionKind::Limits,
+        super::editors::RetentionSelection::Interest => StreamRetentionKind::Interest,
+        super::editors::RetentionSelection::WorkQueue => StreamRetentionKind::WorkQueue,
+    }
+}
+
+fn deliver_policy_kind(
+    selection: super::editors::DeliverPolicySelection,
+) -> ConsumerDeliverPolicyKind {
+    match selection {
+        super::editors::DeliverPolicySelection::All => ConsumerDeliverPolicyKind::All,
+        super::editors::DeliverPolicySelection::Last => ConsumerDeliverPolicyKind::Last,
+        super::editors::DeliverPolicySelection::New => ConsumerDeliverPolicyKind::New,
+    }
+}
+
+fn ack_policy_kind(selection: super::editors::AckPolicySelection) -> ConsumerAckPolicyKind {
+    match selection {
+        super::editors::AckPolicySelection::Explicit => ConsumerAckPolicyKind::Explicit,
+        super::editors::AckPolicySelection::All => ConsumerAckPolicyKind::All,
+        super::editors::AckPolicySelection::None => ConsumerAckPolicyKind::None,
+    }
+}
+
 fn matches_pubsub_tab(tab: &TabKind, connection_id: u64, tab_kind: PubSubTabKind) -> bool {
     match (tab_kind, tab) {
         (
@@ -696,115 +683,4 @@ fn matches_pubsub_tab(tab: &TabKind, connection_id: u64, tab_kind: PubSubTabKind
 }
 
 #[cfg(test)]
-mod tests {
-    use std::sync::{Arc, Mutex};
-
-    use nats_backend::{AuthMethod, ConnectionConfig, MonitoringConfig};
-
-    use super::EasyNatsApp;
-    use crate::log_layer::LogBuffer;
-    use crate::settings::{AppSettings, PubSubTabMode};
-    use crate::tabs::TabKind;
-    use crate::theme::ThemeId;
-
-    fn test_app(mode: PubSubTabMode) -> EasyNatsApp {
-        EasyNatsApp::new(
-            AppSettings {
-                pubsub_tab_mode: mode,
-                ..Default::default()
-            },
-            ThemeId::EguiDark,
-            Arc::new(Mutex::new(LogBuffer::default())),
-        )
-    }
-
-    fn push_metrics_connection(app: &mut EasyNatsApp, connection_id: u64) {
-        app.config.connections.push(ConnectionConfig {
-            id: connection_id,
-            name: "local".to_string(),
-            urls: vec!["nats://localhost:4222".to_string()],
-            auth: AuthMethod::None,
-            tls_enabled: false,
-            tls_first: false,
-            monitoring: Some(MonitoringConfig {
-                endpoint: "http://localhost:8222".to_string(),
-            }),
-        });
-    }
-
-    fn count_publisher_tabs(app: &EasyNatsApp, connection_id: u64) -> usize {
-        app.dock_state
-            .iter_all_tabs()
-            .filter(|(_, tab)| {
-                matches!(
-                    tab,
-                    TabKind::Publisher {
-                        connection_id: existing_id,
-                        ..
-                    } if *existing_id == connection_id
-                )
-            })
-            .count()
-    }
-
-    fn count_subscriber_tabs(app: &EasyNatsApp, connection_id: u64) -> usize {
-        app.dock_state
-            .iter_all_tabs()
-            .filter(|(_, tab)| {
-                matches!(
-                    tab,
-                    TabKind::Subscriber {
-                        connection_id: existing_id,
-                        ..
-                    } if *existing_id == connection_id
-                )
-            })
-            .count()
-    }
-
-    fn count_metrics_tabs(app: &EasyNatsApp, connection_id: u64) -> usize {
-        app.dock_state
-            .iter_all_tabs()
-            .filter(|(_, tab)| {
-                matches!(
-                    tab,
-                    TabKind::Metrics {
-                        connection_id: existing_id,
-                        ..
-                    } if *existing_id == connection_id
-                )
-            })
-            .count()
-    }
-
-    #[test]
-    fn publisher_reuses_existing_tab_when_configured() {
-        let mut app = test_app(PubSubTabMode::ReuseExisting);
-
-        app.open_or_focus_publisher_tab(7);
-        app.open_or_focus_publisher_tab(7);
-
-        assert_eq!(count_publisher_tabs(&app, 7), 1);
-    }
-
-    #[test]
-    fn subscriber_opens_new_tabs_by_default() {
-        let mut app = test_app(PubSubTabMode::NewTab);
-
-        app.open_or_focus_subscriber_tab(7);
-        app.open_or_focus_subscriber_tab(7);
-
-        assert_eq!(count_subscriber_tabs(&app, 7), 2);
-    }
-
-    #[test]
-    fn metrics_tab_focuses_existing_tab_for_same_connection() {
-        let mut app = test_app(PubSubTabMode::NewTab);
-        push_metrics_connection(&mut app, 7);
-
-        app.open_or_focus_metrics_tab(7);
-        app.open_or_focus_metrics_tab(7);
-
-        assert_eq!(count_metrics_tabs(&app, 7), 1);
-    }
-}
+mod tests;

--- a/crates/app/src/app/actions.rs
+++ b/crates/app/src/app/actions.rs
@@ -357,7 +357,7 @@ impl EasyNatsApp {
                 name: name.clone(),
                 durable_name: self.consumer_editor.durable.then_some(name),
                 filter_subject: trimmed_optional(&self.consumer_editor.filter_subject),
-                deliver_policy: deliver_policy_kind(self.consumer_editor.deliver_policy),
+                deliver_policy: deliver_policy_kind(&self.consumer_editor),
                 ack_policy: ack_policy_kind(self.consumer_editor.ack_policy),
                 max_deliver: parse_optional(&self.consumer_editor.max_deliver),
                 max_ack_pending: parse_optional(&self.consumer_editor.max_ack_pending),
@@ -393,7 +393,7 @@ impl EasyNatsApp {
                 name: original.name.clone(),
                 durable_name: original.durable_name.clone(),
                 filter_subject: original.filter_subject.clone(),
-                deliver_policy: original.deliver_policy,
+                deliver_policy: original.deliver_policy.clone(),
                 ack_policy: original.ack_policy,
                 max_deliver: parse_optional(&self.consumer_edit_editor.max_deliver),
                 max_ack_pending: parse_optional(&self.consumer_edit_editor.max_ack_pending),
@@ -644,13 +644,24 @@ fn retention_kind(selection: super::editors::RetentionSelection) -> StreamRetent
     }
 }
 
-fn deliver_policy_kind(
-    selection: super::editors::DeliverPolicySelection,
-) -> ConsumerDeliverPolicyKind {
-    match selection {
+fn deliver_policy_kind(editor: &super::editors::ConsumerCreateEditor) -> ConsumerDeliverPolicyKind {
+    match editor.deliver_policy {
         super::editors::DeliverPolicySelection::All => ConsumerDeliverPolicyKind::All,
         super::editors::DeliverPolicySelection::Last => ConsumerDeliverPolicyKind::Last,
         super::editors::DeliverPolicySelection::New => ConsumerDeliverPolicyKind::New,
+        super::editors::DeliverPolicySelection::ByStartSequence => {
+            ConsumerDeliverPolicyKind::ByStartSequence {
+                start_sequence: editor.deliver_start_sequence.parse::<u64>().unwrap_or(1),
+            }
+        }
+        super::editors::DeliverPolicySelection::ByStartTime => {
+            ConsumerDeliverPolicyKind::ByStartTime {
+                start_time: editor.deliver_start_time.trim().to_string(),
+            }
+        }
+        super::editors::DeliverPolicySelection::LastPerSubject => {
+            ConsumerDeliverPolicyKind::LastPerSubject
+        }
     }
 }
 

--- a/crates/app/src/app/actions/tests.rs
+++ b/crates/app/src/app/actions/tests.rs
@@ -1,0 +1,110 @@
+use std::sync::{Arc, Mutex};
+
+use nats_backend::{AuthMethod, ConnectionConfig, MonitoringConfig};
+
+use super::EasyNatsApp;
+use crate::log_layer::LogBuffer;
+use crate::settings::{AppSettings, PubSubTabMode};
+use crate::tabs::TabKind;
+use crate::theme::ThemeId;
+
+fn test_app(mode: PubSubTabMode) -> EasyNatsApp {
+    EasyNatsApp::new(
+        AppSettings {
+            pubsub_tab_mode: mode,
+            ..Default::default()
+        },
+        ThemeId::EguiDark,
+        Arc::new(Mutex::new(LogBuffer::default())),
+    )
+}
+
+fn push_metrics_connection(app: &mut EasyNatsApp, connection_id: u64) {
+    app.config.connections.push(ConnectionConfig {
+        id: connection_id,
+        name: "local".to_string(),
+        urls: vec!["nats://localhost:4222".to_string()],
+        auth: AuthMethod::None,
+        tls_enabled: false,
+        tls_first: false,
+        monitoring: Some(MonitoringConfig {
+            endpoint: "http://localhost:8222".to_string(),
+        }),
+    });
+}
+
+fn count_publisher_tabs(app: &EasyNatsApp, connection_id: u64) -> usize {
+    app.dock_state
+        .iter_all_tabs()
+        .filter(|(_, tab)| {
+            matches!(
+                tab,
+                TabKind::Publisher {
+                    connection_id: existing_id,
+                    ..
+                } if *existing_id == connection_id
+            )
+        })
+        .count()
+}
+
+fn count_subscriber_tabs(app: &EasyNatsApp, connection_id: u64) -> usize {
+    app.dock_state
+        .iter_all_tabs()
+        .filter(|(_, tab)| {
+            matches!(
+                tab,
+                TabKind::Subscriber {
+                    connection_id: existing_id,
+                    ..
+                } if *existing_id == connection_id
+            )
+        })
+        .count()
+}
+
+fn count_metrics_tabs(app: &EasyNatsApp, connection_id: u64) -> usize {
+    app.dock_state
+        .iter_all_tabs()
+        .filter(|(_, tab)| {
+            matches!(
+                tab,
+                TabKind::Metrics {
+                    connection_id: existing_id,
+                    ..
+                } if *existing_id == connection_id
+            )
+        })
+        .count()
+}
+
+#[test]
+fn publisher_reuses_existing_tab_when_configured() {
+    let mut app = test_app(PubSubTabMode::ReuseExisting);
+
+    app.open_or_focus_publisher_tab(7);
+    app.open_or_focus_publisher_tab(7);
+
+    assert_eq!(count_publisher_tabs(&app, 7), 1);
+}
+
+#[test]
+fn subscriber_opens_new_tabs_by_default() {
+    let mut app = test_app(PubSubTabMode::NewTab);
+
+    app.open_or_focus_subscriber_tab(7);
+    app.open_or_focus_subscriber_tab(7);
+
+    assert_eq!(count_subscriber_tabs(&app, 7), 2);
+}
+
+#[test]
+fn metrics_tab_focuses_existing_tab_for_same_connection() {
+    let mut app = test_app(PubSubTabMode::NewTab);
+    push_metrics_connection(&mut app, 7);
+
+    app.open_or_focus_metrics_tab(7);
+    app.open_or_focus_metrics_tab(7);
+
+    assert_eq!(count_metrics_tabs(&app, 7), 1);
+}

--- a/crates/app/src/app/editors.rs
+++ b/crates/app/src/app/editors.rs
@@ -1,4 +1,7 @@
 use crate::i18n::t;
+use nats_backend::{
+    ConsumerAckPolicyKind, ConsumerDeliverPolicyKind, ConsumerInfo, KvBucketInfo, StorageKind,
+};
 
 #[derive(Default)]
 pub(crate) struct ConnectionEditor {
@@ -185,14 +188,6 @@ impl DeliverPolicySelection {
             Self::New => t("consumer.policy_new"),
         }
     }
-
-    pub(crate) fn as_wire(self) -> &'static str {
-        match self {
-            Self::All => "All",
-            Self::Last => "Last",
-            Self::New => "New",
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -208,14 +203,6 @@ impl AckPolicySelection {
             Self::Explicit => t("consumer.ack_explicit"),
             Self::All => t("consumer.ack_all"),
             Self::None => t("consumer.ack_none"),
-        }
-    }
-
-    pub(crate) fn as_wire(self) -> &'static str {
-        match self {
-            Self::Explicit => "Explicit",
-            Self::All => "All",
-            Self::None => "None",
         }
     }
 }
@@ -254,6 +241,7 @@ impl RetentionSelection {
     }
 }
 
+#[derive(Default)]
 pub(crate) struct ConsumerEditEditor {
     pub(crate) visible: bool,
     pub(crate) connection_id: u64,
@@ -262,57 +250,39 @@ pub(crate) struct ConsumerEditEditor {
     pub(crate) description: String,
     pub(crate) max_deliver: String,
     pub(crate) max_ack_pending: String,
-    /// Full original config JSON, used as base for update
-    pub(crate) original_config: serde_json::Value,
+    pub(crate) original_config: ConsumerEditableConfig,
 }
 
-impl Default for ConsumerEditEditor {
-    fn default() -> Self {
-        Self {
-            visible: false,
-            connection_id: 0,
-            stream_name: String::new(),
-            consumer_name: String::new(),
-            description: String::new(),
-            max_deliver: String::new(),
-            max_ack_pending: String::new(),
-            original_config: serde_json::Value::Null,
-        }
-    }
+#[derive(Default, Debug, Clone)]
+pub(crate) struct ConsumerEditableConfig {
+    pub(crate) name: String,
+    pub(crate) durable_name: Option<String>,
+    pub(crate) filter_subject: Option<String>,
+    pub(crate) deliver_policy: ConsumerDeliverPolicyKind,
+    pub(crate) ack_policy: ConsumerAckPolicyKind,
 }
 
 impl ConsumerEditEditor {
-    pub(crate) fn from_json(
-        connection_id: u64,
-        stream_name: String,
-        json: &serde_json::Value,
-    ) -> Self {
-        let name = json["config"]["name"]
-            .as_str()
-            .or_else(|| json["config"]["durable_name"].as_str())
-            .unwrap_or_default()
-            .to_string();
-        let desc = json["config"]["description"]
-            .as_str()
-            .unwrap_or_default()
-            .to_string();
-        let max_d = json["config"]["max_deliver"]
-            .as_i64()
-            .map(|v| v.to_string())
-            .unwrap_or_default();
-        let max_a = json["config"]["max_ack_pending"]
-            .as_i64()
-            .map(|v| v.to_string())
-            .unwrap_or_default();
+    pub(crate) fn from_info(connection_id: u64, stream_name: String, info: &ConsumerInfo) -> Self {
+        let name = info
+            .durable_name
+            .clone()
+            .unwrap_or_else(|| info.name.clone());
         Self {
             visible: true,
             connection_id,
             stream_name,
-            consumer_name: name,
-            description: desc,
-            max_deliver: max_d,
-            max_ack_pending: max_a,
-            original_config: json.clone(),
+            consumer_name: name.clone(),
+            description: info.description.clone().unwrap_or_default(),
+            max_deliver: info.max_deliver.to_string(),
+            max_ack_pending: info.max_ack_pending.to_string(),
+            original_config: ConsumerEditableConfig {
+                name,
+                durable_name: info.durable_name.clone(),
+                filter_subject: info.filter_subject.clone(),
+                deliver_policy: ConsumerDeliverPolicyKind::from_display(&info.deliver_policy),
+                ack_policy: ConsumerAckPolicyKind::from_display(&info.ack_policy),
+            },
         }
     }
 }
@@ -327,46 +297,38 @@ pub(crate) struct KvBucketEditEditor {
     pub(crate) max_age_secs: String,
     pub(crate) max_value_size: String,
     pub(crate) max_bytes: String,
+    pub(crate) storage: StorageKind,
     pub(crate) num_replicas: String,
 }
 
 impl KvBucketEditEditor {
-    pub(crate) fn from_json(connection_id: u64, json: &serde_json::Value) -> Self {
-        let bucket = json["bucket"].as_str().unwrap_or_default().to_string();
-        let desc = json["description"].as_str().unwrap_or_default().to_string();
-        let history = json["history"]
-            .as_i64()
-            .map(|v| v.to_string())
-            .unwrap_or("1".to_string());
-        let max_age = json["max_age_nanos"]
-            .as_u64()
-            .filter(|&v| v > 0)
-            .map(|v| (v / 1_000_000_000).to_string())
-            .unwrap_or_default();
-        let max_vs = json["max_value_size"]
-            .as_i64()
-            .filter(|&v| v > 0)
-            .map(|v| v.to_string())
-            .unwrap_or_default();
-        let max_b = json["max_bytes"]
-            .as_i64()
-            .filter(|&v| v > 0)
-            .map(|v| v.to_string())
-            .unwrap_or_default();
-        let replicas = json["num_replicas"]
-            .as_u64()
-            .map(|v| v.to_string())
-            .unwrap_or("1".to_string());
+    pub(crate) fn from_info(connection_id: u64, info: &KvBucketInfo) -> Self {
+        let max_age = if info.max_age_secs > 0 {
+            info.max_age_secs.to_string()
+        } else {
+            String::new()
+        };
+        let max_value_size = if info.max_value_size > 0 {
+            info.max_value_size.to_string()
+        } else {
+            String::new()
+        };
+        let max_bytes = if info.max_bytes > 0 {
+            info.max_bytes.to_string()
+        } else {
+            String::new()
+        };
         Self {
             visible: true,
             connection_id,
-            bucket,
-            description: desc,
-            history,
+            bucket: info.bucket.clone(),
+            description: info.description.clone(),
+            history: info.history_depth.to_string(),
             max_age_secs: max_age,
-            max_value_size: max_vs,
-            max_bytes: max_b,
-            num_replicas: replicas,
+            max_value_size,
+            max_bytes,
+            storage: StorageKind::from_display(&info.storage),
+            num_replicas: info.num_replicas.to_string(),
         }
     }
 }

--- a/crates/app/src/app/editors.rs
+++ b/crates/app/src/app/editors.rs
@@ -118,6 +118,8 @@ pub(crate) struct ConsumerCreateEditor {
     pub(crate) name: String,
     pub(crate) durable: bool,
     pub(crate) deliver_policy: DeliverPolicySelection,
+    pub(crate) deliver_start_sequence: String,
+    pub(crate) deliver_start_time: String,
     pub(crate) ack_policy: AckPolicySelection,
     pub(crate) filter_subject: String,
     pub(crate) max_deliver: String,
@@ -134,6 +136,8 @@ impl Default for ConsumerCreateEditor {
             name: String::new(),
             durable: true,
             deliver_policy: DeliverPolicySelection::All,
+            deliver_start_sequence: "1".to_string(),
+            deliver_start_time: String::new(),
             ack_policy: AckPolicySelection::Explicit,
             filter_subject: String::new(),
             max_deliver: String::new(),
@@ -178,14 +182,29 @@ pub(crate) enum DeliverPolicySelection {
     All,
     Last,
     New,
+    ByStartSequence,
+    ByStartTime,
+    LastPerSubject,
 }
 
 impl DeliverPolicySelection {
+    pub(crate) const ALL: [Self; 6] = [
+        Self::All,
+        Self::Last,
+        Self::New,
+        Self::ByStartSequence,
+        Self::ByStartTime,
+        Self::LastPerSubject,
+    ];
+
     pub(crate) fn label(self) -> &'static str {
         match self {
             Self::All => t("consumer.policy_all"),
             Self::Last => t("consumer.policy_last"),
             Self::New => t("consumer.policy_new"),
+            Self::ByStartSequence => t("consumer.policy_by_start_sequence"),
+            Self::ByStartTime => t("consumer.policy_by_start_time"),
+            Self::LastPerSubject => t("consumer.policy_last_per_subject"),
         }
     }
 }
@@ -280,7 +299,7 @@ impl ConsumerEditEditor {
                 name,
                 durable_name: info.durable_name.clone(),
                 filter_subject: info.filter_subject.clone(),
-                deliver_policy: ConsumerDeliverPolicyKind::from_display(&info.deliver_policy),
+                deliver_policy: info.deliver_policy.clone(),
                 ack_policy: ConsumerAckPolicyKind::from_display(&info.ack_policy),
             },
         }

--- a/crates/app/src/app/events.rs
+++ b/crates/app/src/app/events.rs
@@ -60,12 +60,11 @@ impl EasyNatsApp {
                     }
                     self.conn_statuses.insert(connection_id, status);
                 }
-                BackendEvent::OperationResult {
+                BackendEvent::OperationSucceeded {
                     connection_id,
                     operation,
-                    data,
                 } => {
-                    self.handle_operation_result(connection_id, operation, data);
+                    self.handle_operation_result(connection_id, operation);
                 }
                 BackendEvent::RequestResponse {
                     connection_id,
@@ -128,19 +127,236 @@ impl EasyNatsApp {
                 } => {
                     self.apply_metrics_snapshot(connection_id, *snapshot);
                 }
+                BackendEvent::KvBucketsListed {
+                    connection_id,
+                    buckets,
+                } => {
+                    self.apply_kv_buckets(connection_id, buckets);
+                }
+                BackendEvent::KvBucketCreated {
+                    connection_id,
+                    bucket,
+                } => {
+                    self.apply_kv_bucket_changed(
+                        connection_id,
+                        nats_backend::BackendOperation::CreateKvBucket,
+                        bucket,
+                    );
+                }
+                BackendEvent::KvBucketUpdated {
+                    connection_id,
+                    bucket,
+                } => {
+                    self.apply_kv_bucket_changed(
+                        connection_id,
+                        nats_backend::BackendOperation::UpdateKvBucket,
+                        bucket,
+                    );
+                }
+                BackendEvent::KvBucketDeleted {
+                    connection_id,
+                    bucket,
+                } => {
+                    self.apply_kv_bucket_deleted(connection_id, bucket);
+                }
+                BackendEvent::KvKeysListed {
+                    connection_id,
+                    batch,
+                } => {
+                    self.apply_kv_key_batch(connection_id, batch);
+                }
+                BackendEvent::KvEntryFetched {
+                    connection_id,
+                    entry,
+                } => {
+                    self.apply_kv_entry(connection_id, entry);
+                }
+                BackendEvent::KvHistoryFetched {
+                    connection_id,
+                    bucket,
+                    key,
+                    history,
+                } => {
+                    self.apply_kv_history(connection_id, bucket, key, history);
+                }
+                BackendEvent::KvEntryMutated {
+                    connection_id,
+                    operation,
+                    bucket,
+                    key,
+                } => {
+                    self.apply_kv_entry_mutation(connection_id, operation, bucket, key);
+                }
+                BackendEvent::ObjectStoreBucketsListed {
+                    connection_id,
+                    buckets,
+                } => {
+                    self.apply_obj_store_buckets(connection_id, buckets);
+                }
+                BackendEvent::ObjectStoreBucketCreated {
+                    connection_id,
+                    bucket,
+                } => {
+                    self.apply_obj_store_bucket_created(connection_id, bucket);
+                }
+                BackendEvent::ObjectStoreBucketDeleted {
+                    connection_id,
+                    bucket,
+                } => {
+                    self.apply_obj_store_bucket_deleted(connection_id, bucket);
+                }
+                BackendEvent::ObjectStoreObjectsListed {
+                    connection_id,
+                    bucket,
+                    objects,
+                } => {
+                    self.apply_obj_store_objects(connection_id, bucket, objects);
+                }
+                BackendEvent::ObjectStoreObjectUploaded {
+                    connection_id,
+                    object,
+                } => {
+                    self.apply_obj_store_uploaded(connection_id, object);
+                }
+                BackendEvent::ObjectStoreObjectDownloaded {
+                    connection_id,
+                    result,
+                } => {
+                    self.apply_obj_store_downloaded(connection_id, result);
+                }
+                BackendEvent::ObjectStoreObjectDeleted {
+                    connection_id,
+                    bucket,
+                    name,
+                } => {
+                    self.apply_obj_store_deleted(connection_id, bucket, name);
+                }
+                BackendEvent::ServerInfoLoaded {
+                    connection_id,
+                    info,
+                } => {
+                    self.apply_server_info(connection_id, info);
+                }
+                BackendEvent::JetStreamAccountInfoLoaded {
+                    connection_id,
+                    info,
+                } => {
+                    self.apply_jetstream_account_info(connection_id, info);
+                }
+                BackendEvent::StreamsListed {
+                    connection_id,
+                    streams,
+                } => {
+                    self.apply_streams(connection_id, streams);
+                }
+                BackendEvent::StreamCreated {
+                    connection_id,
+                    stream,
+                } => {
+                    self.apply_stream_changed(
+                        connection_id,
+                        nats_backend::BackendOperation::CreateStream,
+                        stream,
+                    );
+                }
+                BackendEvent::StreamUpdated {
+                    connection_id,
+                    stream,
+                } => {
+                    self.apply_stream_changed(
+                        connection_id,
+                        nats_backend::BackendOperation::UpdateStream,
+                        stream,
+                    );
+                }
+                BackendEvent::StreamDeleted {
+                    connection_id,
+                    name,
+                } => {
+                    self.apply_stream_deleted(connection_id, name);
+                }
+                BackendEvent::StreamPurged {
+                    connection_id,
+                    name,
+                    purged,
+                } => {
+                    self.apply_stream_purged(connection_id, name, purged);
+                }
+                BackendEvent::StreamMessagesFetched {
+                    connection_id,
+                    stream,
+                    messages,
+                } => {
+                    self.apply_stream_messages(connection_id, stream, messages);
+                }
+                BackendEvent::StreamMessageDeleted {
+                    connection_id,
+                    stream,
+                    sequence,
+                } => {
+                    self.apply_stream_message_deleted(connection_id, stream, sequence);
+                }
+                BackendEvent::ConsumersListed {
+                    connection_id,
+                    stream,
+                    consumers,
+                } => {
+                    self.apply_consumers(connection_id, stream, consumers);
+                }
+                BackendEvent::ConsumerCreated {
+                    connection_id,
+                    stream,
+                    consumer: _,
+                } => {
+                    self.apply_consumer_changed(
+                        connection_id,
+                        nats_backend::BackendOperation::CreateConsumer,
+                        stream,
+                    );
+                }
+                BackendEvent::ConsumerUpdated {
+                    connection_id,
+                    stream,
+                    consumer: _,
+                } => {
+                    self.apply_consumer_changed(
+                        connection_id,
+                        nats_backend::BackendOperation::UpdateConsumer,
+                        stream,
+                    );
+                }
+                BackendEvent::ConsumerDeleted {
+                    connection_id,
+                    stream,
+                    name: _,
+                } => {
+                    self.apply_consumer_changed(
+                        connection_id,
+                        nats_backend::BackendOperation::DeleteConsumer,
+                        stream,
+                    );
+                }
+                BackendEvent::ConsumerMessagesFetched {
+                    connection_id,
+                    stream,
+                    consumer,
+                    messages,
+                } => {
+                    self.apply_consumer_messages(connection_id, stream, consumer, messages);
+                }
                 BackendEvent::Error {
                     connection_id,
                     backend_id,
                     operation,
                     message,
-                    data,
+                    context,
                 } => {
                     self.handle_error(
                         connection_id,
                         backend_id,
                         operation,
                         &message,
-                        data.as_ref(),
+                        context.as_ref(),
                     );
                 }
             }

--- a/crates/app/src/app/kv_results.rs
+++ b/crates/app/src/app/kv_results.rs
@@ -1,215 +1,222 @@
-use nats_backend::{BackendCommand, BackendOperation};
+use nats_backend::{
+    BackendCommand, BackendErrorContext, BackendOperation, KvBucketInfo, KvEntryInfo,
+    KvHistoryItem, KvKeyBatch,
+};
 
 use crate::tabs::TabKind;
 use crate::toast::ToastLevel;
 
-use super::{model::EasyNatsApp, util::decode_kv_value};
+use super::model::EasyNatsApp;
 
 impl EasyNatsApp {
-    pub(crate) fn apply_kv_operation(
+    pub(crate) fn apply_kv_buckets(&mut self, connection_id: u64, buckets: Vec<KvBucketInfo>) {
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::KvBucket {
+                connection_id: cid,
+                bucket_name,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+            {
+                state.info = buckets
+                    .iter()
+                    .find(|info| info.bucket == *bucket_name)
+                    .cloned();
+            }
+        }
+        self.kv_lists.insert(connection_id, buckets);
+    }
+
+    pub(crate) fn apply_kv_bucket_changed(
         &mut self,
         connection_id: u64,
         operation: BackendOperation,
-        data: &serde_json::Value,
-    ) -> bool {
-        match operation {
-            BackendOperation::ListKvBuckets => {
-                if let Some(arr) = data.as_array() {
-                    let infos = arr.clone();
-                    for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
-                        if let TabKind::KvBucket {
-                            connection_id: cid,
-                            bucket_name,
-                            state,
-                            ..
-                        } = tab
-                            && *cid == connection_id
-                        {
-                            state.info = infos
-                                .iter()
-                                .find(|i| i["bucket"].as_str() == Some(bucket_name.as_str()))
-                                .cloned();
-                        }
-                    }
-                    self.kv_lists.insert(connection_id, infos);
-                }
-                true
+        bucket: KvBucketInfo,
+    ) {
+        self.toasts
+            .push(ToastLevel::Success, format!("{operation} succeeded"));
+        upsert_kv_bucket(
+            self.kv_lists.entry(connection_id).or_default(),
+            bucket.clone(),
+        );
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::KvBucket {
+                connection_id: cid,
+                bucket_name,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+                && *bucket_name == bucket.bucket
+            {
+                state.info = Some(bucket.clone());
             }
-            BackendOperation::CreateKvBucket
-            | BackendOperation::DeleteKvBucket
-            | BackendOperation::UpdateKvBucket => {
-                self.toasts
-                    .push(ToastLevel::Success, format!("{operation} succeeded"));
-                if operation == BackendOperation::DeleteKvBucket
-                    && let Some(bucket) = data["bucket"].as_str()
-                {
-                    self.remove_tabs_matching(|tab| {
-                        matches!(tab, TabKind::KvBucket { connection_id: cid, bucket_name, .. }
-                            if *cid == connection_id && bucket_name == bucket)
-                    });
-                }
-                self.backend
-                    .send(BackendCommand::ListKvBuckets { connection_id });
-                true
-            }
-            BackendOperation::ListKvKeys => {
-                let bucket = data["bucket"].as_str().unwrap_or("").to_string();
-                let generation = data["generation"].as_u64().unwrap_or(0);
-                let done = data["done"].as_bool().unwrap_or(true);
-                let new_keys: Vec<String> = data["entries"]
-                    .as_array()
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|v| v["key"].as_str().map(str::to_owned))
-                            .collect()
-                    })
-                    .unwrap_or_default();
+        }
+        self.backend
+            .send(BackendCommand::ListKvBuckets { connection_id });
+    }
 
-                for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
-                    if let TabKind::KvBucket {
-                        connection_id: cid,
-                        bucket_name,
-                        state,
-                        ..
-                    } = tab
-                        && *cid == connection_id
-                        && *bucket_name == bucket
-                        && state.load_generation == generation
-                    {
-                        state.keys.extend(new_keys.clone());
-                        if !new_keys.is_empty() {
-                            state.search_generation = state.search_generation.wrapping_add(1);
-                        }
-                        if done {
-                            state.keys.sort();
-                            state.keys_complete = true;
-                            state.loading_entries = false;
-                            state.search_generation = state.search_generation.wrapping_add(1);
-                        }
-                    }
+    pub(crate) fn apply_kv_bucket_deleted(&mut self, connection_id: u64, bucket: String) {
+        self.toasts.push(
+            ToastLevel::Success,
+            format!("{} succeeded", BackendOperation::DeleteKvBucket),
+        );
+        if let Some(buckets) = self.kv_lists.get_mut(&connection_id) {
+            buckets.retain(|info| info.bucket != bucket);
+        }
+        self.remove_tabs_matching(|tab| {
+            matches!(tab, TabKind::KvBucket { connection_id: cid, bucket_name, .. }
+                if *cid == connection_id && bucket_name == &bucket)
+        });
+        self.backend
+            .send(BackendCommand::ListKvBuckets { connection_id });
+    }
+
+    pub(crate) fn apply_kv_key_batch(&mut self, connection_id: u64, batch: KvKeyBatch) {
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::KvBucket {
+                connection_id: cid,
+                bucket_name,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+                && *bucket_name == batch.bucket
+                && state.load_generation == batch.generation
+            {
+                state.keys.extend(batch.keys.clone());
+                if !batch.keys.is_empty() {
+                    state.search_generation = state.search_generation.wrapping_add(1);
                 }
-                true
-            }
-            BackendOperation::GetKvEntry => {
-                let bucket = data["bucket"].as_str().unwrap_or("").to_string();
-                let entry = data["entry"].clone();
-                let entry_key = entry["key"].as_str().unwrap_or("");
-                for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
-                    if let TabKind::KvBucket {
-                        connection_id: cid,
-                        bucket_name,
-                        state,
-                        ..
-                    } = tab
-                        && *cid == connection_id
-                        && *bucket_name == bucket
-                    {
-                        let entry_value = decode_kv_value(&entry);
-                        state
-                            .fetched_values
-                            .insert(entry_key.to_string(), entry_value.clone());
-                        state.search_generation = state.search_generation.wrapping_add(1);
-                        if state.value_search_pending.remove(entry_key) {
-                            state.value_search_scanning = state.value_search_pending.len();
-                        }
-                        if state.selected_key.as_deref() == Some(entry_key) {
-                            state.loading_entry = false;
-                            state.entry_key = entry_key.to_string();
-                            state.entry_value = entry_value;
-                            state.entry_revision = entry["revision"].as_u64();
-                            state.entry_operation = entry["operation"].as_str().map(str::to_owned);
-                            state.entry_created = entry["created"].as_str().map(str::to_owned);
-                        }
-                    }
+                if batch.done {
+                    state.keys.sort();
+                    state.keys_complete = true;
+                    state.loading_entries = false;
+                    state.search_generation = state.search_generation.wrapping_add(1);
                 }
-                true
             }
-            BackendOperation::GetKvHistory => {
-                let bucket = data["bucket"].as_str().unwrap_or("").to_string();
-                let key = data["key"].as_str().unwrap_or("");
-                let history = data["history"].as_array().cloned().unwrap_or_default();
-                for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
-                    if let TabKind::KvBucket {
-                        connection_id: cid,
-                        bucket_name,
-                        state,
-                        ..
-                    } = tab
-                        && *cid == connection_id
-                        && *bucket_name == bucket
-                        && state.selected_key.as_deref() == Some(key)
-                    {
-                        state.history = history.clone();
-                        state.loading_history = false;
-                    }
+        }
+    }
+
+    pub(crate) fn apply_kv_entry(&mut self, connection_id: u64, entry: KvEntryInfo) {
+        let entry_key = entry.key.as_str();
+        let entry_value = decode_kv_bytes(&entry.value);
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::KvBucket {
+                connection_id: cid,
+                bucket_name,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+                && *bucket_name == entry.bucket
+            {
+                state
+                    .fetched_values
+                    .insert(entry_key.to_string(), entry_value.clone());
+                state.search_generation = state.search_generation.wrapping_add(1);
+                if state.value_search_pending.remove(entry_key) {
+                    state.value_search_scanning = state.value_search_pending.len();
                 }
-                true
-            }
-            BackendOperation::PutKvEntry
-            | BackendOperation::DeleteKvEntry
-            | BackendOperation::PurgeKvEntry => {
-                let bucket = data["bucket"].as_str().unwrap_or("").to_string();
-                let key = data["key"].as_str().unwrap_or("").to_string();
-                let is_put = operation == BackendOperation::PutKvEntry;
-                self.toasts
-                    .push(ToastLevel::Success, format!("{operation} succeeded"));
-                if !bucket.is_empty() {
-                    let mut refresh_cancel = None;
-                    for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
-                        if let TabKind::KvBucket {
-                            connection_id: cid,
-                            bucket_name,
-                            state,
-                            guard,
-                            ..
-                        } = tab
-                            && *cid == connection_id
-                            && *bucket_name == bucket
-                        {
-                            let new_gen = crate::tabs::next_generation();
-                            state.loading_entries = true;
-                            state.load_generation = new_gen;
-                            state.keys.clear();
-                            state.fetched_values.clear();
-                            state.value_search_cursor = 0;
-                            state.value_search_scanning = 0;
-                            state.value_search_pending.clear();
-                            state.search_generation = state.search_generation.wrapping_add(1);
-                            state.keys_complete = false;
-                            if is_put && !key.is_empty() {
-                                state.selected_key = Some(key.clone());
-                                state.show_history = false;
-                            }
-                            if state.selected_key.as_deref() == Some(key.as_str()) {
-                                state.loading_history = true;
-                            }
-                            refresh_cancel = Some((guard.cancellation(), new_gen));
-                        }
-                    }
-                    if let Some((cancel, generation)) = refresh_cancel {
-                        self.backend.send(BackendCommand::ListKvKeys {
-                            connection_id,
-                            bucket: bucket.clone(),
-                            cancel,
-                            generation,
-                        });
-                    }
-                    if !key.is_empty() {
-                        self.backend.send(BackendCommand::GetKvEntry {
-                            connection_id,
-                            bucket: bucket.clone(),
-                            key: key.clone(),
-                        });
-                        self.backend.send(BackendCommand::GetKvHistory {
-                            connection_id,
-                            bucket,
-                            key,
-                        });
-                    }
+                if state.selected_key.as_deref() == Some(entry_key) {
+                    state.loading_entry = false;
+                    state.entry_key = entry_key.to_string();
+                    state.entry_value = entry_value.clone();
+                    state.entry_revision = entry.revision;
+                    state.entry_operation = entry.operation.clone();
+                    state.entry_created = entry.created.clone();
                 }
-                true
             }
-            _ => false,
+        }
+    }
+
+    pub(crate) fn apply_kv_history(
+        &mut self,
+        connection_id: u64,
+        bucket: String,
+        key: String,
+        history: Vec<KvHistoryItem>,
+    ) {
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::KvBucket {
+                connection_id: cid,
+                bucket_name,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+                && *bucket_name == bucket
+                && state.selected_key.as_deref() == Some(key.as_str())
+            {
+                state.history = history.clone();
+                state.loading_history = false;
+            }
+        }
+    }
+
+    pub(crate) fn apply_kv_entry_mutation(
+        &mut self,
+        connection_id: u64,
+        operation: BackendOperation,
+        bucket: String,
+        key: String,
+    ) {
+        let is_put = operation == BackendOperation::PutKvEntry;
+        self.toasts
+            .push(ToastLevel::Success, format!("{operation} succeeded"));
+
+        let mut refresh_cancel = None;
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::KvBucket {
+                connection_id: cid,
+                bucket_name,
+                state,
+                guard,
+                ..
+            } = tab
+                && *cid == connection_id
+                && *bucket_name == bucket
+            {
+                let new_gen = crate::tabs::next_generation();
+                state.loading_entries = true;
+                state.load_generation = new_gen;
+                state.keys.clear();
+                state.fetched_values.clear();
+                state.value_search_cursor = 0;
+                state.value_search_scanning = 0;
+                state.value_search_pending.clear();
+                state.search_generation = state.search_generation.wrapping_add(1);
+                state.keys_complete = false;
+                if is_put && !key.is_empty() {
+                    state.selected_key = Some(key.clone());
+                    state.show_history = false;
+                }
+                if state.selected_key.as_deref() == Some(key.as_str()) {
+                    state.loading_history = true;
+                }
+                refresh_cancel = Some((guard.cancellation(), new_gen));
+            }
+        }
+        if let Some((cancel, generation)) = refresh_cancel {
+            self.backend.send(BackendCommand::ListKvKeys {
+                connection_id,
+                bucket: bucket.clone(),
+                cancel,
+                generation,
+            });
+        }
+        if !key.is_empty() {
+            self.backend.send(BackendCommand::GetKvEntry {
+                connection_id,
+                bucket: bucket.clone(),
+                key: key.clone(),
+            });
+            self.backend.send(BackendCommand::GetKvHistory {
+                connection_id,
+                bucket,
+                key,
+            });
         }
     }
 
@@ -217,7 +224,7 @@ impl EasyNatsApp {
         &mut self,
         connection_id: u64,
         operation: BackendOperation,
-        data: Option<&serde_json::Value>,
+        context: Option<&BackendErrorContext>,
     ) {
         match operation {
             BackendOperation::ListKvKeys => {
@@ -247,8 +254,12 @@ impl EasyNatsApp {
                 }
             }
             BackendOperation::GetKvEntry => {
-                let failed_bucket = data.and_then(|data| data["bucket"].as_str());
-                let failed_key = data.and_then(|data| data["key"].as_str());
+                let (failed_bucket, failed_key) = match context {
+                    Some(BackendErrorContext::KvEntry { bucket, key }) => {
+                        (Some(bucket.as_str()), Some(key.as_str()))
+                    }
+                    None => (None, None),
+                };
                 for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
                     if let TabKind::KvBucket {
                         connection_id: tab_cid,
@@ -282,12 +293,25 @@ impl EasyNatsApp {
     }
 }
 
+fn upsert_kv_bucket(buckets: &mut Vec<KvBucketInfo>, bucket: KvBucketInfo) {
+    if let Some(existing) = buckets.iter_mut().find(|info| info.bucket == bucket.bucket) {
+        *existing = bucket;
+    } else {
+        buckets.push(bucket);
+        buckets.sort_by(|a, b| a.bucket.cmp(&b.bucket));
+    }
+}
+
+fn decode_kv_bytes(value: &[u8]) -> String {
+    String::from_utf8_lossy(value).to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::{Arc, Mutex};
 
     use egui_dock::DockState;
-    use nats_backend::BackendOperation;
+    use nats_backend::{BackendErrorContext, BackendOperation};
     use tokio_util::sync::CancellationToken;
 
     use super::EasyNatsApp;
@@ -324,12 +348,12 @@ mod tests {
         };
         state.value_search_pending.insert("orders/1".to_string());
         let mut app = test_app_with_kv_tab(7, "ORDERS", state);
-        let data = serde_json::json!({
-            "bucket": "ORDERS",
-            "key": "orders/1"
-        });
+        let context = BackendErrorContext::KvEntry {
+            bucket: "ORDERS".to_string(),
+            key: "orders/1".to_string(),
+        };
 
-        app.clear_kv_loading_on_error(7, BackendOperation::GetKvEntry, Some(&data));
+        app.clear_kv_loading_on_error(7, BackendOperation::GetKvEntry, Some(&context));
 
         let (_, tab) = app
             .dock_state
@@ -353,12 +377,12 @@ mod tests {
         };
         state.value_search_pending.insert("orders/1".to_string());
         let mut app = test_app_with_kv_tab(7, "ORDERS", state);
-        let data = serde_json::json!({
-            "bucket": "ORDERS",
-            "key": "orders/1"
-        });
+        let context = BackendErrorContext::KvEntry {
+            bucket: "ORDERS".to_string(),
+            key: "orders/1".to_string(),
+        };
 
-        app.clear_kv_loading_on_error(7, BackendOperation::GetKvEntry, Some(&data));
+        app.clear_kv_loading_on_error(7, BackendOperation::GetKvEntry, Some(&context));
 
         let (_, tab) = app
             .dock_state

--- a/crates/app/src/app/model.rs
+++ b/crates/app/src/app/model.rs
@@ -1,7 +1,9 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use egui_dock::DockState;
-use nats_backend::{AppConfig, ConnectionStatusKind};
+use nats_backend::{
+    AppConfig, ConnectionStatusKind, KvBucketInfo, ObjectStoreBucketInfo, StreamInfo,
+};
 
 use crate::log_layer::SharedLogBuffer;
 use crate::schema::MessageSchemaManager;
@@ -73,9 +75,9 @@ pub struct EasyNatsApp {
     pub(crate) kv_bucket_edit_editor: KvBucketEditEditor,
     pub(crate) kv_entry_create_editor: KvEntryCreateEditor,
     pub(crate) obj_store_bucket_editor: ObjStoreBucketCreateEditor,
-    pub(crate) stream_lists: HashMap<u64, Vec<serde_json::Value>>,
-    pub(crate) kv_lists: HashMap<u64, Vec<serde_json::Value>>,
-    pub(crate) obj_store_lists: HashMap<u64, Vec<serde_json::Value>>,
+    pub(crate) stream_lists: HashMap<u64, Vec<StreamInfo>>,
+    pub(crate) kv_lists: HashMap<u64, Vec<KvBucketInfo>>,
+    pub(crate) obj_store_lists: HashMap<u64, Vec<ObjectStoreBucketInfo>>,
     pub(crate) dock_state: DockState<TabKind>,
     pub(crate) toasts: Toasts,
     pub(crate) theme_id: ThemeId,

--- a/crates/app/src/app/obj_store_results.rs
+++ b/crates/app/src/app/obj_store_results.rs
@@ -1,6 +1,7 @@
 use nats_backend::BackendCommand;
-
-use nats_backend::BackendOperation;
+use nats_backend::{
+    BackendOperation, ObjectStoreBucketInfo, ObjectStoreDownloadResult, ObjectStoreObjectInfo,
+};
 
 use crate::tabs::TabKind;
 use crate::toast::ToastLevel;
@@ -8,104 +9,145 @@ use crate::toast::ToastLevel;
 use super::model::EasyNatsApp;
 
 impl EasyNatsApp {
-    pub(crate) fn apply_obj_store_operation(
+    pub(crate) fn apply_obj_store_buckets(
+        &mut self,
+        connection_id: u64,
+        buckets: Vec<ObjectStoreBucketInfo>,
+    ) {
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::ObjectStoreBucket {
+                connection_id: cid,
+                bucket_name,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+            {
+                state.info = buckets
+                    .iter()
+                    .find(|info| info.bucket == *bucket_name)
+                    .cloned();
+            }
+        }
+        self.obj_store_lists.insert(connection_id, buckets);
+    }
+
+    pub(crate) fn apply_obj_store_bucket_created(
+        &mut self,
+        connection_id: u64,
+        bucket: ObjectStoreBucketInfo,
+    ) {
+        self.toasts.push(
+            ToastLevel::Success,
+            format!("{} succeeded", BackendOperation::CreateObjectStoreBucket),
+        );
+        upsert_obj_store_bucket(
+            self.obj_store_lists.entry(connection_id).or_default(),
+            bucket,
+        );
+        self.backend
+            .send(BackendCommand::ListObjectStoreBuckets { connection_id });
+    }
+
+    pub(crate) fn apply_obj_store_bucket_deleted(&mut self, connection_id: u64, bucket: String) {
+        self.toasts.push(
+            ToastLevel::Success,
+            format!("{} succeeded", BackendOperation::DeleteObjectStoreBucket),
+        );
+        if let Some(buckets) = self.obj_store_lists.get_mut(&connection_id) {
+            buckets.retain(|info| info.bucket != bucket);
+        }
+        self.remove_tabs_matching(|tab| {
+            matches!(tab, TabKind::ObjectStoreBucket { connection_id: cid, bucket_name, .. }
+                if *cid == connection_id && bucket_name == &bucket)
+        });
+        self.backend
+            .send(BackendCommand::ListObjectStoreBuckets { connection_id });
+    }
+
+    pub(crate) fn apply_obj_store_objects(
+        &mut self,
+        connection_id: u64,
+        bucket: String,
+        objects: Vec<ObjectStoreObjectInfo>,
+    ) {
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::ObjectStoreBucket {
+                connection_id: cid,
+                bucket_name,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+                && *bucket_name == bucket
+            {
+                state.objects = objects.clone();
+                state.loading_objects = false;
+            }
+        }
+    }
+
+    pub(crate) fn apply_obj_store_uploaded(
+        &mut self,
+        connection_id: u64,
+        object: ObjectStoreObjectInfo,
+    ) {
+        self.refresh_object_store_after_mutation(
+            connection_id,
+            BackendOperation::UploadObject,
+            object.bucket,
+        );
+    }
+
+    pub(crate) fn apply_obj_store_deleted(
+        &mut self,
+        connection_id: u64,
+        bucket: String,
+        _name: String,
+    ) {
+        self.refresh_object_store_after_mutation(
+            connection_id,
+            BackendOperation::DeleteObject,
+            bucket,
+        );
+    }
+
+    pub(crate) fn apply_obj_store_downloaded(
+        &mut self,
+        _connection_id: u64,
+        result: ObjectStoreDownloadResult,
+    ) {
+        self.toasts.push(
+            ToastLevel::Success,
+            format!("{} → {}", result.name, result.file_path),
+        );
+    }
+
+    fn refresh_object_store_after_mutation(
         &mut self,
         connection_id: u64,
         operation: BackendOperation,
-        data: &serde_json::Value,
-    ) -> bool {
-        match operation {
-            BackendOperation::ListObjectStoreBuckets => {
-                if let Some(arr) = data.as_array() {
-                    let infos = arr.clone();
-                    for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
-                        if let TabKind::ObjectStoreBucket {
-                            connection_id: cid,
-                            bucket_name,
-                            state,
-                            ..
-                        } = tab
-                            && *cid == connection_id
-                        {
-                            state.info = infos
-                                .iter()
-                                .find(|i| i["bucket"].as_str() == Some(bucket_name.as_str()))
-                                .cloned();
-                        }
-                    }
-                    self.obj_store_lists.insert(connection_id, infos);
-                }
-                true
+        bucket: String,
+    ) {
+        self.toasts
+            .push(ToastLevel::Success, format!("{operation} succeeded"));
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::ObjectStoreBucket {
+                connection_id: cid,
+                bucket_name,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+                && *bucket_name == bucket
+            {
+                state.loading_objects = true;
             }
-            BackendOperation::CreateObjectStoreBucket
-            | BackendOperation::DeleteObjectStoreBucket => {
-                self.toasts
-                    .push(ToastLevel::Success, format!("{operation} succeeded"));
-                if operation == BackendOperation::DeleteObjectStoreBucket
-                    && let Some(bucket) = data["bucket"].as_str()
-                {
-                    self.remove_tabs_matching(|tab| {
-                        matches!(tab, TabKind::ObjectStoreBucket { connection_id: cid, bucket_name, .. }
-                            if *cid == connection_id && bucket_name == bucket)
-                    });
-                }
-                self.backend
-                    .send(BackendCommand::ListObjectStoreBuckets { connection_id });
-                true
-            }
-            BackendOperation::ListObjects => {
-                let bucket = data["bucket"].as_str().unwrap_or("").to_string();
-                let objects = data["objects"].as_array().cloned().unwrap_or_default();
-                for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
-                    if let TabKind::ObjectStoreBucket {
-                        connection_id: cid,
-                        bucket_name,
-                        state,
-                        ..
-                    } = tab
-                        && *cid == connection_id
-                        && *bucket_name == bucket
-                    {
-                        state.objects = objects.clone();
-                        state.loading_objects = false;
-                    }
-                }
-                true
-            }
-            BackendOperation::UploadObject | BackendOperation::DeleteObject => {
-                let bucket = data["bucket"].as_str().unwrap_or("").to_string();
-                self.toasts
-                    .push(ToastLevel::Success, format!("{operation} succeeded"));
-                if !bucket.is_empty() {
-                    for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
-                        if let TabKind::ObjectStoreBucket {
-                            connection_id: cid,
-                            bucket_name,
-                            state,
-                            ..
-                        } = tab
-                            && *cid == connection_id
-                            && *bucket_name == bucket
-                        {
-                            state.loading_objects = true;
-                        }
-                    }
-                    self.backend.send(BackendCommand::ListObjects {
-                        connection_id,
-                        bucket,
-                    });
-                }
-                true
-            }
-            BackendOperation::DownloadObject => {
-                let name = data["name"].as_str().unwrap_or("?");
-                let file_path = data["file_path"].as_str().unwrap_or("?");
-                self.toasts
-                    .push(ToastLevel::Success, format!("{name} → {file_path}"));
-                true
-            }
-            _ => false,
         }
+        self.backend.send(BackendCommand::ListObjects {
+            connection_id,
+            bucket,
+        });
     }
 
     pub(crate) fn clear_obj_store_loading_on_error(
@@ -126,5 +168,17 @@ impl EasyNatsApp {
                 }
             }
         }
+    }
+}
+
+fn upsert_obj_store_bucket(
+    buckets: &mut Vec<ObjectStoreBucketInfo>,
+    bucket: ObjectStoreBucketInfo,
+) {
+    if let Some(existing) = buckets.iter_mut().find(|info| info.bucket == bucket.bucket) {
+        *existing = bucket;
+    } else {
+        buckets.push(bucket);
+        buckets.sort_by(|a, b| a.bucket.cmp(&b.bucket));
     }
 }

--- a/crates/app/src/app/operation_results.rs
+++ b/crates/app/src/app/operation_results.rs
@@ -1,4 +1,4 @@
-use nats_backend::BackendOperation;
+use nats_backend::{BackendErrorContext, BackendOperation};
 
 use crate::tabs::TabKind;
 use crate::toast::ToastLevel;
@@ -10,21 +10,12 @@ impl EasyNatsApp {
         &mut self,
         connection_id: u64,
         operation: BackendOperation,
-        data: serde_json::Value,
     ) {
         if operation == BackendOperation::Publish {
             self.toasts.push(
                 ToastLevel::Success,
                 format!("Published to {}", self.conn_name(connection_id)),
             );
-            return;
-        }
-
-        if self.apply_stream_operation(connection_id, operation, &data)
-            || self.apply_kv_operation(connection_id, operation, &data)
-            || self.apply_obj_store_operation(connection_id, operation, &data)
-            || self.apply_server_info_operation(connection_id, operation, &data)
-        {
             return;
         }
 
@@ -38,7 +29,7 @@ impl EasyNatsApp {
         backend_id: Option<u64>,
         operation: BackendOperation,
         message: &str,
-        data: Option<&serde_json::Value>,
+        context: Option<&BackendErrorContext>,
     ) {
         if operation == BackendOperation::Request
             && let Some(cid) = connection_id
@@ -91,7 +82,7 @@ impl EasyNatsApp {
         }
 
         if let Some(cid) = connection_id {
-            self.clear_kv_loading_on_error(cid, operation, data);
+            self.clear_kv_loading_on_error(cid, operation, context);
             self.clear_obj_store_loading_on_error(cid, operation);
             self.clear_server_info_loading_on_error(cid, operation);
         }

--- a/crates/app/src/app/search_workspace.rs
+++ b/crates/app/src/app/search_workspace.rs
@@ -193,7 +193,7 @@ impl EasyNatsApp {
                 if let Some(idx) = state
                     .messages
                     .iter()
-                    .position(|msg| msg["sequence"].as_u64() == Some(sequence))
+                    .position(|msg| msg.sequence == sequence)
                 {
                     state.selected_msg = Some(idx);
                     return true;

--- a/crates/app/src/app/server_info_results.rs
+++ b/crates/app/src/app/server_info_results.rs
@@ -1,48 +1,41 @@
-use nats_backend::BackendOperation;
+use nats_backend::{BackendOperation, JetStreamAccountInfoSnapshot, ServerInfoSnapshot};
 
 use crate::tabs::TabKind;
 
 use super::model::EasyNatsApp;
 
 impl EasyNatsApp {
-    pub(crate) fn apply_server_info_operation(
+    pub(crate) fn apply_server_info(&mut self, connection_id: u64, info: ServerInfoSnapshot) {
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::ServerInfo {
+                connection_id: cid,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+            {
+                state.server_info = Some(info.clone());
+                state.loading = false;
+            }
+        }
+    }
+
+    pub(crate) fn apply_jetstream_account_info(
         &mut self,
         connection_id: u64,
-        operation: BackendOperation,
-        data: &serde_json::Value,
-    ) -> bool {
-        match operation {
-            BackendOperation::ServerInfo => {
-                for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
-                    if let TabKind::ServerInfo {
-                        connection_id: cid,
-                        state,
-                        ..
-                    } = tab
-                        && *cid == connection_id
-                    {
-                        state.server_info = Some(data.clone());
-                        state.loading = false;
-                    }
-                }
-                true
+        info: JetStreamAccountInfoSnapshot,
+    ) {
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::ServerInfo {
+                connection_id: cid,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+            {
+                state.account_info = Some(info.clone());
+                state.loading = false;
             }
-            BackendOperation::JetStreamAccountInfo => {
-                for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
-                    if let TabKind::ServerInfo {
-                        connection_id: cid,
-                        state,
-                        ..
-                    } = tab
-                        && *cid == connection_id
-                    {
-                        state.account_info = Some(data.clone());
-                        state.loading = false;
-                    }
-                }
-                true
-            }
-            _ => false,
         }
     }
 

--- a/crates/app/src/app/sidebar.rs
+++ b/crates/app/src/app/sidebar.rs
@@ -260,9 +260,8 @@ fn render_streams_section(
             });
             if let Some(infos) = app.stream_lists.get(&id) {
                 for info in infos {
-                    if let Some(stream_name) = info["config"]["name"].as_str()
-                        && ui.selectable_label(false, stream_name).clicked()
-                    {
+                    let stream_name = info.name.as_str();
+                    if ui.selectable_label(false, stream_name).clicked() {
                         let cancel = CancellationToken::new();
                         let guard = TabGuard::new_without_id(cancel);
                         *action = Some(SidebarAction::OpenTab(Box::new(TabKind::Stream {
@@ -311,9 +310,8 @@ fn render_kv_section(
 
             if let Some(infos) = app.kv_lists.get(&id) {
                 for info in infos {
-                    if let Some(bucket_name) = info["bucket"].as_str()
-                        && ui.selectable_label(false, bucket_name).clicked()
-                    {
+                    let bucket_name = info.bucket.as_str();
+                    if ui.selectable_label(false, bucket_name).clicked() {
                         let cancel = CancellationToken::new();
                         let guard = TabGuard::new_without_id(cancel);
                         *action = Some(SidebarAction::OpenTab(Box::new(TabKind::KvBucket {
@@ -363,9 +361,8 @@ fn render_obj_store_section(
 
             if let Some(infos) = app.obj_store_lists.get(&id) {
                 for info in infos {
-                    if let Some(bucket_name) = info["bucket"].as_str()
-                        && ui.selectable_label(false, bucket_name).clicked()
-                    {
+                    let bucket_name = info.bucket.as_str();
+                    if ui.selectable_label(false, bucket_name).clicked() {
                         let cancel = CancellationToken::new();
                         let guard = TabGuard::new_without_id(cancel);
                         *action = Some(SidebarAction::OpenTab(Box::new(

--- a/crates/app/src/app/stream_results.rs
+++ b/crates/app/src/app/stream_results.rs
@@ -1,4 +1,4 @@
-use nats_backend::{BackendCommand, BackendOperation};
+use nats_backend::{BackendCommand, BackendOperation, ConsumerInfo, StreamInfo, StreamMessageInfo};
 
 use crate::i18n::t;
 use crate::tabs::TabKind;
@@ -7,165 +7,190 @@ use crate::toast::ToastLevel;
 use super::model::EasyNatsApp;
 
 impl EasyNatsApp {
-    pub(crate) fn apply_stream_operation(
+    pub(crate) fn apply_streams(&mut self, connection_id: u64, streams: Vec<StreamInfo>) {
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::Stream {
+                connection_id: cid,
+                stream_name,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+            {
+                state.info = streams
+                    .iter()
+                    .find(|info| info.name == *stream_name)
+                    .cloned();
+            }
+        }
+        self.stream_lists.insert(connection_id, streams);
+    }
+
+    pub(crate) fn apply_stream_changed(
         &mut self,
         connection_id: u64,
         operation: BackendOperation,
-        data: &serde_json::Value,
-    ) -> bool {
-        match operation {
-            BackendOperation::ListStreams => {
-                if let Some(arr) = data.as_array() {
-                    let infos = arr.clone();
-                    for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
-                        if let TabKind::Stream {
-                            connection_id: cid,
-                            stream_name,
-                            state,
-                            ..
-                        } = tab
-                            && *cid == connection_id
-                        {
-                            state.info = infos
-                                .iter()
-                                .find(|i| {
-                                    i["config"]["name"].as_str() == Some(stream_name.as_str())
-                                })
-                                .cloned();
-                        }
-                    }
-                    self.stream_lists.insert(connection_id, infos);
-                }
-                true
+        stream: StreamInfo,
+    ) {
+        self.toasts
+            .push(ToastLevel::Success, format!("{operation} succeeded"));
+        upsert_stream(
+            self.stream_lists.entry(connection_id).or_default(),
+            stream.clone(),
+        );
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::Stream {
+                connection_id: cid,
+                stream_name,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+                && *stream_name == stream.name
+            {
+                state.info = Some(stream.clone());
             }
-            BackendOperation::CreateStream | BackendOperation::UpdateStream => {
-                self.toasts
-                    .push(ToastLevel::Success, format!("{operation} succeeded"));
-                self.backend
-                    .send(BackendCommand::ListStreams { connection_id });
-                true
-            }
-            BackendOperation::DeleteStream => {
-                self.toasts
-                    .push(ToastLevel::Success, t("toast.stream_deleted").to_string());
-                if let Some(name) = data["name"].as_str() {
-                    self.remove_tabs_matching(|tab| {
-                        matches!(tab, TabKind::Stream { connection_id: cid, stream_name, .. }
-                            if *cid == connection_id && stream_name == name)
-                    });
-                }
-                self.backend
-                    .send(BackendCommand::ListStreams { connection_id });
-                true
-            }
-            BackendOperation::PurgeStream => {
-                let purged = data["purged"].as_u64().unwrap_or(0);
-                self.toasts
-                    .push(ToastLevel::Success, format!("Purged {purged} messages"));
-                true
-            }
-            BackendOperation::GetStreamMessages => {
-                let stream_name = data["stream"].as_str().unwrap_or("").to_string();
-                let messages = data["messages"].as_array().cloned().unwrap_or_default();
-                for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
-                    if let TabKind::Stream {
-                        connection_id: cid,
-                        stream_name: sname,
-                        state,
-                        ..
-                    } = tab
-                        && *cid == connection_id
-                        && *sname == stream_name
-                    {
-                        state.messages = messages.clone();
-                        state.fetching = false;
-                        state.selected_msg = None;
-                        state.search_generation = state.search_generation.wrapping_add(1);
-                        state.cached_filtered = None;
-                    }
-                }
-                true
-            }
-            BackendOperation::ListConsumers => {
-                let stream_name = data["stream"].as_str().unwrap_or("").to_string();
-                let consumers = data["consumers"].as_array().cloned().unwrap_or_default();
-                for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
-                    if let TabKind::Stream {
-                        connection_id: cid,
-                        stream_name: sname,
-                        state,
-                        ..
-                    } = tab
-                        && *cid == connection_id
-                        && *sname == stream_name
-                    {
-                        state.consumers = consumers.clone();
-                        state.consumers_fetching = false;
-                    }
-                }
-                true
-            }
-            BackendOperation::CreateConsumer
-            | BackendOperation::DeleteConsumer
-            | BackendOperation::UpdateConsumer => {
-                let stream_name = data["stream"]
-                    .as_str()
-                    .or_else(|| data["stream_name"].as_str())
-                    .unwrap_or("")
-                    .to_string();
-                self.toasts
-                    .push(ToastLevel::Success, format!("{operation} succeeded"));
-                if !stream_name.is_empty() {
-                    for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
-                        if let TabKind::Stream {
-                            connection_id: cid,
-                            stream_name: sname,
-                            state,
-                            ..
-                        } = tab
-                            && *cid == connection_id
-                            && *sname == stream_name
-                        {
-                            state.consumers_fetching = true;
-                        }
-                    }
-                    self.backend.send(BackendCommand::ListConsumers {
-                        connection_id,
-                        stream: stream_name,
-                    });
-                }
-                self.backend
-                    .send(BackendCommand::ListStreams { connection_id });
-                true
-            }
-            BackendOperation::DeleteStreamMessage => {
-                self.toasts
-                    .push(ToastLevel::Success, t("toast.message_deleted").to_string());
-                true
-            }
-            BackendOperation::FetchConsumerMessages => {
-                let stream_name = data["stream"].as_str().unwrap_or("").to_string();
-                let consumer_name = data["consumer"].as_str().unwrap_or("").to_string();
-                let messages = data["messages"].as_array().cloned().unwrap_or_default();
-                for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
-                    if let TabKind::Stream {
-                        connection_id: cid,
-                        stream_name: sname,
-                        state,
-                        ..
-                    } = tab
-                        && *cid == connection_id
-                        && *sname == stream_name
-                    {
-                        state.consumer_fetching.remove(&consumer_name);
-                        state
-                            .consumer_fetched
-                            .insert(consumer_name.clone(), messages.clone());
-                    }
-                }
-                true
-            }
-            _ => false,
         }
+        self.backend
+            .send(BackendCommand::ListStreams { connection_id });
+    }
+
+    pub(crate) fn apply_stream_deleted(&mut self, connection_id: u64, name: String) {
+        self.toasts
+            .push(ToastLevel::Success, t("toast.stream_deleted").to_string());
+        if let Some(streams) = self.stream_lists.get_mut(&connection_id) {
+            streams.retain(|stream| stream.name != name);
+        }
+        self.remove_tabs_matching(|tab| {
+            matches!(tab, TabKind::Stream { connection_id: cid, stream_name, .. }
+                if *cid == connection_id && stream_name == &name)
+        });
+        self.backend
+            .send(BackendCommand::ListStreams { connection_id });
+    }
+
+    pub(crate) fn apply_stream_purged(&mut self, _connection_id: u64, _name: String, purged: u64) {
+        self.toasts
+            .push(ToastLevel::Success, format!("Purged {purged} messages"));
+    }
+
+    pub(crate) fn apply_stream_messages(
+        &mut self,
+        connection_id: u64,
+        stream_name: String,
+        messages: Vec<StreamMessageInfo>,
+    ) {
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::Stream {
+                connection_id: cid,
+                stream_name: sname,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+                && *sname == stream_name
+            {
+                state.messages = messages.clone();
+                state.fetching = false;
+                state.selected_msg = None;
+                state.search_generation = state.search_generation.wrapping_add(1);
+                state.cached_filtered = None;
+            }
+        }
+    }
+
+    pub(crate) fn apply_consumers(
+        &mut self,
+        connection_id: u64,
+        stream_name: String,
+        consumers: Vec<ConsumerInfo>,
+    ) {
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::Stream {
+                connection_id: cid,
+                stream_name: sname,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+                && *sname == stream_name
+            {
+                state.consumers = consumers.clone();
+                state.consumers_fetching = false;
+            }
+        }
+    }
+
+    pub(crate) fn apply_consumer_changed(
+        &mut self,
+        connection_id: u64,
+        operation: BackendOperation,
+        stream_name: String,
+    ) {
+        self.toasts
+            .push(ToastLevel::Success, format!("{operation} succeeded"));
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::Stream {
+                connection_id: cid,
+                stream_name: sname,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+                && *sname == stream_name
+            {
+                state.consumers_fetching = true;
+            }
+        }
+        self.backend.send(BackendCommand::ListConsumers {
+            connection_id,
+            stream: stream_name,
+        });
+        self.backend
+            .send(BackendCommand::ListStreams { connection_id });
+    }
+
+    pub(crate) fn apply_stream_message_deleted(
+        &mut self,
+        _connection_id: u64,
+        _stream: String,
+        _sequence: u64,
+    ) {
+        self.toasts
+            .push(ToastLevel::Success, t("toast.message_deleted").to_string());
+    }
+
+    pub(crate) fn apply_consumer_messages(
+        &mut self,
+        connection_id: u64,
+        stream_name: String,
+        consumer_name: String,
+        messages: Vec<StreamMessageInfo>,
+    ) {
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::Stream {
+                connection_id: cid,
+                stream_name: sname,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+                && *sname == stream_name
+            {
+                state.consumer_fetching.remove(&consumer_name);
+                state
+                    .consumer_fetched
+                    .insert(consumer_name.clone(), messages.clone());
+            }
+        }
+    }
+}
+
+fn upsert_stream(streams: &mut Vec<StreamInfo>, stream: StreamInfo) {
+    if let Some(existing) = streams.iter_mut().find(|info| info.name == stream.name) {
+        *existing = stream;
+    } else {
+        streams.push(stream);
+        streams.sort_by(|a, b| a.name.cmp(&b.name));
     }
 }

--- a/crates/app/src/app/ui.rs
+++ b/crates/app/src/app/ui.rs
@@ -100,17 +100,17 @@ impl eframe::App for EasyNatsApp {
                 TabAction::OpenConsumerEdit {
                     connection_id,
                     stream_name,
-                    consumer_json,
+                    consumer_info,
                 } => {
                     self.consumer_edit_editor =
-                        ConsumerEditEditor::from_json(connection_id, stream_name, &consumer_json);
+                        ConsumerEditEditor::from_info(connection_id, stream_name, &consumer_info);
                 }
                 TabAction::OpenKvBucketEdit {
                     connection_id,
-                    bucket_json,
+                    bucket_info,
                 } => {
                     self.kv_bucket_edit_editor =
-                        KvBucketEditEditor::from_json(connection_id, &bucket_json);
+                        KvBucketEditEditor::from_info(connection_id, &bucket_info);
                 }
                 TabAction::OpenKvEntryCreate {
                     connection_id,

--- a/crates/app/src/app/util.rs
+++ b/crates/app/src/app/util.rs
@@ -1,14 +1,4 @@
-use base64::Engine;
-
 use crate::tabs::TabKind;
-
-pub(crate) fn decode_kv_value(entry: &serde_json::Value) -> String {
-    entry["value_base64"]
-        .as_str()
-        .and_then(|value| base64::engine::general_purpose::STANDARD.decode(value).ok())
-        .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
-        .unwrap_or_default()
-}
 
 pub(crate) fn same_tab(a: &TabKind, b: &TabKind) -> bool {
     match (a, b) {

--- a/crates/app/src/app/windows/consumer.rs
+++ b/crates/app/src/app/windows/consumer.rs
@@ -36,23 +36,33 @@ pub(crate) fn render(app: &mut EasyNatsApp, ui: &mut egui::Ui) {
                         egui::ComboBox::from_id_salt("consumer_deliver_policy")
                             .selected_text(app.consumer_editor.deliver_policy.label())
                             .show_ui(ui, |ui| {
-                                ui.selectable_value(
-                                    &mut app.consumer_editor.deliver_policy,
-                                    DeliverPolicySelection::All,
-                                    DeliverPolicySelection::All.label(),
-                                );
-                                ui.selectable_value(
-                                    &mut app.consumer_editor.deliver_policy,
-                                    DeliverPolicySelection::Last,
-                                    DeliverPolicySelection::Last.label(),
-                                );
-                                ui.selectable_value(
-                                    &mut app.consumer_editor.deliver_policy,
-                                    DeliverPolicySelection::New,
-                                    DeliverPolicySelection::New.label(),
-                                );
+                                for policy in DeliverPolicySelection::ALL {
+                                    ui.selectable_value(
+                                        &mut app.consumer_editor.deliver_policy,
+                                        policy,
+                                        policy.label(),
+                                    );
+                                }
                             });
                         ui.end_row();
+
+                        match app.consumer_editor.deliver_policy {
+                            DeliverPolicySelection::ByStartSequence => {
+                                ui.label(t("consumer.start_sequence"));
+                                ui.text_edit_singleline(
+                                    &mut app.consumer_editor.deliver_start_sequence,
+                                );
+                                ui.end_row();
+                            }
+                            DeliverPolicySelection::ByStartTime => {
+                                ui.label(t("consumer.start_time"));
+                                ui.text_edit_singleline(
+                                    &mut app.consumer_editor.deliver_start_time,
+                                );
+                                ui.end_row();
+                            }
+                            _ => {}
+                        }
 
                         ui.label(t("consumer.ack_policy"));
                         egui::ComboBox::from_id_salt("consumer_ack_policy")
@@ -94,7 +104,8 @@ pub(crate) fn render(app: &mut EasyNatsApp, ui: &mut egui::Ui) {
                     });
                 ui.add_space(8.0);
                 ui.horizontal(|ui| {
-                    let valid = !app.consumer_editor.name.trim().is_empty();
+                    let valid = !app.consumer_editor.name.trim().is_empty()
+                        && deliver_policy_input_valid(&app.consumer_editor);
                     if ui
                         .add_enabled(valid, egui::Button::new(t("common.save")))
                         .clicked()
@@ -109,6 +120,16 @@ pub(crate) fn render(app: &mut EasyNatsApp, ui: &mut egui::Ui) {
     }
     if save_requested {
         app.save_consumer_editor();
+    }
+}
+
+fn deliver_policy_input_valid(editor: &super::super::editors::ConsumerCreateEditor) -> bool {
+    match editor.deliver_policy {
+        DeliverPolicySelection::ByStartSequence => {
+            editor.deliver_start_sequence.trim().parse::<u64>().is_ok()
+        }
+        DeliverPolicySelection::ByStartTime => !editor.deliver_start_time.trim().is_empty(),
+        _ => true,
     }
 }
 

--- a/crates/app/src/app/windows/obj_store.rs
+++ b/crates/app/src/app/windows/obj_store.rs
@@ -1,4 +1,5 @@
 use eframe::egui;
+use nats_backend::{BackendCommand, ObjectStoreBucketConfigInput, StorageKind};
 
 use crate::i18n::t;
 
@@ -108,36 +109,29 @@ fn save_obj_store_bucket(app: &mut EasyNatsApp) {
     if bucket.is_empty() {
         return;
     }
-    let storage = match app.obj_store_bucket_editor.storage {
-        StorageSelection::File => "file",
-        StorageSelection::Memory => "memory",
-    };
-
-    let mut config = serde_json::json!({
-        "bucket": bucket,
-        "storage": storage,
-    });
-
-    if let Ok(v) = app.obj_store_bucket_editor.max_bytes.trim().parse::<i64>() {
-        config["max_bytes"] = serde_json::json!(v);
-    }
-    if let Ok(v) = app
-        .obj_store_bucket_editor
-        .num_replicas
-        .trim()
-        .parse::<usize>()
-    {
-        config["num_replicas"] = serde_json::json!(v);
-    }
-    if !app.obj_store_bucket_editor.description.trim().is_empty() {
-        config["description"] = serde_json::json!(app.obj_store_bucket_editor.description.trim());
-    }
     let connection_id = app.obj_store_bucket_editor.connection_id;
 
-    app.backend
-        .send(nats_backend::BackendCommand::CreateObjectStoreBucket {
-            connection_id,
-            config,
-        });
+    app.backend.send(BackendCommand::CreateObjectStoreBucket {
+        connection_id,
+        config: ObjectStoreBucketConfigInput {
+            bucket,
+            storage: match app.obj_store_bucket_editor.storage {
+                StorageSelection::File => StorageKind::File,
+                StorageSelection::Memory => StorageKind::Memory,
+            },
+            max_bytes: parse_optional(&app.obj_store_bucket_editor.max_bytes),
+            num_replicas: parse_optional(&app.obj_store_bucket_editor.num_replicas),
+            description: trimmed_optional(&app.obj_store_bucket_editor.description),
+        },
+    });
     app.obj_store_bucket_editor.visible = false;
+}
+
+fn parse_optional<T: std::str::FromStr>(value: &str) -> Option<T> {
+    value.trim().parse::<T>().ok()
+}
+
+fn trimmed_optional(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_string())
 }

--- a/crates/app/src/tabs/common.rs
+++ b/crates/app/src/tabs/common.rs
@@ -1,6 +1,5 @@
 use std::time::SystemTime;
 
-use base64::Engine;
 use eframe::egui;
 use eframe::egui::{Popup, PopupCloseBehavior, TextEdit};
 
@@ -90,28 +89,6 @@ pub(crate) fn matches_query(value: &str, query: &str) -> bool {
 
 pub(crate) fn searchable_payload_text(payload: &[u8]) -> String {
     String::from_utf8_lossy(payload).into_owned()
-}
-
-pub(crate) fn searchable_json_payload(value: &serde_json::Value) -> String {
-    if let Some(payload) = value["payload"].as_str() {
-        return payload.to_string();
-    }
-    if let Some(value_base64) = value["payload_base64"]
-        .as_str()
-        .or_else(|| value["value_base64"].as_str())
-    {
-        return searchable_payload_text(&decode_base64_payload(Some(value_base64)));
-    }
-    if let Some(payload) = value.get("payload") {
-        return payload.to_string();
-    }
-    String::new()
-}
-
-pub(crate) fn decode_base64_payload(value_base64: Option<&str>) -> Vec<u8> {
-    value_base64
-        .and_then(|value| base64::engine::general_purpose::STANDARD.decode(value).ok())
-        .unwrap_or_default()
 }
 
 /// Render auto-refresh toggle + interval selector inline.

--- a/crates/app/src/tabs/kv.rs
+++ b/crates/app/src/tabs/kv.rs
@@ -1,5 +1,5 @@
 use eframe::egui;
-use nats_backend::{BackendCommand, BackendHandle};
+use nats_backend::{BackendCommand, BackendHandle, KvBucketInfo, KvHistoryItem};
 
 use crate::format;
 use crate::i18n::t;
@@ -7,8 +7,8 @@ use crate::schema::{MessageSchemaManager, kv_subject};
 use crate::tabs::guard::TabGuard;
 
 use super::common::{
-    KV_VALUE_SEARCH_BATCH, SearchStatus, auto_refresh_ui, decode_base64_payload, format_bytes,
-    matches_query, render_search_row, searchable_json_payload,
+    KV_VALUE_SEARCH_BATCH, SearchStatus, auto_refresh_ui, format_bytes, matches_query,
+    render_search_row,
 };
 use super::types::{KvBucketState, TabAction};
 
@@ -30,7 +30,7 @@ pub fn kv_bucket_ui(
         {
             actions.push(TabAction::OpenKvBucketEdit {
                 connection_id,
-                bucket_json: info.clone(),
+                bucket_info: info.clone(),
             });
         }
         if ui.button(t("kv.delete_bucket")).clicked() {
@@ -72,7 +72,7 @@ pub fn kv_bucket_ui(
         egui::CollapsingHeader::new(t("kv.bucket_info"))
             .id_salt(("kv_bucket_info", connection_id, bucket_name))
             .default_open(false)
-            .show(ui, |ui| kv_bucket_info_panel(ui, info));
+            .show(ui, |ui| kv_bucket_info_panel(ui, info, state));
     }
     ui.separator();
 
@@ -311,7 +311,7 @@ fn filtered_keys(state: &KvBucketState) -> Vec<String> {
                 && state
                     .history
                     .iter()
-                    .any(|item| matches_query(&searchable_json_payload(item), &query));
+                    .any(|item| matches_query(&searchable_kv_history_item(item), &query));
             key_matches || fetched_value_matches || history_matches
         })
         .cloned()
@@ -541,18 +541,17 @@ fn render_history(
             .max_height(220.0)
             .show(ui, |ui| {
                 for item in &state.history {
-                    let revision = item["revision"].as_u64().unwrap_or(0);
-                    let operation = item["operation"].as_str().unwrap_or(t("kv.none"));
-                    let created = item["created"].as_str().unwrap_or("");
+                    let revision = item.revision;
+                    let operation = item.operation.as_str();
+                    let created = item.created.as_str();
                     egui::CollapsingHeader::new(format!("r{revision} — {operation} — {created}"))
                         .id_salt(("kv_history_item", connection_id, bucket_name, revision))
                         .show(ui, |ui| {
-                            let payload = decode_base64_payload(item["value_base64"].as_str());
                             let subject =
                                 kv_subject(bucket_name, &normalized_entry_key(&state.entry_key));
                             format::render_payload_with_schema(
                                 ui,
-                                &payload,
+                                &item.value,
                                 state.history_format,
                                 "kv_history_proto",
                                 &mut state.history_proto_view,
@@ -597,26 +596,30 @@ fn render_generate_json_button(
     }
 }
 
-fn kv_bucket_info_panel(ui: &mut egui::Ui, info: &serde_json::Value) {
+fn current_kv_count_text(state: &KvBucketState) -> String {
+    let suffix = if state.keys_complete { "" } else { "+" };
+    format!("{}{}", state.keys.len(), suffix)
+}
+
+fn searchable_kv_history_item(item: &KvHistoryItem) -> String {
+    String::from_utf8_lossy(&item.value).into_owned()
+}
+
+fn kv_bucket_info_panel(ui: &mut egui::Ui, info: &KvBucketInfo, state: &KvBucketState) {
     egui::Grid::new("kv_bucket_info_grid")
         .num_columns(2)
         .spacing([8.0, 4.0])
         .show(ui, |ui| {
             for (label, value) in [
-                (t("kv.bucket"), info["bucket"].as_str().map(str::to_owned)),
+                (t("kv.bucket"), Some(info.bucket.clone())),
+                (t("kv.current_keys"), Some(current_kv_count_text(state))),
                 (
-                    t("kv.values"),
-                    Some(info["values"].as_u64().unwrap_or(0).to_string()),
+                    t("kv.values_stored"),
+                    Some(info.stored_history_values.to_string()),
                 ),
-                (
-                    t("kv.history_depth"),
-                    Some(info["history"].as_i64().unwrap_or(0).to_string()),
-                ),
-                (t("kv.storage"), info["storage"].as_str().map(str::to_owned)),
-                (
-                    t("kv.bytes"),
-                    Some(format_bytes(info["bytes"].as_u64().unwrap_or(0))),
-                ),
+                (t("kv.history_depth"), Some(info.history_depth.to_string())),
+                (t("kv.storage"), Some(info.storage.clone())),
+                (t("kv.bytes"), Some(format_bytes(info.bytes))),
             ] {
                 ui.label(label);
                 ui.label(value.unwrap_or_default());
@@ -651,6 +654,18 @@ mod tests {
         state.value_search_cursor = 100;
         assert_eq!(state.value_search_cursor, 100);
         assert_eq!(state.keys.len(), 150);
+    }
+
+    #[test]
+    fn current_kv_count_marks_incomplete_key_lists() {
+        let mut state = KvBucketState {
+            keys: vec!["a".to_string(), "b".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(current_kv_count_text(&state), "2+");
+
+        state.keys_complete = true;
+        assert_eq!(current_kv_count_text(&state), "2");
     }
 
     #[test]

--- a/crates/app/src/tabs/object_store.rs
+++ b/crates/app/src/tabs/object_store.rs
@@ -1,5 +1,5 @@
 use eframe::egui;
-use nats_backend::{BackendCommand, BackendHandle};
+use nats_backend::{BackendCommand, BackendHandle, ObjectStoreBucketInfo, ObjectStoreObjectInfo};
 
 use crate::i18n::t;
 
@@ -118,12 +118,11 @@ fn render_object_list(
     let filter_lower = state.object_filter.to_lowercase();
     egui::ScrollArea::vertical().show(ui, |ui| {
         for obj in &state.objects {
-            let name = obj["name"].as_str().unwrap_or("?");
+            let name = obj.name.as_str();
             if !filter_lower.is_empty() && !name.to_lowercase().contains(&filter_lower) {
                 continue;
             }
-            let size = obj["size"].as_u64().unwrap_or(0);
-            let label = format!("{name}  ({})", format_bytes(size));
+            let label = format!("{name}  ({})", format_bytes(obj.size as u64));
             let selected = state.selected_object.as_deref() == Some(name);
             if ui.selectable_label(selected, &label).clicked() {
                 state.selected_object = Some(name.to_string());
@@ -148,10 +147,7 @@ fn render_detail_panel(
     };
     let obj_name = obj_name.clone();
 
-    let obj = state
-        .objects
-        .iter()
-        .find(|o| o["name"].as_str() == Some(obj_name.as_str()));
+    let obj = state.objects.iter().find(|object| object.name == obj_name);
 
     ui.heading(&obj_name);
     ui.separator();
@@ -195,27 +191,25 @@ fn render_detail_panel(
     });
 }
 
-fn render_object_metadata(ui: &mut egui::Ui, obj: &serde_json::Value) {
+fn render_object_metadata(ui: &mut egui::Ui, obj: &ObjectStoreObjectInfo) {
     egui::Grid::new("obj_metadata")
         .num_columns(2)
         .spacing([12.0, 4.0])
         .show(ui, |ui| {
-            if let Some(size) = obj["size"].as_u64() {
-                ui.label(t("obj_store.size"));
-                ui.label(format_bytes(size));
-                ui.end_row();
-            }
-            if let Some(chunks) = obj["chunks"].as_u64() {
-                ui.label(t("obj_store.chunks"));
-                ui.label(chunks.to_string());
-                ui.end_row();
-            }
-            if let Some(digest) = obj["digest"].as_str() {
+            ui.label(t("obj_store.size"));
+            ui.label(format_bytes(obj.size as u64));
+            ui.end_row();
+
+            ui.label(t("obj_store.chunks"));
+            ui.label(obj.chunks.to_string());
+            ui.end_row();
+
+            if let Some(digest) = obj.digest.as_deref() {
                 ui.label(t("obj_store.digest"));
                 ui.label(digest);
                 ui.end_row();
             }
-            if let Some(modified) = obj["modified"].as_str() {
+            if let Some(modified) = obj.modified.as_deref() {
                 ui.label(t("obj_store.modified"));
                 ui.label(modified);
                 ui.end_row();
@@ -223,35 +217,29 @@ fn render_object_metadata(ui: &mut egui::Ui, obj: &serde_json::Value) {
         });
 }
 
-fn bucket_info_panel(ui: &mut egui::Ui, info: &serde_json::Value) {
+fn bucket_info_panel(ui: &mut egui::Ui, info: &ObjectStoreBucketInfo) {
     egui::Grid::new("objstore_info_grid")
         .num_columns(2)
         .spacing([12.0, 4.0])
         .show(ui, |ui| {
-            if let Some(bucket) = info["bucket"].as_str() {
-                ui.label(t("obj_store.bucket_name"));
-                ui.label(bucket);
-                ui.end_row();
-            }
-            if let Some(bytes) = info["bytes"].as_u64() {
-                ui.label(t("obj_store.total_bytes"));
-                ui.label(format_bytes(bytes));
-                ui.end_row();
-            }
-            if let Some(count) = info["values"].as_u64() {
-                ui.label(t("obj_store.object_count"));
-                ui.label(count.to_string());
-                ui.end_row();
-            }
-            if let Some(storage) = info["storage"].as_str() {
-                ui.label(t("common.storage_label"));
-                ui.label(storage);
-                ui.end_row();
-            }
-            if let Some(replicas) = info["replicas"].as_u64() {
-                ui.label(t("common.replicas"));
-                ui.label(replicas.to_string());
-                ui.end_row();
-            }
+            ui.label(t("obj_store.bucket_name"));
+            ui.label(&info.bucket);
+            ui.end_row();
+
+            ui.label(t("obj_store.total_bytes"));
+            ui.label(format_bytes(info.bytes));
+            ui.end_row();
+
+            ui.label(t("obj_store.object_count"));
+            ui.label(info.object_count.to_string());
+            ui.end_row();
+
+            ui.label(t("common.storage_label"));
+            ui.label(&info.storage);
+            ui.end_row();
+
+            ui.label(t("common.replicas"));
+            ui.label(info.num_replicas.to_string());
+            ui.end_row();
         });
 }

--- a/crates/app/src/tabs/search_workspace.rs
+++ b/crates/app/src/tabs/search_workspace.rs
@@ -3,8 +3,7 @@ use eframe::egui;
 use crate::i18n::t;
 
 use super::common::{
-    SEARCH_RESULT_LIMIT, format_timestamp, matches_query, searchable_json_payload,
-    searchable_payload_text,
+    SEARCH_RESULT_LIMIT, format_timestamp, matches_query, searchable_payload_text,
 };
 use super::types::{
     SearchField, SearchRecordSnapshot, SearchResultIdentity, SearchResultLocator,
@@ -85,9 +84,9 @@ pub(crate) fn source_snapshot_from_tab(tab: &TabKind) -> Option<SearchSourceSnap
                 stream_name: stream_name.clone(),
             };
             let mut records = Vec::new();
-            for (idx, msg) in state.messages.iter().enumerate() {
-                let sequence = msg["sequence"].as_u64().unwrap_or(idx as u64);
-                let subject = msg["subject"].as_str().unwrap_or_default();
+            for msg in &state.messages {
+                let sequence = msg.sequence;
+                let subject = msg.subject.as_str();
                 let item_label = if subject.is_empty() {
                     format!("#{sequence}")
                 } else {
@@ -107,7 +106,7 @@ pub(crate) fn source_snapshot_from_tab(tab: &TabKind) -> Option<SearchSourceSnap
                         },
                     });
                 }
-                let payload = searchable_json_payload(msg);
+                let payload = searchable_payload_text(&msg.payload);
                 if !payload.is_empty() {
                     records.push(SearchRecordSnapshot {
                         field: SearchField::Payload,
@@ -640,141 +639,4 @@ pub(crate) fn compact_text(text: &str, max_chars: usize) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::tabs::types::{SearchRecordSnapshot, SearchResultLocator};
-
-    fn source(id: &str, generation: u64, text: &str) -> SearchSourceSnapshot {
-        let source_id = SearchSourceId::Stream {
-            connection_id: 1,
-            stream_name: id.to_string(),
-        };
-        source_with_records(source_id, id, generation, vec![("1", text)])
-    }
-
-    fn source_with_records(
-        id: SearchSourceId,
-        label: &str,
-        generation: u64,
-        records: Vec<(&str, &str)>,
-    ) -> SearchSourceSnapshot {
-        SearchSourceSnapshot {
-            id,
-            label: label.to_string(),
-            generation,
-            coverage: SearchSourceCoverage::Stream {
-                messages: records.len(),
-            },
-            records: records
-                .into_iter()
-                .enumerate()
-                .map(|(idx, (item_id, text))| {
-                    let sequence = idx as u64 + 1;
-                    SearchRecordSnapshot {
-                        field: SearchField::Payload,
-                        item_id: item_id.to_string(),
-                        item_label: format!("#{sequence}"),
-                        text: text.to_string(),
-                        snippet: text.to_string(),
-                        locator: SearchResultLocator::StreamMessage {
-                            connection_id: 1,
-                            stream_name: label.to_string(),
-                            sequence,
-                        },
-                    }
-                })
-                .collect(),
-        }
-    }
-
-    #[test]
-    fn workspace_results_match_selected_sources_only() {
-        let selected = SearchSourceId::Stream {
-            connection_id: 1,
-            stream_name: "orders".to_string(),
-        };
-        let mut state = SearchWorkspaceState {
-            query: "balance".to_string(),
-            selected_sources: vec![selected],
-            ..Default::default()
-        };
-        let sources = [
-            source("orders", 1, "balance: 42"),
-            source("payments", 1, "balance: 99"),
-        ];
-
-        let results = workspace_results(&mut state, &sources);
-
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].source_label, "orders");
-    }
-
-    #[test]
-    fn workspace_cache_invalidates_when_source_generation_changes() {
-        let source_id = SearchSourceId::Stream {
-            connection_id: 1,
-            stream_name: "orders".to_string(),
-        };
-        let mut state = SearchWorkspaceState {
-            query: "balance".to_string(),
-            selected_sources: vec![source_id],
-            ..Default::default()
-        };
-        let first_sources = [source("orders", 1, "balance: 42")];
-        assert_eq!(workspace_results(&mut state, &first_sources).len(), 1);
-
-        let second_sources = [source("orders", 2, "no match")];
-        assert_eq!(workspace_results(&mut state, &second_sources).len(), 0);
-    }
-
-    #[test]
-    fn workspace_results_are_capped() {
-        let source_id = SearchSourceId::Stream {
-            connection_id: 1,
-            stream_name: "orders".to_string(),
-        };
-        let mut state = SearchWorkspaceState {
-            query: "balance".to_string(),
-            selected_sources: vec![source_id.clone()],
-            ..Default::default()
-        };
-        let records = (0..SEARCH_RESULT_LIMIT + 5)
-            .map(|idx| (idx.to_string(), "balance"))
-            .collect::<Vec<_>>();
-        let record_refs = records
-            .iter()
-            .map(|(id, text)| (id.as_str(), *text))
-            .collect::<Vec<_>>();
-        let sources = [source_with_records(source_id, "orders", 1, record_refs)];
-
-        let results = workspace_results(&mut state, &sources);
-
-        assert_eq!(results.len(), SEARCH_RESULT_LIMIT);
-    }
-
-    #[test]
-    fn workspace_cache_invalidates_when_source_disappears() {
-        let source_id = SearchSourceId::Stream {
-            connection_id: 1,
-            stream_name: "orders".to_string(),
-        };
-        let mut state = SearchWorkspaceState {
-            query: "balance".to_string(),
-            selected_sources: vec![source_id],
-            ..Default::default()
-        };
-        let sources = [source("orders", 1, "balance: 42")];
-        assert_eq!(workspace_results(&mut state, &sources).len(), 1);
-
-        let no_sources = [];
-        let results = workspace_results(&mut state, &no_sources);
-
-        assert!(results.is_empty());
-    }
-
-    #[test]
-    fn compact_text_collapses_and_truncates() {
-        assert_eq!(compact_text("a\n b  c", 8), "a b c");
-        assert_eq!(compact_text("abcdef", 3), "abc...");
-    }
-}
+mod tests;

--- a/crates/app/src/tabs/search_workspace/tests.rs
+++ b/crates/app/src/tabs/search_workspace/tests.rs
@@ -1,0 +1,136 @@
+use super::*;
+use crate::tabs::types::{SearchRecordSnapshot, SearchResultLocator};
+
+fn source(id: &str, generation: u64, text: &str) -> SearchSourceSnapshot {
+    let source_id = SearchSourceId::Stream {
+        connection_id: 1,
+        stream_name: id.to_string(),
+    };
+    source_with_records(source_id, id, generation, vec![("1", text)])
+}
+
+fn source_with_records(
+    id: SearchSourceId,
+    label: &str,
+    generation: u64,
+    records: Vec<(&str, &str)>,
+) -> SearchSourceSnapshot {
+    SearchSourceSnapshot {
+        id,
+        label: label.to_string(),
+        generation,
+        coverage: SearchSourceCoverage::Stream {
+            messages: records.len(),
+        },
+        records: records
+            .into_iter()
+            .enumerate()
+            .map(|(idx, (item_id, text))| {
+                let sequence = idx as u64 + 1;
+                SearchRecordSnapshot {
+                    field: SearchField::Payload,
+                    item_id: item_id.to_string(),
+                    item_label: format!("#{sequence}"),
+                    text: text.to_string(),
+                    snippet: text.to_string(),
+                    locator: SearchResultLocator::StreamMessage {
+                        connection_id: 1,
+                        stream_name: label.to_string(),
+                        sequence,
+                    },
+                }
+            })
+            .collect(),
+    }
+}
+
+#[test]
+fn workspace_results_match_selected_sources_only() {
+    let selected = SearchSourceId::Stream {
+        connection_id: 1,
+        stream_name: "orders".to_string(),
+    };
+    let mut state = SearchWorkspaceState {
+        query: "balance".to_string(),
+        selected_sources: vec![selected],
+        ..Default::default()
+    };
+    let sources = [
+        source("orders", 1, "balance: 42"),
+        source("payments", 1, "balance: 99"),
+    ];
+
+    let results = workspace_results(&mut state, &sources);
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].source_label, "orders");
+}
+
+#[test]
+fn workspace_cache_invalidates_when_source_generation_changes() {
+    let source_id = SearchSourceId::Stream {
+        connection_id: 1,
+        stream_name: "orders".to_string(),
+    };
+    let mut state = SearchWorkspaceState {
+        query: "balance".to_string(),
+        selected_sources: vec![source_id],
+        ..Default::default()
+    };
+    let first_sources = [source("orders", 1, "balance: 42")];
+    assert_eq!(workspace_results(&mut state, &first_sources).len(), 1);
+
+    let second_sources = [source("orders", 2, "no match")];
+    assert_eq!(workspace_results(&mut state, &second_sources).len(), 0);
+}
+
+#[test]
+fn workspace_results_are_capped() {
+    let source_id = SearchSourceId::Stream {
+        connection_id: 1,
+        stream_name: "orders".to_string(),
+    };
+    let mut state = SearchWorkspaceState {
+        query: "balance".to_string(),
+        selected_sources: vec![source_id.clone()],
+        ..Default::default()
+    };
+    let records = (0..SEARCH_RESULT_LIMIT + 5)
+        .map(|idx| (idx.to_string(), "balance"))
+        .collect::<Vec<_>>();
+    let record_refs = records
+        .iter()
+        .map(|(id, text)| (id.as_str(), *text))
+        .collect::<Vec<_>>();
+    let sources = [source_with_records(source_id, "orders", 1, record_refs)];
+
+    let results = workspace_results(&mut state, &sources);
+
+    assert_eq!(results.len(), SEARCH_RESULT_LIMIT);
+}
+
+#[test]
+fn workspace_cache_invalidates_when_source_disappears() {
+    let source_id = SearchSourceId::Stream {
+        connection_id: 1,
+        stream_name: "orders".to_string(),
+    };
+    let mut state = SearchWorkspaceState {
+        query: "balance".to_string(),
+        selected_sources: vec![source_id],
+        ..Default::default()
+    };
+    let sources = [source("orders", 1, "balance: 42")];
+    assert_eq!(workspace_results(&mut state, &sources).len(), 1);
+
+    let no_sources = [];
+    let results = workspace_results(&mut state, &no_sources);
+
+    assert!(results.is_empty());
+}
+
+#[test]
+fn compact_text_collapses_and_truncates() {
+    assert_eq!(compact_text("a\n b  c", 8), "a b c");
+    assert_eq!(compact_text("abcdef", 3), "abc...");
+}

--- a/crates/app/src/tabs/server_info.rs
+++ b/crates/app/src/tabs/server_info.rs
@@ -1,5 +1,7 @@
 use eframe::egui;
-use nats_backend::{BackendCommand, BackendHandle};
+use nats_backend::{
+    BackendCommand, BackendHandle, JetStreamAccountInfoSnapshot, ServerInfoSnapshot,
+};
 
 use crate::i18n::t;
 
@@ -45,7 +47,7 @@ pub fn server_info_ui(
     });
 }
 
-fn render_server_info(ui: &mut egui::Ui, info: &serde_json::Value) {
+fn render_server_info(ui: &mut egui::Ui, info: &ServerInfoSnapshot) {
     egui::CollapsingHeader::new(t("server_info.section_server"))
         .default_open(true)
         .show(ui, |ui| {
@@ -53,45 +55,37 @@ fn render_server_info(ui: &mut egui::Ui, info: &serde_json::Value) {
                 .num_columns(2)
                 .spacing([16.0, 4.0])
                 .show(ui, |ui| {
-                    row(ui, t("server_info.server_name"), &info["server_name"]);
-                    row(ui, t("server_info.server_id"), &info["server_id"]);
-                    row(ui, t("server_info.version"), &info["version"]);
-                    row(
+                    row_text(ui, t("server_info.server_name"), &info.server_name);
+                    row_text(ui, t("server_info.server_id"), &info.server_id);
+                    row_text(ui, t("server_info.version"), &info.version);
+                    row_text(
                         ui,
                         t("server_info.host_port"),
-                        &serde_json::json!(format!(
-                            "{}:{}",
-                            info["host"].as_str().unwrap_or(""),
-                            info["port"].as_u64().unwrap_or(0)
-                        )),
+                        &format!("{}:{}", info.host, info.port),
                     );
-                    row(ui, t("server_info.go_version"), &info["go"]);
-                    row(ui, t("server_info.proto"), &info["proto"]);
-                    row(ui, t("server_info.client_id"), &info["client_id"]);
-                    if let Some(max) = info["max_payload"].as_u64() {
-                        ui.label(t("server_info.max_payload"));
-                        ui.label(format_bytes(max));
-                        ui.end_row();
-                    }
-                    row_bool(ui, t("server_info.auth_required"), &info["auth_required"]);
-                    row_bool(ui, t("server_info.tls_required"), &info["tls_required"]);
+                    row_text(ui, t("server_info.go_version"), &info.go);
+                    row_text(ui, t("server_info.proto"), &info.proto.to_string());
+                    row_text(ui, t("server_info.client_id"), &info.client_id.to_string());
+                    row_text(
+                        ui,
+                        t("server_info.max_payload"),
+                        &format_bytes(info.max_payload as u64),
+                    );
+                    row_bool(ui, t("server_info.auth_required"), info.auth_required);
+                    row_bool(ui, t("server_info.tls_required"), info.tls_required);
                 });
 
-            if let Some(urls) = info["connect_urls"].as_array()
-                && !urls.is_empty()
-            {
+            if !info.connect_urls.is_empty() {
                 ui.add_space(8.0);
                 ui.label(t("server_info.connect_urls"));
-                for url in urls {
-                    if let Some(u) = url.as_str() {
-                        ui.monospace(format!("  • {u}"));
-                    }
+                for url in &info.connect_urls {
+                    ui.monospace(format!("  • {url}"));
                 }
             }
         });
 }
 
-fn render_account_info(ui: &mut egui::Ui, account: &serde_json::Value) {
+fn render_account_info(ui: &mut egui::Ui, account: &JetStreamAccountInfoSnapshot) {
     egui::CollapsingHeader::new(t("server_info.section_jetstream"))
         .default_open(true)
         .show(ui, |ui| {
@@ -99,82 +93,77 @@ fn render_account_info(ui: &mut egui::Ui, account: &serde_json::Value) {
                 .num_columns(2)
                 .spacing([16.0, 4.0])
                 .show(ui, |ui| {
-                    if let Some(domain) = account["domain"].as_str() {
+                    if let Some(domain) = account.domain.as_deref() {
                         ui.label(t("server_info.domain"));
                         ui.label(domain);
                         ui.end_row();
                     }
-                    if let Some(mem) = account["memory"].as_u64() {
-                        ui.label(t("server_info.memory_used"));
-                        ui.label(format_bytes(mem));
-                        ui.end_row();
-                    }
-                    if let Some(storage) = account["storage"].as_u64() {
-                        ui.label(t("server_info.storage_used"));
-                        ui.label(format_bytes(storage));
-                        ui.end_row();
-                    }
-                    row(ui, t("server_info.streams"), &account["streams"]);
-                    row(ui, t("server_info.consumers"), &account["consumers"]);
-                    row(ui, t("server_info.api_total"), &account["api_total"]);
-                    row(ui, t("server_info.api_errors"), &account["api_errors"]);
+                    row_text(
+                        ui,
+                        t("server_info.memory_used"),
+                        &format_bytes(account.memory),
+                    );
+                    row_text(
+                        ui,
+                        t("server_info.storage_used"),
+                        &format_bytes(account.storage),
+                    );
+                    row_text(ui, t("server_info.streams"), &account.streams.to_string());
+                    row_text(
+                        ui,
+                        t("server_info.consumers"),
+                        &account.consumers.to_string(),
+                    );
+                    row_text(
+                        ui,
+                        t("server_info.api_total"),
+                        &account.api_total.to_string(),
+                    );
+                    row_text(
+                        ui,
+                        t("server_info.api_errors"),
+                        &account.api_errors.to_string(),
+                    );
                 });
 
-            if let Some(limits) = account.get("limits") {
-                ui.add_space(8.0);
-                egui::CollapsingHeader::new(t("server_info.section_limits"))
-                    .default_open(false)
-                    .show(ui, |ui| {
-                        egui::Grid::new("limits_grid")
-                            .num_columns(2)
-                            .spacing([16.0, 4.0])
-                            .show(ui, |ui| {
-                                limit_bytes_row(
-                                    ui,
-                                    t("server_info.max_memory"),
-                                    limits["max_memory"].as_i64(),
-                                );
-                                limit_bytes_row(
-                                    ui,
-                                    t("server_info.max_storage"),
-                                    limits["max_storage"].as_i64(),
-                                );
-                                limit_row(
-                                    ui,
-                                    t("server_info.max_streams"),
-                                    limits["max_streams"].as_i64(),
-                                );
-                                limit_row(
-                                    ui,
-                                    t("server_info.max_consumers"),
-                                    limits["max_consumers"].as_i64(),
-                                );
-                            });
-                    });
-            }
+            ui.add_space(8.0);
+            egui::CollapsingHeader::new(t("server_info.section_limits"))
+                .default_open(false)
+                .show(ui, |ui| {
+                    egui::Grid::new("limits_grid")
+                        .num_columns(2)
+                        .spacing([16.0, 4.0])
+                        .show(ui, |ui| {
+                            limit_bytes_row(
+                                ui,
+                                t("server_info.max_memory"),
+                                account.limits.max_memory,
+                            );
+                            limit_bytes_row(
+                                ui,
+                                t("server_info.max_storage"),
+                                account.limits.max_storage,
+                            );
+                            limit_row(ui, t("server_info.max_streams"), account.limits.max_streams);
+                            limit_row(
+                                ui,
+                                t("server_info.max_consumers"),
+                                account.limits.max_consumers,
+                            );
+                        });
+                });
         });
 }
 
-fn row(ui: &mut egui::Ui, label: &str, value: &serde_json::Value) {
+fn row_text(ui: &mut egui::Ui, label: &str, value: &str) {
     ui.label(label);
-    match value {
-        serde_json::Value::String(s) => {
-            ui.label(s.as_str());
-        }
-        serde_json::Value::Number(n) => {
-            ui.label(n.to_string());
-        }
-        _ => {
-            ui.label(value.to_string());
-        }
-    }
+    ui.label(value);
     ui.end_row();
 }
 
-fn row_bool(ui: &mut egui::Ui, label: &str, value: &serde_json::Value) {
+fn row_bool(ui: &mut egui::Ui, label: &str, value: bool) {
     ui.label(label);
-    let b = value.as_bool().unwrap_or(false);
-    ui.label(if b { "✅" } else { "❌" });
+    ui.label(if value { "✅" } else { "❌" });
     ui.end_row();
 }
 

--- a/crates/app/src/tabs/stream.rs
+++ b/crates/app/src/tabs/stream.rs
@@ -1,6 +1,5 @@
-use base64::Engine;
 use eframe::egui;
-use nats_backend::{BackendCommand, BackendHandle};
+use nats_backend::{BackendCommand, BackendHandle, StreamInfo, StreamMessageInfo};
 use std::time::{Duration, SystemTime};
 
 use crate::format::{self, PayloadFormat};
@@ -9,7 +8,7 @@ use crate::schema::MessageSchemaManager;
 
 use super::common::{
     SEARCH_RESULT_LIMIT, SearchStatus, auto_refresh_ui, format_bytes, matches_query,
-    render_search_row, searchable_json_payload,
+    render_search_row, searchable_payload_text,
 };
 use super::stream_consumers::render_consumers;
 use super::types::{SearchCacheKey, StreamState, TabAction};
@@ -115,17 +114,13 @@ fn render_message_controls(
     actions: &mut Vec<TabAction>,
 ) {
     // WorkQueue retention warning
-    if let Some(info) = &state.info {
-        let retention = info["config"]["retention"]
-            .as_str()
-            .unwrap_or("")
-            .to_lowercase();
-        if retention.contains("work") {
-            ui.horizontal(|ui| {
-                ui.colored_label(egui::Color32::YELLOW, "⚠");
-                ui.label(t("stream.workqueue_hint"));
-            });
-        }
+    if let Some(info) = &state.info
+        && info.retention.to_lowercase().contains("work")
+    {
+        ui.horizontal(|ui| {
+            ui.colored_label(egui::Color32::YELLOW, "⚠");
+            ui.label(t("stream.workqueue_hint"));
+        });
     }
 
     ui.horizontal(|ui| {
@@ -278,28 +273,23 @@ fn filtered_stream_rows(state: &mut StreamState) -> &[(usize, String)] {
 }
 
 fn stream_message_matches(
-    msg: &serde_json::Value,
+    msg: &StreamMessageInfo,
     search: &super::types::ScopedSearchState,
     query: &str,
 ) -> bool {
     if !search.is_active() {
         return true;
     }
-    let subject_matches = search.primary
-        && msg["subject"]
-            .as_str()
-            .is_some_and(|subject| matches_query(subject, query));
-    let payload_matches = search.secondary && matches_query(&searchable_json_payload(msg), query);
+    let subject_matches = search.primary && matches_query(&msg.subject, query);
+    let payload_matches =
+        search.secondary && matches_query(&searchable_payload_text(&msg.payload), query);
     subject_matches || payload_matches
 }
 
-fn stream_message_label(msg: &serde_json::Value) -> String {
-    let seq = msg["sequence"].as_u64().unwrap_or(0);
-    let subject = msg["subject"].as_str().unwrap_or("");
-    let time_str = msg["time"]
-        .as_str()
-        .and_then(format_rfc3339_short)
-        .unwrap_or_default();
+fn stream_message_label(msg: &StreamMessageInfo) -> String {
+    let seq = msg.sequence;
+    let subject = msg.subject.as_str();
+    let time_str = format_rfc3339_short(&msg.time).unwrap_or_default();
     if time_str.is_empty() {
         format!("#{seq} {subject}")
     } else {
@@ -318,10 +308,7 @@ fn format_rfc3339_short(rfc: &str) -> Option<String> {
 
 fn default_publish_subject(state: &StreamState) -> String {
     if let Some(idx) = state.selected_msg
-        && let Some(subject) = state
-            .messages
-            .get(idx)
-            .and_then(|msg| msg["subject"].as_str())
+        && let Some(subject) = state.messages.get(idx).map(|msg| msg.subject.as_str())
         && is_publishable_subject(subject)
     {
         return subject.to_string();
@@ -333,10 +320,9 @@ fn default_publish_subject(state: &StreamState) -> String {
     }
 
     if let Some(info) = &state.info
-        && let Some(subjects) = info["config"]["subjects"].as_array()
-        && let Some(subject) = subjects
+        && let Some(subject) = info
+            .subjects
             .iter()
-            .filter_map(|item| item.as_str())
             .find(|subject| is_publishable_subject(subject))
     {
         return subject.to_string();
@@ -428,81 +414,36 @@ fn render_purge_controls(
             });
             if let Some(idx) = state.selected_msg
                 && let Some(msg) = state.messages.get(idx)
-                && let Some(seq) = msg["sequence"].as_u64()
                 && ui
-                    .button(format!("{} #{seq}", t("stream.delete_msg")))
+                    .button(format!("{} #{}", t("stream.delete_msg"), msg.sequence))
                     .clicked()
             {
                 backend.send(BackendCommand::DeleteStreamMessage {
                     connection_id,
                     stream: stream_name.to_string(),
-                    sequence: seq,
+                    sequence: msg.sequence,
                 });
             }
         });
 }
 
-fn stream_info_panel(ui: &mut egui::Ui, info: &serde_json::Value) {
+fn stream_info_panel(ui: &mut egui::Ui, info: &StreamInfo) {
     egui::Grid::new("stream_info_grid")
         .num_columns(2)
         .spacing([8.0, 4.0])
         .show(ui, |ui| {
-            if let Some(config) = info.get("config") {
-                if let Some(name) = config.get("name").and_then(|v| v.as_str()) {
-                    ui.label(t("stream.name"));
-                    ui.label(name);
-                    ui.end_row();
-                }
-                if let Some(subjects) = config.get("subjects").and_then(|v| v.as_array()) {
-                    ui.label(t("stream.subjects"));
-                    ui.label(
-                        subjects
-                            .iter()
-                            .filter_map(|s| s.as_str())
-                            .collect::<Vec<_>>()
-                            .join(", "),
-                    );
-                    ui.end_row();
-                }
-                if let Some(storage) = config.get("storage").and_then(|v| v.as_str()) {
-                    ui.label(t("stream.storage"));
-                    ui.label(storage);
-                    ui.end_row();
-                }
-                if let Some(retention) = config.get("retention").and_then(|v| v.as_str()) {
-                    ui.label(t("stream.retention"));
-                    ui.label(retention);
-                    ui.end_row();
-                }
-            }
-            if let Some(st) = info.get("state") {
-                for (label, value, is_bytes) in [
-                    (
-                        t("stream.msg_count"),
-                        st.get("messages").and_then(|v| v.as_u64()),
-                        false,
-                    ),
-                    (
-                        t("stream.bytes"),
-                        st.get("bytes").and_then(|v| v.as_u64()),
-                        true,
-                    ),
-                    (
-                        t("stream.consumers"),
-                        st.get("consumer_count").and_then(|v| v.as_u64()),
-                        false,
-                    ),
-                ] {
-                    if let Some(value) = value {
-                        ui.label(label);
-                        if is_bytes {
-                            ui.label(format_bytes(value));
-                        } else {
-                            ui.label(value.to_string());
-                        }
-                        ui.end_row();
-                    }
-                }
+            for (label, value) in [
+                (t("stream.name"), info.name.clone()),
+                (t("stream.subjects"), info.subjects.join(", ")),
+                (t("stream.storage"), info.storage.clone()),
+                (t("stream.retention"), info.retention.clone()),
+                (t("stream.msg_count"), info.messages.to_string()),
+                (t("stream.bytes"), format_bytes(info.bytes)),
+                (t("stream.consumers"), info.consumer_count.to_string()),
+            ] {
+                ui.label(label);
+                ui.label(value);
+                ui.end_row();
             }
         });
 }
@@ -510,7 +451,7 @@ fn stream_info_panel(ui: &mut egui::Ui, info: &serde_json::Value) {
 fn stream_message_detail(
     ui: &mut egui::Ui,
     connection_id: u64,
-    msg: &serde_json::Value,
+    msg: &StreamMessageInfo,
     payload_format: &mut PayloadFormat,
     proto_view: &mut crate::proto::ProtoViewState,
     schema_manager: &MessageSchemaManager,
@@ -524,80 +465,59 @@ fn stream_message_detail(
         .num_columns(2)
         .spacing([8.0, 4.0])
         .show(ui, |ui| {
-            if let Some(seq) = msg["sequence"].as_u64() {
-                ui.label(t("stream.msg_sequence"));
-                ui.label(seq.to_string());
-                ui.end_row();
-            }
-            if let Some(subject) = msg["subject"].as_str() {
-                ui.label(t("stream.msg_subject"));
-                ui.label(subject);
-                ui.end_row();
-            }
-            if let Some(time) = msg["time"].as_str()
-                && !time.is_empty()
-            {
+            ui.label(t("stream.msg_sequence"));
+            ui.label(msg.sequence.to_string());
+            ui.end_row();
+
+            ui.label(t("stream.msg_subject"));
+            ui.label(&msg.subject);
+            ui.end_row();
+
+            if !msg.time.is_empty() {
                 ui.label(t("stream.msg_time"));
-                ui.label(time);
+                ui.label(&msg.time);
                 ui.end_row();
             }
         });
 
-    if let Some(headers) = msg["headers"].as_array()
-        && !headers.is_empty()
-    {
+    if !msg.headers.is_empty() {
         ui.add_space(4.0);
         ui.label(t("stream.msg_headers"));
         egui::Grid::new("stream_msg_headers")
             .num_columns(2)
             .striped(true)
             .show(ui, |ui| {
-                for h in headers {
-                    if let Some(arr) = h.as_array()
-                        && arr.len() == 2
-                    {
-                        ui.label(arr[0].as_str().unwrap_or(""));
-                        ui.label(arr[1].as_str().unwrap_or(""));
-                        ui.end_row();
-                    }
+                for (name, value) in &msg.headers {
+                    ui.label(name);
+                    ui.label(value);
+                    ui.end_row();
                 }
             });
     }
 
     ui.add_space(4.0);
     ui.label(t("stream.msg_payload"));
-    if let Some(payload_b64) = msg["payload_base64"].as_str() {
-        match base64::engine::general_purpose::STANDARD.decode(payload_b64) {
-            Ok(data) => {
-                if let Some(subject) = msg["subject"].as_str() {
-                    format::render_payload_with_schema(
-                        ui,
-                        &data,
-                        *payload_format,
-                        "stream_proto",
-                        proto_view,
-                        format::SchemaRenderContext {
-                            manager: schema_manager,
-                            connection_id,
-                            subject,
-                        },
-                    );
-                } else {
-                    format::render_payload_with_proto(
-                        ui,
-                        &data,
-                        *payload_format,
-                        "stream_proto",
-                        proto_view,
-                        schema_manager,
-                    );
-                }
-            }
-            Err(_) => {
-                ui.label(t("stream.invalid_base64"));
-            }
-        }
+    if !msg.subject.is_empty() {
+        format::render_payload_with_schema(
+            ui,
+            &msg.payload,
+            *payload_format,
+            "stream_proto",
+            proto_view,
+            format::SchemaRenderContext {
+                manager: schema_manager,
+                connection_id,
+                subject: &msg.subject,
+            },
+        );
     } else {
-        ui.label(t("stream.no_payload"));
+        format::render_payload_with_proto(
+            ui,
+            &msg.payload,
+            *payload_format,
+            "stream_proto",
+            proto_view,
+            schema_manager,
+        );
     }
 }

--- a/crates/app/src/tabs/stream_consumers.rs
+++ b/crates/app/src/tabs/stream_consumers.rs
@@ -79,6 +79,7 @@ fn consumer_card(
     } else {
         t("consumer.type_pull")
     };
+    let deliver_policy = consumer.deliver_policy.display();
 
     // Stable ID scope for the entire consumer card
     ui.push_id(
@@ -107,7 +108,7 @@ fn consumer_card(
                             info_row(
                                 ui,
                                 t("consumer.deliver_policy"),
-                                Some(consumer.deliver_policy.as_str()),
+                                Some(deliver_policy.as_str()),
                             );
                             info_row(ui, t("consumer.ack_policy"), Some(&consumer.ack_policy));
                             info_num_row(ui, t("consumer.max_deliver"), consumer.max_deliver);

--- a/crates/app/src/tabs/stream_consumers.rs
+++ b/crates/app/src/tabs/stream_consumers.rs
@@ -1,5 +1,5 @@
 use eframe::egui;
-use nats_backend::{BackendCommand, BackendHandle};
+use nats_backend::{BackendCommand, BackendHandle, ConsumerInfo, StreamMessageInfo};
 
 use crate::i18n::t;
 
@@ -68,14 +68,13 @@ fn consumer_card(
     ui: &mut egui::Ui,
     connection_id: u64,
     stream_name: &str,
-    consumer: &serde_json::Value,
+    consumer: &ConsumerInfo,
     state: &mut StreamState,
     backend: &BackendHandle,
     actions: &mut Vec<TabAction>,
 ) {
-    let name = consumer["name"].as_str().unwrap_or(t("consumer.unnamed"));
-    let config = &consumer["config"];
-    let consumer_type = if config["deliver_subject"].as_str().is_some() {
+    let name = consumer.name.as_str();
+    let consumer_type = if consumer.deliver_subject.is_some() {
         t("consumer.type_push")
     } else {
         t("consumer.type_pull")
@@ -98,54 +97,34 @@ fn consumer_card(
                             info_row(
                                 ui,
                                 t("consumer.durable"),
-                                config["durable_name"].as_str().filter(|s| !s.is_empty()),
+                                consumer.durable_name.as_deref().filter(|s| !s.is_empty()),
                             );
                             info_row(
                                 ui,
                                 t("consumer.filter_subject"),
-                                config["filter_subject"].as_str().filter(|s| !s.is_empty()),
+                                consumer.filter_subject.as_deref().filter(|s| !s.is_empty()),
                             );
                             info_row(
                                 ui,
                                 t("consumer.deliver_policy"),
-                                config["deliver_policy"].as_str(),
+                                Some(consumer.deliver_policy.as_str()),
                             );
-                            info_row(ui, t("consumer.ack_policy"), config["ack_policy"].as_str());
-                            info_num_row(
-                                ui,
-                                t("consumer.max_deliver"),
-                                config["max_deliver"].as_i64(),
-                            );
+                            info_row(ui, t("consumer.ack_policy"), Some(&consumer.ack_policy));
+                            info_num_row(ui, t("consumer.max_deliver"), consumer.max_deliver);
                             info_num_row(
                                 ui,
                                 t("consumer.max_ack_pending"),
-                                config["max_ack_pending"].as_i64(),
+                                consumer.max_ack_pending,
                             );
                             info_row(
                                 ui,
                                 t("consumer.description"),
-                                config["description"].as_str().filter(|s| !s.is_empty()),
+                                consumer.description.as_deref().filter(|s| !s.is_empty()),
                             );
-                            info_u64_row(
-                                ui,
-                                t("consumer.pending"),
-                                consumer["num_pending"].as_u64(),
-                            );
-                            info_u64_row(
-                                ui,
-                                t("consumer.ack_pending"),
-                                consumer["num_ack_pending"].as_u64(),
-                            );
-                            info_u64_row(
-                                ui,
-                                t("consumer.waiting"),
-                                consumer["num_waiting"].as_u64(),
-                            );
-                            info_u64_row(
-                                ui,
-                                t("consumer.redelivered"),
-                                consumer["num_redelivered"].as_u64(),
-                            );
+                            info_u64_row(ui, t("consumer.pending"), consumer.num_pending);
+                            info_u64_row(ui, t("consumer.ack_pending"), consumer.num_ack_pending);
+                            info_u64_row(ui, t("consumer.waiting"), consumer.num_waiting);
+                            info_u64_row(ui, t("consumer.redelivered"), consumer.num_redelivered);
                         });
 
                     ui.add_space(4.0);
@@ -154,7 +133,7 @@ fn consumer_card(
                             actions.push(TabAction::OpenConsumerEdit {
                                 connection_id,
                                 stream_name: stream_name.to_string(),
-                                consumer_json: consumer.clone(),
+                                consumer_info: consumer.clone(),
                             });
                         }
                         let is_fetching = state.consumer_fetching.contains(name);
@@ -195,22 +174,20 @@ fn consumer_card(
                                 .max_height(200.0)
                                 .show(ui, |ui| {
                                     for (i, msg) in msgs.iter().enumerate() {
-                                        let subj = msg["subject"].as_str().unwrap_or("?");
-                                        let seq = msg["seq"].as_u64().unwrap_or(0);
-                                        let time = msg["time"].as_str().unwrap_or("");
+                                        let subj = msg.subject.as_str();
+                                        let seq = msg.sequence;
+                                        let time = msg.time.as_str();
                                         let header = format!("#{seq} {subj}  {time}");
                                         egui::CollapsingHeader::new(header)
                                             .id_salt(("fetched_msg", i))
                                             .default_open(false)
                                             .show(ui, |ui| {
-                                                let payload = msg["payload"].as_str().unwrap_or("");
+                                                let mut payload = consumer_message_payload(msg);
                                                 ui.add(
-                                                    egui::TextEdit::multiline(
-                                                        &mut payload.to_string(),
-                                                    )
-                                                    .desired_rows(3)
-                                                    .interactive(false)
-                                                    .desired_width(ui.available_width()),
+                                                    egui::TextEdit::multiline(&mut payload)
+                                                        .desired_rows(3)
+                                                        .interactive(false)
+                                                        .desired_width(ui.available_width()),
                                                 );
                                             });
                                     }
@@ -235,16 +212,18 @@ fn info_row(ui: &mut egui::Ui, label: &str, value: Option<&str>) {
     }
 }
 
-fn info_num_row(ui: &mut egui::Ui, label: &str, value: Option<i64>) {
-    if let Some(value) = value {
-        ui.label(label);
-        ui.label(value.to_string());
-        ui.end_row();
-    }
+fn info_num_row(ui: &mut egui::Ui, label: &str, value: i64) {
+    ui.label(label);
+    ui.label(value.to_string());
+    ui.end_row();
 }
 
-fn info_u64_row(ui: &mut egui::Ui, label: &str, value: Option<u64>) {
+fn info_u64_row(ui: &mut egui::Ui, label: &str, value: u64) {
     ui.label(label);
-    ui.label(value.unwrap_or(0).to_string());
+    ui.label(value.to_string());
     ui.end_row();
+}
+
+fn consumer_message_payload(msg: &StreamMessageInfo) -> String {
+    String::from_utf8_lossy(&msg.payload).to_string()
 }

--- a/crates/app/src/tabs/types.rs
+++ b/crates/app/src/tabs/types.rs
@@ -1,18 +1,22 @@
+mod metrics_state;
+mod tab_kind;
+
+pub use metrics_state::MetricsState;
+pub use tab_kind::{AppTabViewer, TabKind};
+
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::{Instant, SystemTime};
 
 use eframe::egui;
-use egui_dock::TabViewer;
-use egui_dock::tab_viewer::OnCloseResponse;
-use nats_backend::MetricsSnapshot;
+use nats_backend::{
+    ConsumerInfo, JetStreamAccountInfoSnapshot, KvBucketInfo, KvHistoryItem, ObjectStoreBucketInfo,
+    ObjectStoreObjectInfo, ServerInfoSnapshot, StreamInfo, StreamMessageInfo,
+};
 
 use crate::format::PayloadFormat;
-use crate::i18n::t;
 use crate::proto::ProtoViewState;
-use crate::schema::{MessageSchemaManager, SchemaSelector, SchemaSourceKind, ValidationPolicy};
+use crate::schema::{SchemaSelector, SchemaSourceKind, ValidationPolicy};
 use crate::theme::ThemeId;
-
-use super::guard::TabGuard;
 
 /// Auto-refresh configuration for periodic data reloading.
 #[derive(Debug)]
@@ -60,11 +64,11 @@ pub enum TabAction {
     OpenConsumerEdit {
         connection_id: u64,
         stream_name: String,
-        consumer_json: serde_json::Value,
+        consumer_info: ConsumerInfo,
     },
     OpenKvBucketEdit {
         connection_id: u64,
-        bucket_json: serde_json::Value,
+        bucket_info: KvBucketInfo,
     },
     OpenKvEntryCreate {
         connection_id: u64,
@@ -492,8 +496,8 @@ impl SubscriberState {
 
 #[derive(Debug)]
 pub struct StreamState {
-    pub info: Option<serde_json::Value>,
-    pub messages: Vec<serde_json::Value>,
+    pub info: Option<StreamInfo>,
+    pub messages: Vec<StreamMessageInfo>,
     pub selected_msg: Option<usize>,
     pub payload_format: PayloadFormat,
     pub start_seq: String,
@@ -502,11 +506,11 @@ pub struct StreamState {
     pub batch_size: String,
     pub fetching: bool,
     pub purge_subject: String,
-    pub consumers: Vec<serde_json::Value>,
+    pub consumers: Vec<ConsumerInfo>,
     pub consumers_fetching: bool,
     pub auto_refresh: AutoRefresh,
     pub proto_view: ProtoViewState,
-    pub consumer_fetched: std::collections::HashMap<String, Vec<serde_json::Value>>,
+    pub consumer_fetched: std::collections::HashMap<String, Vec<StreamMessageInfo>>,
     pub consumer_fetching: std::collections::HashSet<String>,
     pub search: ScopedSearchState,
     pub search_generation: u64,
@@ -541,7 +545,7 @@ impl Default for StreamState {
 
 #[derive(Debug)]
 pub struct KvBucketState {
-    pub info: Option<serde_json::Value>,
+    pub info: Option<KvBucketInfo>,
     pub keys: Vec<String>,
     pub selected_key: Option<String>,
     pub search: ScopedSearchState,
@@ -562,7 +566,7 @@ pub struct KvBucketState {
     pub entry_operation: Option<String>,
     pub entry_created: Option<String>,
     pub editor_format: PayloadFormat,
-    pub history: Vec<serde_json::Value>,
+    pub history: Vec<KvHistoryItem>,
     pub history_format: PayloadFormat,
     pub show_history: bool,
     pub auto_refresh: AutoRefresh,
@@ -606,8 +610,8 @@ impl Default for KvBucketState {
 
 #[derive(Debug, Default)]
 pub struct ObjectStoreBucketState {
-    pub info: Option<serde_json::Value>,
-    pub objects: Vec<serde_json::Value>,
+    pub info: Option<ObjectStoreBucketInfo>,
+    pub objects: Vec<ObjectStoreObjectInfo>,
     pub selected_object: Option<String>,
     pub object_filter: String,
     pub loading_objects: bool,
@@ -617,461 +621,7 @@ pub struct ObjectStoreBucketState {
 
 #[derive(Debug, Default)]
 pub struct ServerInfoState {
-    pub server_info: Option<serde_json::Value>,
-    pub account_info: Option<serde_json::Value>,
+    pub server_info: Option<ServerInfoSnapshot>,
+    pub account_info: Option<JetStreamAccountInfoSnapshot>,
     pub loading: bool,
-}
-
-#[derive(Debug, Default)]
-pub struct MetricsState {
-    endpoint: String,
-    latest_attempt: Option<MetricsSnapshot>,
-    history: VecDeque<MetricsSnapshot>,
-    pub loading: bool,
-    pub auto_refresh: AutoRefresh,
-}
-
-impl MetricsState {
-    const MAX_SAMPLES: usize = 720;
-
-    pub fn with_endpoint(endpoint: String) -> Self {
-        let mut state = Self {
-            endpoint,
-            ..Default::default()
-        };
-        state.auto_refresh.enabled = true;
-        state.auto_refresh.interval_secs = 5;
-        state
-    }
-
-    pub fn endpoint(&self) -> &str {
-        self.endpoint.as_str()
-    }
-
-    pub fn endpoint_configured(&self) -> bool {
-        !self.endpoint.trim().is_empty()
-    }
-
-    pub fn set_endpoint(&mut self, endpoint: String) {
-        if self.endpoint == endpoint {
-            return;
-        }
-        self.endpoint = endpoint;
-        self.latest_attempt = None;
-        self.history.clear();
-        self.loading = false;
-        self.auto_refresh.last_refresh = Instant::now();
-    }
-
-    pub fn begin_refresh(&mut self) {
-        self.loading = true;
-        self.auto_refresh.mark_refreshed();
-    }
-
-    pub fn apply_snapshot(&mut self, snapshot: MetricsSnapshot) {
-        self.endpoint = snapshot.endpoint.clone();
-        self.loading = false;
-        if snapshot.has_any_data() {
-            if self.history.len() >= Self::MAX_SAMPLES {
-                self.history.pop_front();
-            }
-            self.history.push_back(snapshot.clone());
-        }
-        self.latest_attempt = Some(snapshot);
-    }
-
-    pub fn has_never_loaded(&self) -> bool {
-        self.latest_attempt.is_none() && self.history.is_empty()
-    }
-
-    pub fn latest_attempt(&self) -> Option<&MetricsSnapshot> {
-        self.latest_attempt.as_ref()
-    }
-
-    pub fn latest_data(&self) -> Option<&MetricsSnapshot> {
-        self.latest_attempt
-            .as_ref()
-            .filter(|snapshot| snapshot.has_any_data())
-            .or_else(|| self.history.back())
-    }
-
-    pub fn history(&self) -> &VecDeque<MetricsSnapshot> {
-        &self.history
-    }
-
-    pub fn is_stale(&self) -> bool {
-        self.latest_attempt
-            .as_ref()
-            .is_some_and(|snapshot| !snapshot.has_any_data())
-            && !self.history.is_empty()
-    }
-}
-
-#[derive(Debug)]
-#[allow(dead_code)] // guard fields exist for RAII Drop cleanup, not direct reads
-pub enum TabKind {
-    Welcome,
-    Publisher {
-        connection_id: u64,
-        connection_name: String,
-        guard: TabGuard,
-        backend_id: u64,
-        state: PublisherState,
-    },
-    Subscriber {
-        connection_id: u64,
-        connection_name: String,
-        guard: TabGuard,
-        backend_id: u64,
-        state: SubscriberState,
-    },
-    Stream {
-        connection_id: u64,
-        connection_name: String,
-        stream_name: String,
-        guard: TabGuard,
-        state: StreamState,
-    },
-    KvBucket {
-        connection_id: u64,
-        connection_name: String,
-        bucket_name: String,
-        guard: TabGuard,
-        state: KvBucketState,
-    },
-    ObjectStoreBucket {
-        connection_id: u64,
-        connection_name: String,
-        bucket_name: String,
-        guard: TabGuard,
-        state: ObjectStoreBucketState,
-    },
-    ServerInfo {
-        connection_id: u64,
-        connection_name: String,
-        guard: TabGuard,
-        state: ServerInfoState,
-    },
-    Metrics {
-        connection_id: u64,
-        connection_name: String,
-        state: MetricsState,
-    },
-    SearchWorkspace {
-        state: SearchWorkspaceState,
-    },
-    MessageSchemas {
-        state: MessageSchemasState,
-    },
-    Settings,
-    LogViewer,
-}
-
-impl TabKind {
-    pub fn title(&self) -> String {
-        match self {
-            TabKind::Welcome => t("common.tab_welcome").to_string(),
-            TabKind::Publisher {
-                connection_name,
-                guard,
-                ..
-            } => {
-                if let Some(id) = guard.display_id() {
-                    format!(
-                        "{} #{} ({})",
-                        t("common.tab_publisher"),
-                        id,
-                        connection_name
-                    )
-                } else {
-                    format!("{} ({})", t("common.tab_publisher"), connection_name)
-                }
-            }
-            TabKind::Subscriber {
-                connection_name,
-                guard,
-                ..
-            } => {
-                if let Some(id) = guard.display_id() {
-                    format!(
-                        "{} #{} ({})",
-                        t("common.tab_subscriber"),
-                        id,
-                        connection_name
-                    )
-                } else {
-                    format!("{} ({})", t("common.tab_subscriber"), connection_name)
-                }
-            }
-            TabKind::Stream {
-                connection_name,
-                stream_name,
-                ..
-            } => {
-                format!("{stream_name} ({connection_name})")
-            }
-            TabKind::KvBucket {
-                connection_name,
-                bucket_name,
-                ..
-            } => {
-                format!("{bucket_name} ({connection_name})")
-            }
-            TabKind::ObjectStoreBucket {
-                connection_name,
-                bucket_name,
-                ..
-            } => {
-                format!("{bucket_name} ({connection_name})")
-            }
-            TabKind::ServerInfo {
-                connection_name, ..
-            } => {
-                format!("{} ({})", t("server_info.title"), connection_name)
-            }
-            TabKind::Metrics {
-                connection_name, ..
-            } => {
-                format!("{} ({})", t("common.tab_metrics"), connection_name)
-            }
-            TabKind::SearchWorkspace { .. } => t("common.tab_search_workspace").to_string(),
-            TabKind::MessageSchemas { .. } => t("common.tab_message_schemas").to_string(),
-            TabKind::Settings => t("settings.title").to_string(),
-            TabKind::LogViewer => t("log_viewer.title").to_string(),
-        }
-    }
-
-    /// Structural identity for use in close actions and deduplication.
-    pub fn tab_id(&self) -> egui::Id {
-        match self {
-            TabKind::Welcome => egui::Id::new("tab:welcome"),
-            TabKind::Publisher {
-                connection_id,
-                backend_id,
-                ..
-            } => egui::Id::new(("tab:publisher", *connection_id, *backend_id)),
-            TabKind::Subscriber {
-                connection_id,
-                backend_id,
-                ..
-            } => egui::Id::new(("tab:subscriber", *connection_id, *backend_id)),
-            TabKind::Stream {
-                connection_id,
-                stream_name,
-                ..
-            } => egui::Id::new(("tab:stream", *connection_id, stream_name.as_str())),
-            TabKind::KvBucket {
-                connection_id,
-                bucket_name,
-                ..
-            } => egui::Id::new(("tab:kv", *connection_id, bucket_name.as_str())),
-            TabKind::ObjectStoreBucket {
-                connection_id,
-                bucket_name,
-                ..
-            } => egui::Id::new(("tab:object-store", *connection_id, bucket_name.as_str())),
-            TabKind::ServerInfo { connection_id, .. } => {
-                egui::Id::new(("tab:server-info", *connection_id))
-            }
-            TabKind::Metrics { connection_id, .. } => {
-                egui::Id::new(("tab:metrics", *connection_id))
-            }
-            TabKind::SearchWorkspace { .. } => egui::Id::new("tab:search-workspace"),
-            TabKind::MessageSchemas { .. } => egui::Id::new("tab:message-schemas"),
-            TabKind::Settings => egui::Id::new("tab:settings"),
-            TabKind::LogViewer => egui::Id::new("tab:log-viewer"),
-        }
-    }
-}
-
-pub struct AppTabViewer<'a> {
-    pub backend: &'a nats_backend::BackendHandle,
-    pub actions: &'a mut Vec<TabAction>,
-    pub search_sources: &'a [SearchSourceSnapshot],
-    pub settings: &'a mut crate::settings::AppSettings,
-    pub theme_id: &'a mut ThemeId,
-    pub log_buffer: &'a crate::log_layer::SharedLogBuffer,
-    pub schema_manager: &'a MessageSchemaManager,
-    pub connections: &'a [(u64, String)],
-}
-
-impl TabViewer for AppTabViewer<'_> {
-    type Tab = TabKind;
-
-    fn title(&mut self, tab: &mut Self::Tab) -> egui::WidgetText {
-        tab.title().into()
-    }
-
-    fn id(&mut self, tab: &mut Self::Tab) -> egui::Id {
-        tab.tab_id()
-    }
-
-    fn ui(&mut self, ui: &mut egui::Ui, tab: &mut Self::Tab) {
-        crate::tabs::viewer::render_tab(self, ui, tab);
-    }
-
-    fn context_menu(&mut self, ui: &mut egui::Ui, tab: &mut Self::Tab, _path: egui_dock::NodePath) {
-        let tab_id = self.id(tab);
-        if ui.button(t("common.close_others")).clicked() {
-            self.actions.push(TabAction::CloseOtherTabs {
-                keep_tab_id: tab_id,
-            });
-            ui.close();
-        }
-        if ui.button(t("common.close_all")).clicked() {
-            self.actions.push(TabAction::CloseAllTabs);
-            ui.close();
-        }
-        if ui.button(t("common.close_to_right")).clicked() {
-            self.actions
-                .push(TabAction::CloseTabsToRight { of_tab_id: tab_id });
-            ui.close();
-        }
-    }
-
-    fn is_closeable(&self, tab: &Self::Tab) -> bool {
-        !matches!(tab, TabKind::Welcome)
-    }
-
-    fn allowed_in_windows(&self, tab: &mut Self::Tab) -> bool {
-        !matches!(tab, TabKind::Welcome)
-    }
-
-    fn on_close(&mut self, tab: &mut Self::Tab) -> OnCloseResponse {
-        // Send explicit Unsubscribe to clean up worker state.
-        // TabGuard Drop handles cancellation + display ID recycling automatically.
-        if let TabKind::Subscriber {
-            connection_id,
-            backend_id,
-            state,
-            ..
-        } = tab
-        {
-            for sub in &state.subscriptions {
-                if sub.active {
-                    self.backend
-                        .send(nats_backend::BackendCommand::Unsubscribe {
-                            connection_id: *connection_id,
-                            backend_id: *backend_id,
-                            subject: sub.subject.clone(),
-                        });
-                }
-            }
-        }
-        OnCloseResponse::Close
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::time::{Duration, SystemTime};
-
-    use nats_backend::{MetricsSection, MetricsSectionError, MetricsSnapshot, VarzMetrics};
-
-    use super::MetricsState;
-
-    fn sample_snapshot(endpoint: &str, collected_at: SystemTime, in_msgs: u64) -> MetricsSnapshot {
-        MetricsSnapshot {
-            endpoint: endpoint.to_string(),
-            collected_at,
-            health: None,
-            varz: Some(VarzMetrics {
-                server_name: Some("local".to_string()),
-                server_id: Some("server-1".to_string()),
-                version: Some("2.11.0".to_string()),
-                host: Some("127.0.0.1".to_string()),
-                port: Some(4222),
-                uptime: Some("1m".to_string()),
-                mem_bytes: 1024,
-                cpu_percent: 1.0,
-                connections: 2,
-                total_connections: 3,
-                subscriptions: 4,
-                slow_consumers: 0,
-                in_msgs,
-                out_msgs: in_msgs,
-                in_bytes: 2048,
-                out_bytes: 2048,
-            }),
-            connz: None,
-            jsz: None,
-            errors: Vec::new(),
-        }
-    }
-
-    #[test]
-    fn metrics_state_marks_last_good_sample_stale_after_failed_refresh() {
-        let mut state = MetricsState::with_endpoint("http://localhost:8222".to_string());
-        let first = sample_snapshot("http://localhost:8222", SystemTime::UNIX_EPOCH, 10);
-        state.apply_snapshot(first);
-
-        state.apply_snapshot(MetricsSnapshot {
-            endpoint: "http://localhost:8222".to_string(),
-            collected_at: SystemTime::UNIX_EPOCH + Duration::from_secs(5),
-            health: None,
-            varz: None,
-            connz: None,
-            jsz: None,
-            errors: vec![MetricsSectionError {
-                section: MetricsSection::Varz,
-                message: "timeout".to_string(),
-            }],
-        });
-
-        assert!(state.is_stale());
-        assert_eq!(state.history().len(), 1);
-        assert_eq!(
-            state.latest_data().unwrap().varz.as_ref().unwrap().in_msgs,
-            10
-        );
-    }
-
-    #[test]
-    fn metrics_state_clears_history_when_endpoint_changes() {
-        let mut state = MetricsState::with_endpoint("http://localhost:8222".to_string());
-        state.apply_snapshot(sample_snapshot(
-            "http://localhost:8222",
-            SystemTime::UNIX_EPOCH,
-            10,
-        ));
-
-        state.set_endpoint("http://localhost:9222".to_string());
-
-        assert!(state.history().is_empty());
-        assert!(state.latest_attempt().is_none());
-        assert_eq!(state.endpoint(), "http://localhost:9222");
-    }
-
-    #[test]
-    fn metrics_state_defaults_to_enabled_auto_refresh_every_five_seconds() {
-        let state = MetricsState::with_endpoint("http://localhost:8222".to_string());
-
-        assert!(state.auto_refresh.enabled);
-        assert_eq!(state.auto_refresh.interval_secs, 5);
-    }
-
-    #[test]
-    fn metrics_state_keeps_one_hour_at_default_refresh() {
-        let mut state = MetricsState::with_endpoint("http://localhost:8222".to_string());
-        for idx in 0..=MetricsState::MAX_SAMPLES {
-            state.apply_snapshot(sample_snapshot(
-                "http://localhost:8222",
-                SystemTime::UNIX_EPOCH + Duration::from_secs(idx as u64 * 5),
-                idx as u64,
-            ));
-        }
-
-        assert_eq!(state.history().len(), MetricsState::MAX_SAMPLES);
-        assert_eq!(
-            state
-                .history()
-                .front()
-                .unwrap()
-                .varz
-                .as_ref()
-                .unwrap()
-                .in_msgs,
-            1
-        );
-    }
 }

--- a/crates/app/src/tabs/types/metrics_state.rs
+++ b/crates/app/src/tabs/types/metrics_state.rs
@@ -1,0 +1,205 @@
+use std::collections::VecDeque;
+use std::time::Instant;
+
+use nats_backend::MetricsSnapshot;
+
+use super::AutoRefresh;
+
+#[derive(Debug, Default)]
+pub struct MetricsState {
+    endpoint: String,
+    latest_attempt: Option<MetricsSnapshot>,
+    history: VecDeque<MetricsSnapshot>,
+    pub loading: bool,
+    pub auto_refresh: AutoRefresh,
+}
+
+impl MetricsState {
+    const MAX_SAMPLES: usize = 720;
+
+    pub fn with_endpoint(endpoint: String) -> Self {
+        let mut state = Self {
+            endpoint,
+            ..Default::default()
+        };
+        state.auto_refresh.enabled = true;
+        state.auto_refresh.interval_secs = 5;
+        state
+    }
+
+    pub fn endpoint(&self) -> &str {
+        self.endpoint.as_str()
+    }
+
+    pub fn endpoint_configured(&self) -> bool {
+        !self.endpoint.trim().is_empty()
+    }
+
+    pub fn set_endpoint(&mut self, endpoint: String) {
+        if self.endpoint == endpoint {
+            return;
+        }
+        self.endpoint = endpoint;
+        self.latest_attempt = None;
+        self.history.clear();
+        self.loading = false;
+        self.auto_refresh.last_refresh = Instant::now();
+    }
+
+    pub fn begin_refresh(&mut self) {
+        self.loading = true;
+        self.auto_refresh.mark_refreshed();
+    }
+
+    pub fn apply_snapshot(&mut self, snapshot: MetricsSnapshot) {
+        self.endpoint = snapshot.endpoint.clone();
+        self.loading = false;
+        if snapshot.has_any_data() {
+            if self.history.len() >= Self::MAX_SAMPLES {
+                self.history.pop_front();
+            }
+            self.history.push_back(snapshot.clone());
+        }
+        self.latest_attempt = Some(snapshot);
+    }
+
+    pub fn has_never_loaded(&self) -> bool {
+        self.latest_attempt.is_none() && self.history.is_empty()
+    }
+
+    pub fn latest_attempt(&self) -> Option<&MetricsSnapshot> {
+        self.latest_attempt.as_ref()
+    }
+
+    pub fn latest_data(&self) -> Option<&MetricsSnapshot> {
+        self.latest_attempt
+            .as_ref()
+            .filter(|snapshot| snapshot.has_any_data())
+            .or_else(|| self.history.back())
+    }
+
+    pub fn history(&self) -> &VecDeque<MetricsSnapshot> {
+        &self.history
+    }
+
+    pub fn is_stale(&self) -> bool {
+        self.latest_attempt
+            .as_ref()
+            .is_some_and(|snapshot| !snapshot.has_any_data())
+            && !self.history.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, SystemTime};
+
+    use nats_backend::{MetricsSection, MetricsSectionError, MetricsSnapshot, VarzMetrics};
+
+    use super::MetricsState;
+
+    fn sample_snapshot(endpoint: &str, collected_at: SystemTime, in_msgs: u64) -> MetricsSnapshot {
+        MetricsSnapshot {
+            endpoint: endpoint.to_string(),
+            collected_at,
+            health: None,
+            varz: Some(VarzMetrics {
+                server_name: Some("local".to_string()),
+                server_id: Some("server-1".to_string()),
+                version: Some("2.11.0".to_string()),
+                host: Some("127.0.0.1".to_string()),
+                port: Some(4222),
+                uptime: Some("1m".to_string()),
+                mem_bytes: 1024,
+                cpu_percent: 1.0,
+                connections: 2,
+                total_connections: 3,
+                subscriptions: 4,
+                slow_consumers: 0,
+                in_msgs,
+                out_msgs: in_msgs,
+                in_bytes: 2048,
+                out_bytes: 2048,
+            }),
+            connz: None,
+            jsz: None,
+            errors: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn metrics_state_marks_last_good_sample_stale_after_failed_refresh() {
+        let mut state = MetricsState::with_endpoint("http://localhost:8222".to_string());
+        let first = sample_snapshot("http://localhost:8222", SystemTime::UNIX_EPOCH, 10);
+        state.apply_snapshot(first);
+
+        state.apply_snapshot(MetricsSnapshot {
+            endpoint: "http://localhost:8222".to_string(),
+            collected_at: SystemTime::UNIX_EPOCH + Duration::from_secs(5),
+            health: None,
+            varz: None,
+            connz: None,
+            jsz: None,
+            errors: vec![MetricsSectionError {
+                section: MetricsSection::Varz,
+                message: "timeout".to_string(),
+            }],
+        });
+
+        assert!(state.is_stale());
+        assert_eq!(state.history().len(), 1);
+        assert_eq!(
+            state.latest_data().unwrap().varz.as_ref().unwrap().in_msgs,
+            10
+        );
+    }
+
+    #[test]
+    fn metrics_state_clears_history_when_endpoint_changes() {
+        let mut state = MetricsState::with_endpoint("http://localhost:8222".to_string());
+        state.apply_snapshot(sample_snapshot(
+            "http://localhost:8222",
+            SystemTime::UNIX_EPOCH,
+            10,
+        ));
+
+        state.set_endpoint("http://localhost:9222".to_string());
+
+        assert!(state.history().is_empty());
+        assert!(state.latest_attempt().is_none());
+        assert_eq!(state.endpoint(), "http://localhost:9222");
+    }
+
+    #[test]
+    fn metrics_state_defaults_to_enabled_auto_refresh_every_five_seconds() {
+        let state = MetricsState::with_endpoint("http://localhost:8222".to_string());
+
+        assert!(state.auto_refresh.enabled);
+        assert_eq!(state.auto_refresh.interval_secs, 5);
+    }
+
+    #[test]
+    fn metrics_state_keeps_one_hour_at_default_refresh() {
+        let mut state = MetricsState::with_endpoint("http://localhost:8222".to_string());
+        for idx in 0..=MetricsState::MAX_SAMPLES {
+            state.apply_snapshot(sample_snapshot(
+                "http://localhost:8222",
+                SystemTime::UNIX_EPOCH + Duration::from_secs(idx as u64 * 5),
+                idx as u64,
+            ));
+        }
+
+        assert_eq!(state.history().len(), MetricsState::MAX_SAMPLES);
+        assert_eq!(
+            state
+                .history()
+                .front()
+                .unwrap()
+                .varz
+                .as_ref()
+                .unwrap()
+                .in_msgs,
+            1
+        );
+    }
+}

--- a/crates/app/src/tabs/types/tab_kind.rs
+++ b/crates/app/src/tabs/types/tab_kind.rs
@@ -1,0 +1,259 @@
+use eframe::egui;
+use egui_dock::TabViewer;
+use egui_dock::tab_viewer::OnCloseResponse;
+
+use crate::i18n::t;
+use crate::schema::MessageSchemaManager;
+use crate::theme::ThemeId;
+
+use super::{
+    KvBucketState, MessageSchemasState, MetricsState, ObjectStoreBucketState, PublisherState,
+    SearchSourceSnapshot, SearchWorkspaceState, ServerInfoState, StreamState, SubscriberState,
+    TabAction,
+};
+use crate::tabs::guard::TabGuard;
+
+#[derive(Debug)]
+#[allow(dead_code)] // guard fields exist for RAII Drop cleanup, not direct reads
+pub enum TabKind {
+    Welcome,
+    Publisher {
+        connection_id: u64,
+        connection_name: String,
+        guard: TabGuard,
+        backend_id: u64,
+        state: PublisherState,
+    },
+    Subscriber {
+        connection_id: u64,
+        connection_name: String,
+        guard: TabGuard,
+        backend_id: u64,
+        state: SubscriberState,
+    },
+    Stream {
+        connection_id: u64,
+        connection_name: String,
+        stream_name: String,
+        guard: TabGuard,
+        state: StreamState,
+    },
+    KvBucket {
+        connection_id: u64,
+        connection_name: String,
+        bucket_name: String,
+        guard: TabGuard,
+        state: KvBucketState,
+    },
+    ObjectStoreBucket {
+        connection_id: u64,
+        connection_name: String,
+        bucket_name: String,
+        guard: TabGuard,
+        state: ObjectStoreBucketState,
+    },
+    ServerInfo {
+        connection_id: u64,
+        connection_name: String,
+        guard: TabGuard,
+        state: ServerInfoState,
+    },
+    Metrics {
+        connection_id: u64,
+        connection_name: String,
+        state: MetricsState,
+    },
+    SearchWorkspace {
+        state: SearchWorkspaceState,
+    },
+    MessageSchemas {
+        state: MessageSchemasState,
+    },
+    Settings,
+    LogViewer,
+}
+
+impl TabKind {
+    pub fn title(&self) -> String {
+        match self {
+            TabKind::Welcome => t("common.tab_welcome").to_string(),
+            TabKind::Publisher {
+                connection_name,
+                guard,
+                ..
+            } => {
+                if let Some(id) = guard.display_id() {
+                    format!(
+                        "{} #{} ({})",
+                        t("common.tab_publisher"),
+                        id,
+                        connection_name
+                    )
+                } else {
+                    format!("{} ({})", t("common.tab_publisher"), connection_name)
+                }
+            }
+            TabKind::Subscriber {
+                connection_name,
+                guard,
+                ..
+            } => {
+                if let Some(id) = guard.display_id() {
+                    format!(
+                        "{} #{} ({})",
+                        t("common.tab_subscriber"),
+                        id,
+                        connection_name
+                    )
+                } else {
+                    format!("{} ({})", t("common.tab_subscriber"), connection_name)
+                }
+            }
+            TabKind::Stream {
+                connection_name,
+                stream_name,
+                ..
+            } => format!("{stream_name} ({connection_name})"),
+            TabKind::KvBucket {
+                connection_name,
+                bucket_name,
+                ..
+            } => format!("{bucket_name} ({connection_name})"),
+            TabKind::ObjectStoreBucket {
+                connection_name,
+                bucket_name,
+                ..
+            } => format!("{bucket_name} ({connection_name})"),
+            TabKind::ServerInfo {
+                connection_name, ..
+            } => format!("{} ({})", t("server_info.title"), connection_name),
+            TabKind::Metrics {
+                connection_name, ..
+            } => format!("{} ({})", t("common.tab_metrics"), connection_name),
+            TabKind::SearchWorkspace { .. } => t("common.tab_search_workspace").to_string(),
+            TabKind::MessageSchemas { .. } => t("common.tab_message_schemas").to_string(),
+            TabKind::Settings => t("settings.title").to_string(),
+            TabKind::LogViewer => t("log_viewer.title").to_string(),
+        }
+    }
+
+    /// Structural identity for use in close actions and deduplication.
+    pub fn tab_id(&self) -> egui::Id {
+        match self {
+            TabKind::Welcome => egui::Id::new("tab:welcome"),
+            TabKind::Publisher {
+                connection_id,
+                backend_id,
+                ..
+            } => egui::Id::new(("tab:publisher", *connection_id, *backend_id)),
+            TabKind::Subscriber {
+                connection_id,
+                backend_id,
+                ..
+            } => egui::Id::new(("tab:subscriber", *connection_id, *backend_id)),
+            TabKind::Stream {
+                connection_id,
+                stream_name,
+                ..
+            } => egui::Id::new(("tab:stream", *connection_id, stream_name.as_str())),
+            TabKind::KvBucket {
+                connection_id,
+                bucket_name,
+                ..
+            } => egui::Id::new(("tab:kv", *connection_id, bucket_name.as_str())),
+            TabKind::ObjectStoreBucket {
+                connection_id,
+                bucket_name,
+                ..
+            } => egui::Id::new(("tab:object-store", *connection_id, bucket_name.as_str())),
+            TabKind::ServerInfo { connection_id, .. } => {
+                egui::Id::new(("tab:server-info", *connection_id))
+            }
+            TabKind::Metrics { connection_id, .. } => {
+                egui::Id::new(("tab:metrics", *connection_id))
+            }
+            TabKind::SearchWorkspace { .. } => egui::Id::new("tab:search-workspace"),
+            TabKind::MessageSchemas { .. } => egui::Id::new("tab:message-schemas"),
+            TabKind::Settings => egui::Id::new("tab:settings"),
+            TabKind::LogViewer => egui::Id::new("tab:log-viewer"),
+        }
+    }
+}
+
+pub struct AppTabViewer<'a> {
+    pub backend: &'a nats_backend::BackendHandle,
+    pub actions: &'a mut Vec<TabAction>,
+    pub search_sources: &'a [SearchSourceSnapshot],
+    pub settings: &'a mut crate::settings::AppSettings,
+    pub theme_id: &'a mut ThemeId,
+    pub log_buffer: &'a crate::log_layer::SharedLogBuffer,
+    pub schema_manager: &'a MessageSchemaManager,
+    pub connections: &'a [(u64, String)],
+}
+
+impl TabViewer for AppTabViewer<'_> {
+    type Tab = TabKind;
+
+    fn title(&mut self, tab: &mut Self::Tab) -> egui::WidgetText {
+        tab.title().into()
+    }
+
+    fn id(&mut self, tab: &mut Self::Tab) -> egui::Id {
+        tab.tab_id()
+    }
+
+    fn ui(&mut self, ui: &mut egui::Ui, tab: &mut Self::Tab) {
+        crate::tabs::viewer::render_tab(self, ui, tab);
+    }
+
+    fn context_menu(&mut self, ui: &mut egui::Ui, tab: &mut Self::Tab, _path: egui_dock::NodePath) {
+        let tab_id = self.id(tab);
+        if ui.button(t("common.close_others")).clicked() {
+            self.actions.push(TabAction::CloseOtherTabs {
+                keep_tab_id: tab_id,
+            });
+            ui.close();
+        }
+        if ui.button(t("common.close_all")).clicked() {
+            self.actions.push(TabAction::CloseAllTabs);
+            ui.close();
+        }
+        if ui.button(t("common.close_to_right")).clicked() {
+            self.actions
+                .push(TabAction::CloseTabsToRight { of_tab_id: tab_id });
+            ui.close();
+        }
+    }
+
+    fn is_closeable(&self, tab: &Self::Tab) -> bool {
+        !matches!(tab, TabKind::Welcome)
+    }
+
+    fn allowed_in_windows(&self, tab: &mut Self::Tab) -> bool {
+        !matches!(tab, TabKind::Welcome)
+    }
+
+    fn on_close(&mut self, tab: &mut Self::Tab) -> OnCloseResponse {
+        // Send explicit Unsubscribe to clean up worker state.
+        // TabGuard Drop handles cancellation + display ID recycling automatically.
+        if let TabKind::Subscriber {
+            connection_id,
+            backend_id,
+            state,
+            ..
+        } = tab
+        {
+            for sub in &state.subscriptions {
+                if sub.active {
+                    self.backend
+                        .send(nats_backend::BackendCommand::Unsubscribe {
+                            connection_id: *connection_id,
+                            backend_id: *backend_id,
+                            subject: sub.subject.clone(),
+                        });
+                }
+            }
+        }
+        OnCloseResponse::Close
+    }
+}

--- a/crates/nats-backend/src/command.rs
+++ b/crates/nats-backend/src/command.rs
@@ -1,5 +1,8 @@
 use crate::cancellation::TaskCancellation;
 use crate::connection::ConnectionConfig;
+use crate::models::{
+    ConsumerConfigInput, KvBucketConfigInput, ObjectStoreBucketConfigInput, StreamConfigInput,
+};
 
 /// Commands sent from the UI thread to the async backend worker.
 #[derive(Debug)]
@@ -43,11 +46,11 @@ pub enum BackendCommand {
     },
     CreateStream {
         connection_id: u64,
-        config: serde_json::Value,
+        config: StreamConfigInput,
     },
     UpdateStream {
         connection_id: u64,
-        config: serde_json::Value,
+        config: StreamConfigInput,
     },
     DeleteStream {
         connection_id: u64,
@@ -78,7 +81,7 @@ pub enum BackendCommand {
     CreateConsumer {
         connection_id: u64,
         stream: String,
-        config: serde_json::Value,
+        config: ConsumerConfigInput,
     },
     DeleteConsumer {
         connection_id: u64,
@@ -88,7 +91,7 @@ pub enum BackendCommand {
     UpdateConsumer {
         connection_id: u64,
         stream: String,
-        config: serde_json::Value,
+        config: ConsumerConfigInput,
     },
     FetchConsumerMessages {
         connection_id: u64,
@@ -102,7 +105,7 @@ pub enum BackendCommand {
     },
     CreateKvBucket {
         connection_id: u64,
-        config: serde_json::Value,
+        config: KvBucketConfigInput,
     },
     DeleteKvBucket {
         connection_id: u64,
@@ -110,7 +113,7 @@ pub enum BackendCommand {
     },
     UpdateKvBucket {
         connection_id: u64,
-        config: serde_json::Value,
+        config: KvBucketConfigInput,
     },
     ListKvKeys {
         connection_id: u64,
@@ -150,7 +153,7 @@ pub enum BackendCommand {
     },
     CreateObjectStoreBucket {
         connection_id: u64,
-        config: serde_json::Value,
+        config: ObjectStoreBucketConfigInput,
     },
     DeleteObjectStoreBucket {
         connection_id: u64,

--- a/crates/nats-backend/src/event.rs
+++ b/crates/nats-backend/src/event.rs
@@ -1,3 +1,8 @@
+use crate::models::{
+    BackendErrorContext, ConsumerInfo, JetStreamAccountInfoSnapshot, KvBucketInfo, KvEntryInfo,
+    KvHistoryItem, KvKeyBatch, ObjectStoreBucketInfo, ObjectStoreDownloadResult,
+    ObjectStoreObjectInfo, ServerInfoSnapshot, StreamInfo, StreamMessageInfo,
+};
 use crate::monitoring::MetricsSnapshot;
 
 #[derive(Debug, Clone)]
@@ -121,11 +126,141 @@ pub enum BackendEvent {
         connection_id: u64,
         snapshot: Box<MetricsSnapshot>,
     },
-    // Operations
-    OperationResult {
+    KvBucketsListed {
+        connection_id: u64,
+        buckets: Vec<KvBucketInfo>,
+    },
+    KvBucketCreated {
+        connection_id: u64,
+        bucket: KvBucketInfo,
+    },
+    KvBucketUpdated {
+        connection_id: u64,
+        bucket: KvBucketInfo,
+    },
+    KvBucketDeleted {
+        connection_id: u64,
+        bucket: String,
+    },
+    KvKeysListed {
+        connection_id: u64,
+        batch: KvKeyBatch,
+    },
+    KvEntryFetched {
+        connection_id: u64,
+        entry: KvEntryInfo,
+    },
+    KvHistoryFetched {
+        connection_id: u64,
+        bucket: String,
+        key: String,
+        history: Vec<KvHistoryItem>,
+    },
+    KvEntryMutated {
         connection_id: u64,
         operation: BackendOperation,
-        data: serde_json::Value,
+        bucket: String,
+        key: String,
+    },
+    ObjectStoreBucketsListed {
+        connection_id: u64,
+        buckets: Vec<ObjectStoreBucketInfo>,
+    },
+    ObjectStoreBucketCreated {
+        connection_id: u64,
+        bucket: ObjectStoreBucketInfo,
+    },
+    ObjectStoreBucketDeleted {
+        connection_id: u64,
+        bucket: String,
+    },
+    ObjectStoreObjectsListed {
+        connection_id: u64,
+        bucket: String,
+        objects: Vec<ObjectStoreObjectInfo>,
+    },
+    ObjectStoreObjectUploaded {
+        connection_id: u64,
+        object: ObjectStoreObjectInfo,
+    },
+    ObjectStoreObjectDownloaded {
+        connection_id: u64,
+        result: ObjectStoreDownloadResult,
+    },
+    ObjectStoreObjectDeleted {
+        connection_id: u64,
+        bucket: String,
+        name: String,
+    },
+    ServerInfoLoaded {
+        connection_id: u64,
+        info: ServerInfoSnapshot,
+    },
+    JetStreamAccountInfoLoaded {
+        connection_id: u64,
+        info: JetStreamAccountInfoSnapshot,
+    },
+    StreamsListed {
+        connection_id: u64,
+        streams: Vec<StreamInfo>,
+    },
+    StreamCreated {
+        connection_id: u64,
+        stream: StreamInfo,
+    },
+    StreamUpdated {
+        connection_id: u64,
+        stream: StreamInfo,
+    },
+    StreamDeleted {
+        connection_id: u64,
+        name: String,
+    },
+    StreamPurged {
+        connection_id: u64,
+        name: String,
+        purged: u64,
+    },
+    StreamMessagesFetched {
+        connection_id: u64,
+        stream: String,
+        messages: Vec<StreamMessageInfo>,
+    },
+    StreamMessageDeleted {
+        connection_id: u64,
+        stream: String,
+        sequence: u64,
+    },
+    ConsumersListed {
+        connection_id: u64,
+        stream: String,
+        consumers: Vec<ConsumerInfo>,
+    },
+    ConsumerCreated {
+        connection_id: u64,
+        stream: String,
+        consumer: ConsumerInfo,
+    },
+    ConsumerUpdated {
+        connection_id: u64,
+        stream: String,
+        consumer: ConsumerInfo,
+    },
+    ConsumerDeleted {
+        connection_id: u64,
+        stream: String,
+        name: String,
+    },
+    ConsumerMessagesFetched {
+        connection_id: u64,
+        stream: String,
+        consumer: String,
+        messages: Vec<StreamMessageInfo>,
+    },
+    // Operations
+    OperationSucceeded {
+        connection_id: u64,
+        operation: BackendOperation,
     },
     // Errors
     Error {
@@ -133,7 +268,7 @@ pub enum BackendEvent {
         backend_id: Option<u64>,
         operation: BackendOperation,
         message: String,
-        data: Option<serde_json::Value>,
+        context: Option<BackendErrorContext>,
     },
 }
 

--- a/crates/nats-backend/src/lib.rs
+++ b/crates/nats-backend/src/lib.rs
@@ -4,6 +4,7 @@ pub mod command;
 pub mod config;
 pub mod connection;
 pub mod event;
+pub mod models;
 pub mod monitoring;
 pub mod paths;
 pub mod worker;
@@ -14,6 +15,16 @@ pub use command::BackendCommand;
 pub use config::AppConfig;
 pub use connection::{AuthMethod, ConnectionConfig, ConnectionStatus, MonitoringConfig};
 pub use event::{BackendEvent, BackendOperation, ConnectionStatusKind, MessageData};
+pub use models::{
+    BackendErrorContext, ConsumerAckPolicyKind, ConsumerConfigInput, ConsumerDeliverPolicyKind,
+    KvBucketConfigInput, KvBucketInfo, KvEntryInfo, KvHistoryItem, KvKeyBatch,
+    ObjectStoreBucketConfigInput, StorageKind, StreamConfigInput, StreamRetentionKind,
+};
+pub use models::{ConsumerInfo, StreamInfo, StreamMessageInfo};
+pub use models::{
+    JetStreamAccountInfoSnapshot, JetStreamAccountLimitsSnapshot, ServerInfoSnapshot,
+};
+pub use models::{ObjectStoreBucketInfo, ObjectStoreDownloadResult, ObjectStoreObjectInfo};
 pub use monitoring::{
     ConnzMetrics, JetStreamMetrics, MetricsHealth, MetricsSection, MetricsSectionError,
     MetricsSnapshot, VarzMetrics,

--- a/crates/nats-backend/src/models.rs
+++ b/crates/nats-backend/src/models.rs
@@ -1,0 +1,697 @@
+use std::time::Duration;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum StorageKind {
+    #[default]
+    File,
+    Memory,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum StreamRetentionKind {
+    #[default]
+    Limits,
+    Interest,
+    WorkQueue,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum ConsumerDeliverPolicyKind {
+    #[default]
+    All,
+    Last,
+    New,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum ConsumerAckPolicyKind {
+    #[default]
+    Explicit,
+    All,
+    None,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StreamConfigInput {
+    pub name: String,
+    pub subjects: Vec<String>,
+    pub storage: StorageKind,
+    pub retention: StreamRetentionKind,
+    pub max_messages: Option<i64>,
+    pub max_bytes: Option<i64>,
+    pub max_age: Option<Duration>,
+    pub num_replicas: Option<usize>,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConsumerConfigInput {
+    pub name: String,
+    pub durable_name: Option<String>,
+    pub filter_subject: Option<String>,
+    pub deliver_policy: ConsumerDeliverPolicyKind,
+    pub ack_policy: ConsumerAckPolicyKind,
+    pub max_deliver: Option<i64>,
+    pub max_ack_pending: Option<i64>,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KvBucketConfigInput {
+    pub bucket: String,
+    pub history: i64,
+    pub storage: StorageKind,
+    pub max_value_size: Option<i32>,
+    pub max_bytes: Option<i64>,
+    pub max_age: Option<Duration>,
+    pub num_replicas: Option<usize>,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectStoreBucketConfigInput {
+    pub bucket: String,
+    pub storage: StorageKind,
+    pub max_bytes: Option<i64>,
+    pub num_replicas: Option<usize>,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KvBucketInfo {
+    pub bucket: String,
+    pub stored_history_values: u64,
+    pub history_depth: i64,
+    pub max_age_secs: u64,
+    pub max_age_nanos: u64,
+    pub description: String,
+    pub storage: String,
+    pub bytes: u64,
+    pub max_bytes: i64,
+    pub max_value_size: i64,
+    pub num_replicas: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KvKeyBatch {
+    pub bucket: String,
+    pub keys: Vec<String>,
+    pub done: bool,
+    pub generation: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KvEntryInfo {
+    pub bucket: String,
+    pub key: String,
+    pub value: Vec<u8>,
+    pub revision: Option<u64>,
+    pub delta: Option<u64>,
+    pub created: Option<String>,
+    pub operation: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KvHistoryItem {
+    pub key: String,
+    pub value: Vec<u8>,
+    pub revision: u64,
+    pub delta: u64,
+    pub created: String,
+    pub operation: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectStoreBucketInfo {
+    pub bucket: String,
+    pub description: String,
+    pub storage: String,
+    pub bytes: u64,
+    pub max_bytes: i64,
+    pub object_count: u64,
+    pub num_replicas: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectStoreObjectInfo {
+    pub bucket: String,
+    pub name: String,
+    pub description: String,
+    pub size: usize,
+    pub chunks: usize,
+    pub modified: Option<String>,
+    pub digest: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectStoreDownloadResult {
+    pub bucket: String,
+    pub name: String,
+    pub file_path: String,
+    pub size: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerInfoSnapshot {
+    pub server_id: String,
+    pub server_name: String,
+    pub version: String,
+    pub host: String,
+    pub port: u16,
+    pub proto: i8,
+    pub go: String,
+    pub max_payload: usize,
+    pub client_id: u64,
+    pub auth_required: bool,
+    pub tls_required: bool,
+    pub connect_urls: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JetStreamAccountLimitsSnapshot {
+    pub max_memory: Option<i64>,
+    pub max_storage: Option<i64>,
+    pub max_streams: Option<i64>,
+    pub max_consumers: Option<i64>,
+    pub max_ack_pending: i64,
+    pub memory_max_stream_bytes: Option<i64>,
+    pub storage_max_stream_bytes: Option<i64>,
+    pub max_bytes_required: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JetStreamAccountInfoSnapshot {
+    pub memory: u64,
+    pub storage: u64,
+    pub streams: usize,
+    pub consumers: usize,
+    pub domain: Option<String>,
+    pub limits: JetStreamAccountLimitsSnapshot,
+    pub api_total: u64,
+    pub api_errors: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StreamInfo {
+    pub name: String,
+    pub subjects: Vec<String>,
+    pub storage: String,
+    pub retention: String,
+    pub messages: u64,
+    pub bytes: u64,
+    pub first_sequence: u64,
+    pub last_sequence: u64,
+    pub consumer_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StreamMessageInfo {
+    pub sequence: u64,
+    pub subject: String,
+    pub payload: Vec<u8>,
+    pub headers: Vec<(String, String)>,
+    pub time: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConsumerInfo {
+    pub name: String,
+    pub stream_name: String,
+    pub durable_name: Option<String>,
+    pub filter_subject: Option<String>,
+    pub deliver_policy: String,
+    pub ack_policy: String,
+    pub max_deliver: i64,
+    pub max_ack_pending: i64,
+    pub description: Option<String>,
+    pub deliver_subject: Option<String>,
+    pub num_pending: u64,
+    pub num_ack_pending: u64,
+    pub num_waiting: u64,
+    pub num_redelivered: u64,
+    pub push_bound: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BackendErrorContext {
+    KvEntry { bucket: String, key: String },
+}
+
+impl StorageKind {
+    pub fn from_display(value: &str) -> Self {
+        if value.eq_ignore_ascii_case("memory") {
+            Self::Memory
+        } else {
+            Self::File
+        }
+    }
+
+    fn into_async_nats(self) -> async_nats::jetstream::stream::StorageType {
+        match self {
+            Self::File => async_nats::jetstream::stream::StorageType::File,
+            Self::Memory => async_nats::jetstream::stream::StorageType::Memory,
+        }
+    }
+}
+
+impl StreamRetentionKind {
+    fn into_async_nats(self) -> async_nats::jetstream::stream::RetentionPolicy {
+        match self {
+            Self::Limits => async_nats::jetstream::stream::RetentionPolicy::Limits,
+            Self::Interest => async_nats::jetstream::stream::RetentionPolicy::Interest,
+            Self::WorkQueue => async_nats::jetstream::stream::RetentionPolicy::WorkQueue,
+        }
+    }
+}
+
+impl ConsumerDeliverPolicyKind {
+    pub fn from_display(value: &str) -> Self {
+        match value.to_ascii_lowercase().as_str() {
+            "last" => Self::Last,
+            "new" => Self::New,
+            _ => Self::All,
+        }
+    }
+
+    fn into_async_nats(self) -> async_nats::jetstream::consumer::DeliverPolicy {
+        match self {
+            Self::All => async_nats::jetstream::consumer::DeliverPolicy::All,
+            Self::Last => async_nats::jetstream::consumer::DeliverPolicy::Last,
+            Self::New => async_nats::jetstream::consumer::DeliverPolicy::New,
+        }
+    }
+}
+
+impl ConsumerAckPolicyKind {
+    pub fn from_display(value: &str) -> Self {
+        match value.to_ascii_lowercase().as_str() {
+            "all" => Self::All,
+            "none" => Self::None,
+            _ => Self::Explicit,
+        }
+    }
+
+    fn into_async_nats(self) -> async_nats::jetstream::consumer::AckPolicy {
+        match self {
+            Self::Explicit => async_nats::jetstream::consumer::AckPolicy::Explicit,
+            Self::All => async_nats::jetstream::consumer::AckPolicy::All,
+            Self::None => async_nats::jetstream::consumer::AckPolicy::None,
+        }
+    }
+}
+
+impl StreamConfigInput {
+    pub fn into_async_nats(self) -> async_nats::jetstream::stream::Config {
+        let mut config = async_nats::jetstream::stream::Config {
+            name: self.name,
+            subjects: self.subjects,
+            storage: self.storage.into_async_nats(),
+            retention: self.retention.into_async_nats(),
+            ..Default::default()
+        };
+        if let Some(max_messages) = self.max_messages {
+            config.max_messages = max_messages;
+        }
+        if let Some(max_bytes) = self.max_bytes {
+            config.max_bytes = max_bytes;
+        }
+        if let Some(max_age) = self.max_age {
+            config.max_age = max_age;
+        }
+        if let Some(num_replicas) = self.num_replicas {
+            config.num_replicas = num_replicas;
+        }
+        config.description = self.description;
+        config
+    }
+}
+
+impl ConsumerConfigInput {
+    pub fn into_async_nats_pull(self) -> async_nats::jetstream::consumer::pull::Config {
+        let mut config = async_nats::jetstream::consumer::pull::Config {
+            name: (!self.name.trim().is_empty()).then_some(self.name),
+            durable_name: self.durable_name,
+            filter_subject: self.filter_subject.unwrap_or_default(),
+            deliver_policy: self.deliver_policy.into_async_nats(),
+            ack_policy: self.ack_policy.into_async_nats(),
+            description: self.description,
+            ..Default::default()
+        };
+        if let Some(max_deliver) = self.max_deliver {
+            config.max_deliver = max_deliver;
+        }
+        if let Some(max_ack_pending) = self.max_ack_pending {
+            config.max_ack_pending = max_ack_pending;
+        }
+        config
+    }
+}
+
+impl KvBucketConfigInput {
+    pub fn into_async_nats(self) -> async_nats::jetstream::kv::Config {
+        let mut config = async_nats::jetstream::kv::Config {
+            bucket: self.bucket,
+            history: self.history,
+            storage: self.storage.into_async_nats(),
+            description: self.description.unwrap_or_default(),
+            ..Default::default()
+        };
+        if let Some(max_value_size) = self.max_value_size {
+            config.max_value_size = max_value_size;
+        }
+        if let Some(max_bytes) = self.max_bytes {
+            config.max_bytes = max_bytes;
+        }
+        if let Some(max_age) = self.max_age {
+            config.max_age = max_age;
+        }
+        if let Some(num_replicas) = self.num_replicas {
+            config.num_replicas = num_replicas;
+        }
+        config
+    }
+}
+
+impl ObjectStoreBucketConfigInput {
+    pub fn into_async_nats(self) -> async_nats::jetstream::object_store::Config {
+        let mut config = async_nats::jetstream::object_store::Config {
+            bucket: self.bucket,
+            storage: self.storage.into_async_nats(),
+            description: self.description,
+            ..Default::default()
+        };
+        if let Some(max_bytes) = self.max_bytes {
+            config.max_bytes = max_bytes;
+        }
+        if let Some(num_replicas) = self.num_replicas {
+            config.num_replicas = num_replicas;
+        }
+        config
+    }
+}
+
+impl KvBucketInfo {
+    pub fn from_status(status: &async_nats::jetstream::kv::bucket::Status) -> Self {
+        Self {
+            bucket: status.bucket().to_string(),
+            stored_history_values: status.values(),
+            history_depth: status.history(),
+            max_age_secs: status.max_age().as_secs(),
+            max_age_nanos: status.max_age().as_nanos() as u64,
+            description: status.info.config.description.clone().unwrap_or_default(),
+            storage: format!("{:?}", status.info.config.storage),
+            bytes: status.info.state.bytes,
+            max_bytes: status.info.config.max_bytes,
+            max_value_size: i64::from(status.info.config.max_message_size),
+            num_replicas: status.info.config.num_replicas,
+        }
+    }
+}
+
+impl KvEntryInfo {
+    pub fn from_entry(entry: &async_nats::jetstream::kv::Entry) -> Self {
+        Self {
+            bucket: entry.bucket.clone(),
+            key: entry.key.clone(),
+            value: entry.value.to_vec(),
+            revision: Some(entry.revision),
+            delta: Some(entry.delta),
+            created: Some(entry.created.to_string()),
+            operation: Some(format!("{:?}", entry.operation)),
+        }
+    }
+
+    pub fn missing(bucket: String, key: String) -> Self {
+        Self {
+            bucket,
+            key,
+            value: Vec::new(),
+            revision: None,
+            delta: None,
+            created: None,
+            operation: None,
+        }
+    }
+}
+
+impl KvHistoryItem {
+    pub fn from_entry(entry: &async_nats::jetstream::kv::Entry) -> Self {
+        Self {
+            key: entry.key.clone(),
+            value: entry.value.to_vec(),
+            revision: entry.revision,
+            delta: entry.delta,
+            created: entry.created.to_string(),
+            operation: format!("{:?}", entry.operation),
+        }
+    }
+}
+
+impl ObjectStoreBucketInfo {
+    pub fn from_stream_info(bucket: String, info: &async_nats::jetstream::stream::Info) -> Self {
+        Self {
+            bucket,
+            description: info.config.description.clone().unwrap_or_default(),
+            storage: format!("{:?}", info.config.storage),
+            bytes: info.state.bytes,
+            max_bytes: info.config.max_bytes,
+            object_count: info.state.messages,
+            num_replicas: info.config.num_replicas,
+        }
+    }
+}
+
+impl ObjectStoreObjectInfo {
+    pub fn from_info(info: &async_nats::jetstream::object_store::ObjectInfo) -> Self {
+        Self {
+            bucket: info.bucket.clone(),
+            name: info.name.clone(),
+            description: info.description.clone().unwrap_or_default(),
+            size: info.size,
+            chunks: info.chunks,
+            modified: info.modified.map(|time| time.to_string()),
+            digest: info.digest.clone(),
+        }
+    }
+}
+
+impl ServerInfoSnapshot {
+    pub fn from_info(info: &async_nats::ServerInfo) -> Self {
+        Self {
+            server_id: info.server_id.clone(),
+            server_name: info.server_name.clone(),
+            version: info.version.clone(),
+            host: info.host.clone(),
+            port: info.port,
+            proto: info.proto,
+            go: info.go.clone(),
+            max_payload: info.max_payload,
+            client_id: info.client_id,
+            auth_required: info.auth_required,
+            tls_required: info.tls_required,
+            connect_urls: info.connect_urls.clone(),
+        }
+    }
+}
+
+impl JetStreamAccountLimitsSnapshot {
+    pub fn from_limits(limits: async_nats::jetstream::account::Limits) -> Self {
+        Self {
+            max_memory: limits.max_memory,
+            max_storage: limits.max_storage,
+            max_streams: limits.max_streams,
+            max_consumers: limits.max_consumers,
+            max_ack_pending: limits.max_ack_pending,
+            memory_max_stream_bytes: limits.memory_max_stream_bytes,
+            storage_max_stream_bytes: limits.storage_max_stream_bytes,
+            max_bytes_required: limits.max_bytes_required,
+        }
+    }
+}
+
+impl JetStreamAccountInfoSnapshot {
+    pub fn from_account(account: async_nats::jetstream::account::Account) -> Self {
+        Self {
+            memory: account.memory,
+            storage: account.storage,
+            streams: account.streams,
+            consumers: account.consumers,
+            domain: account.domain,
+            limits: JetStreamAccountLimitsSnapshot::from_limits(account.limits),
+            api_total: account.requests.total,
+            api_errors: account.requests.errors,
+        }
+    }
+}
+
+impl StreamInfo {
+    pub fn from_info(info: &async_nats::jetstream::stream::Info) -> Self {
+        Self {
+            name: info.config.name.clone(),
+            subjects: info.config.subjects.clone(),
+            storage: format!("{:?}", info.config.storage),
+            retention: format!("{:?}", info.config.retention),
+            messages: info.state.messages,
+            bytes: info.state.bytes,
+            first_sequence: info.state.first_sequence,
+            last_sequence: info.state.last_sequence,
+            consumer_count: info.state.consumer_count,
+        }
+    }
+}
+
+impl StreamMessageInfo {
+    pub fn from_stream_message(msg: &async_nats::jetstream::message::StreamMessage) -> Self {
+        let mut headers = Vec::new();
+        for (name, values) in msg.headers.iter() {
+            for value in values.iter() {
+                headers.push((name.to_string(), value.to_string()));
+            }
+        }
+        Self {
+            sequence: msg.sequence,
+            subject: msg.subject.to_string(),
+            payload: msg.payload.to_vec(),
+            headers,
+            time: msg
+                .time
+                .format(&time::format_description::well_known::Rfc3339)
+                .unwrap_or_default(),
+        }
+    }
+}
+
+impl ConsumerInfo {
+    pub fn from_info(info: &async_nats::jetstream::consumer::Info) -> Self {
+        Self {
+            name: info.name.clone(),
+            stream_name: info.stream_name.clone(),
+            durable_name: info.config.durable_name.clone(),
+            filter_subject: (!info.config.filter_subject.is_empty())
+                .then(|| info.config.filter_subject.clone()),
+            deliver_policy: serde_json::to_value(info.config.deliver_policy)
+                .ok()
+                .and_then(|value| value.as_str().map(str::to_owned))
+                .unwrap_or_else(|| format!("{:?}", info.config.deliver_policy)),
+            ack_policy: serde_json::to_value(info.config.ack_policy)
+                .ok()
+                .and_then(|value| value.as_str().map(str::to_owned))
+                .unwrap_or_else(|| format!("{:?}", info.config.ack_policy)),
+            max_deliver: info.config.max_deliver,
+            max_ack_pending: info.config.max_ack_pending,
+            description: info.config.description.clone(),
+            deliver_subject: info.config.deliver_subject.clone(),
+            num_pending: info.num_pending,
+            num_ack_pending: info.num_ack_pending as u64,
+            num_waiting: info.num_waiting as u64,
+            num_redelivered: info.num_redelivered as u64,
+            push_bound: info.push_bound,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stream_config_input_maps_to_async_nats_config() {
+        let config = StreamConfigInput {
+            name: "orders".to_string(),
+            subjects: vec!["orders.*".to_string()],
+            storage: StorageKind::Memory,
+            retention: StreamRetentionKind::WorkQueue,
+            max_messages: Some(42),
+            max_bytes: Some(1024),
+            max_age: Some(Duration::from_secs(5)),
+            num_replicas: Some(3),
+            description: Some("order events".to_string()),
+        }
+        .into_async_nats();
+
+        assert_eq!(config.name, "orders");
+        assert_eq!(config.subjects, vec!["orders.*"]);
+        assert_eq!(
+            config.storage,
+            async_nats::jetstream::stream::StorageType::Memory
+        );
+        assert_eq!(
+            config.retention,
+            async_nats::jetstream::stream::RetentionPolicy::WorkQueue
+        );
+        assert_eq!(config.max_messages, 42);
+        assert_eq!(config.max_bytes, 1024);
+        assert_eq!(config.max_age, Duration::from_secs(5));
+        assert_eq!(config.num_replicas, 3);
+        assert_eq!(config.description.as_deref(), Some("order events"));
+    }
+
+    #[test]
+    fn consumer_config_input_maps_to_async_nats_pull_config() {
+        let config = ConsumerConfigInput {
+            name: "durable".to_string(),
+            durable_name: Some("durable".to_string()),
+            filter_subject: Some("orders.created".to_string()),
+            deliver_policy: ConsumerDeliverPolicyKind::New,
+            ack_policy: ConsumerAckPolicyKind::All,
+            max_deliver: Some(5),
+            max_ack_pending: Some(128),
+            description: Some("worker".to_string()),
+        }
+        .into_async_nats_pull();
+
+        assert_eq!(config.name.as_deref(), Some("durable"));
+        assert_eq!(config.durable_name.as_deref(), Some("durable"));
+        assert_eq!(config.filter_subject, "orders.created");
+        assert_eq!(
+            config.deliver_policy,
+            async_nats::jetstream::consumer::DeliverPolicy::New
+        );
+        assert_eq!(
+            config.ack_policy,
+            async_nats::jetstream::consumer::AckPolicy::All
+        );
+        assert_eq!(config.max_deliver, 5);
+        assert_eq!(config.max_ack_pending, 128);
+        assert_eq!(config.description.as_deref(), Some("worker"));
+    }
+
+    #[test]
+    fn bucket_config_inputs_map_to_async_nats_configs() {
+        let kv = KvBucketConfigInput {
+            bucket: "settings".to_string(),
+            history: 3,
+            storage: StorageKind::File,
+            max_value_size: Some(2048),
+            max_bytes: Some(4096),
+            max_age: Some(Duration::from_secs(60)),
+            num_replicas: Some(2),
+            description: Some("app settings".to_string()),
+        }
+        .into_async_nats();
+        assert_eq!(kv.bucket, "settings");
+        assert_eq!(kv.history, 3);
+        assert_eq!(kv.max_value_size, 2048);
+        assert_eq!(kv.max_bytes, 4096);
+        assert_eq!(kv.max_age, Duration::from_secs(60));
+        assert_eq!(kv.num_replicas, 2);
+        assert_eq!(kv.description, "app settings");
+
+        let object_store = ObjectStoreBucketConfigInput {
+            bucket: "files".to_string(),
+            storage: StorageKind::Memory,
+            max_bytes: Some(8192),
+            num_replicas: Some(1),
+            description: None,
+        }
+        .into_async_nats();
+        assert_eq!(object_store.bucket, "files");
+        assert_eq!(
+            object_store.storage,
+            async_nats::jetstream::stream::StorageType::Memory
+        );
+        assert_eq!(object_store.max_bytes, 8192);
+        assert_eq!(object_store.num_replicas, 1);
+        assert_eq!(object_store.description, None);
+    }
+}

--- a/crates/nats-backend/src/models.rs
+++ b/crates/nats-backend/src/models.rs
@@ -15,12 +15,19 @@ pub enum StreamRetentionKind {
     WorkQueue,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub enum ConsumerDeliverPolicyKind {
     #[default]
     All,
     Last,
     New,
+    ByStartSequence {
+        start_sequence: u64,
+    },
+    ByStartTime {
+        start_time: String,
+    },
+    LastPerSubject,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -219,7 +226,7 @@ pub struct ConsumerInfo {
     pub stream_name: String,
     pub durable_name: Option<String>,
     pub filter_subject: Option<String>,
-    pub deliver_policy: String,
+    pub deliver_policy: ConsumerDeliverPolicyKind,
     pub ack_policy: String,
     pub max_deliver: i64,
     pub max_ack_pending: i64,
@@ -269,15 +276,61 @@ impl ConsumerDeliverPolicyKind {
         match value.to_ascii_lowercase().as_str() {
             "last" => Self::Last,
             "new" => Self::New,
+            "lastpersubject" | "last_per_subject" | "last per subject" => Self::LastPerSubject,
             _ => Self::All,
         }
     }
 
-    fn into_async_nats(self) -> async_nats::jetstream::consumer::DeliverPolicy {
+    fn from_async_nats(policy: async_nats::jetstream::consumer::DeliverPolicy) -> Self {
+        match policy {
+            async_nats::jetstream::consumer::DeliverPolicy::All => Self::All,
+            async_nats::jetstream::consumer::DeliverPolicy::Last => Self::Last,
+            async_nats::jetstream::consumer::DeliverPolicy::New => Self::New,
+            async_nats::jetstream::consumer::DeliverPolicy::ByStartSequence { start_sequence } => {
+                Self::ByStartSequence { start_sequence }
+            }
+            async_nats::jetstream::consumer::DeliverPolicy::ByStartTime { start_time } => {
+                let start_time = start_time
+                    .format(&time::format_description::well_known::Rfc3339)
+                    .unwrap_or_else(|_| start_time.to_string());
+                Self::ByStartTime { start_time }
+            }
+            async_nats::jetstream::consumer::DeliverPolicy::LastPerSubject => Self::LastPerSubject,
+        }
+    }
+
+    pub fn display(&self) -> String {
         match self {
-            Self::All => async_nats::jetstream::consumer::DeliverPolicy::All,
-            Self::Last => async_nats::jetstream::consumer::DeliverPolicy::Last,
-            Self::New => async_nats::jetstream::consumer::DeliverPolicy::New,
+            Self::All => "All".to_string(),
+            Self::Last => "Last".to_string(),
+            Self::New => "New".to_string(),
+            Self::ByStartSequence { start_sequence } => {
+                format!("By start sequence ({start_sequence})")
+            }
+            Self::ByStartTime { start_time } => format!("By start time ({start_time})"),
+            Self::LastPerSubject => "Last per subject".to_string(),
+        }
+    }
+
+    fn into_async_nats(self) -> Result<async_nats::jetstream::consumer::DeliverPolicy, String> {
+        match self {
+            Self::All => Ok(async_nats::jetstream::consumer::DeliverPolicy::All),
+            Self::Last => Ok(async_nats::jetstream::consumer::DeliverPolicy::Last),
+            Self::New => Ok(async_nats::jetstream::consumer::DeliverPolicy::New),
+            Self::ByStartSequence { start_sequence } => Ok(
+                async_nats::jetstream::consumer::DeliverPolicy::ByStartSequence { start_sequence },
+            ),
+            Self::ByStartTime { start_time } => {
+                let start_time = time::OffsetDateTime::parse(
+                    &start_time,
+                    &time::format_description::well_known::Rfc3339,
+                )
+                .map_err(|e| format!("Invalid deliver policy start time (use RFC3339): {e}"))?;
+                Ok(async_nats::jetstream::consumer::DeliverPolicy::ByStartTime { start_time })
+            }
+            Self::LastPerSubject => {
+                Ok(async_nats::jetstream::consumer::DeliverPolicy::LastPerSubject)
+            }
         }
     }
 }
@@ -327,12 +380,15 @@ impl StreamConfigInput {
 }
 
 impl ConsumerConfigInput {
-    pub fn into_async_nats_pull(self) -> async_nats::jetstream::consumer::pull::Config {
+    pub fn into_async_nats_pull(
+        self,
+    ) -> Result<async_nats::jetstream::consumer::pull::Config, String> {
+        let deliver_policy = self.deliver_policy.into_async_nats()?;
         let mut config = async_nats::jetstream::consumer::pull::Config {
             name: (!self.name.trim().is_empty()).then_some(self.name),
             durable_name: self.durable_name,
             filter_subject: self.filter_subject.unwrap_or_default(),
-            deliver_policy: self.deliver_policy.into_async_nats(),
+            deliver_policy,
             ack_policy: self.ack_policy.into_async_nats(),
             description: self.description,
             ..Default::default()
@@ -343,7 +399,7 @@ impl ConsumerConfigInput {
         if let Some(max_ack_pending) = self.max_ack_pending {
             config.max_ack_pending = max_ack_pending;
         }
-        config
+        Ok(config)
     }
 }
 
@@ -569,10 +625,7 @@ impl ConsumerInfo {
             durable_name: info.config.durable_name.clone(),
             filter_subject: (!info.config.filter_subject.is_empty())
                 .then(|| info.config.filter_subject.clone()),
-            deliver_policy: serde_json::to_value(info.config.deliver_policy)
-                .ok()
-                .and_then(|value| value.as_str().map(str::to_owned))
-                .unwrap_or_else(|| format!("{:?}", info.config.deliver_policy)),
+            deliver_policy: ConsumerDeliverPolicyKind::from_async_nats(info.config.deliver_policy),
             ack_policy: serde_json::to_value(info.config.ack_policy)
                 .ok()
                 .and_then(|value| value.as_str().map(str::to_owned))
@@ -591,107 +644,4 @@ impl ConsumerInfo {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn stream_config_input_maps_to_async_nats_config() {
-        let config = StreamConfigInput {
-            name: "orders".to_string(),
-            subjects: vec!["orders.*".to_string()],
-            storage: StorageKind::Memory,
-            retention: StreamRetentionKind::WorkQueue,
-            max_messages: Some(42),
-            max_bytes: Some(1024),
-            max_age: Some(Duration::from_secs(5)),
-            num_replicas: Some(3),
-            description: Some("order events".to_string()),
-        }
-        .into_async_nats();
-
-        assert_eq!(config.name, "orders");
-        assert_eq!(config.subjects, vec!["orders.*"]);
-        assert_eq!(
-            config.storage,
-            async_nats::jetstream::stream::StorageType::Memory
-        );
-        assert_eq!(
-            config.retention,
-            async_nats::jetstream::stream::RetentionPolicy::WorkQueue
-        );
-        assert_eq!(config.max_messages, 42);
-        assert_eq!(config.max_bytes, 1024);
-        assert_eq!(config.max_age, Duration::from_secs(5));
-        assert_eq!(config.num_replicas, 3);
-        assert_eq!(config.description.as_deref(), Some("order events"));
-    }
-
-    #[test]
-    fn consumer_config_input_maps_to_async_nats_pull_config() {
-        let config = ConsumerConfigInput {
-            name: "durable".to_string(),
-            durable_name: Some("durable".to_string()),
-            filter_subject: Some("orders.created".to_string()),
-            deliver_policy: ConsumerDeliverPolicyKind::New,
-            ack_policy: ConsumerAckPolicyKind::All,
-            max_deliver: Some(5),
-            max_ack_pending: Some(128),
-            description: Some("worker".to_string()),
-        }
-        .into_async_nats_pull();
-
-        assert_eq!(config.name.as_deref(), Some("durable"));
-        assert_eq!(config.durable_name.as_deref(), Some("durable"));
-        assert_eq!(config.filter_subject, "orders.created");
-        assert_eq!(
-            config.deliver_policy,
-            async_nats::jetstream::consumer::DeliverPolicy::New
-        );
-        assert_eq!(
-            config.ack_policy,
-            async_nats::jetstream::consumer::AckPolicy::All
-        );
-        assert_eq!(config.max_deliver, 5);
-        assert_eq!(config.max_ack_pending, 128);
-        assert_eq!(config.description.as_deref(), Some("worker"));
-    }
-
-    #[test]
-    fn bucket_config_inputs_map_to_async_nats_configs() {
-        let kv = KvBucketConfigInput {
-            bucket: "settings".to_string(),
-            history: 3,
-            storage: StorageKind::File,
-            max_value_size: Some(2048),
-            max_bytes: Some(4096),
-            max_age: Some(Duration::from_secs(60)),
-            num_replicas: Some(2),
-            description: Some("app settings".to_string()),
-        }
-        .into_async_nats();
-        assert_eq!(kv.bucket, "settings");
-        assert_eq!(kv.history, 3);
-        assert_eq!(kv.max_value_size, 2048);
-        assert_eq!(kv.max_bytes, 4096);
-        assert_eq!(kv.max_age, Duration::from_secs(60));
-        assert_eq!(kv.num_replicas, 2);
-        assert_eq!(kv.description, "app settings");
-
-        let object_store = ObjectStoreBucketConfigInput {
-            bucket: "files".to_string(),
-            storage: StorageKind::Memory,
-            max_bytes: Some(8192),
-            num_replicas: Some(1),
-            description: None,
-        }
-        .into_async_nats();
-        assert_eq!(object_store.bucket, "files");
-        assert_eq!(
-            object_store.storage,
-            async_nats::jetstream::stream::StorageType::Memory
-        );
-        assert_eq!(object_store.max_bytes, 8192);
-        assert_eq!(object_store.num_replicas, 1);
-        assert_eq!(object_store.description, None);
-    }
-}
+mod tests;

--- a/crates/nats-backend/src/models/tests.rs
+++ b/crates/nats-backend/src/models/tests.rs
@@ -1,0 +1,178 @@
+use super::*;
+
+#[test]
+fn stream_config_input_maps_to_async_nats_config() {
+    let config = StreamConfigInput {
+        name: "orders".to_string(),
+        subjects: vec!["orders.*".to_string()],
+        storage: StorageKind::Memory,
+        retention: StreamRetentionKind::WorkQueue,
+        max_messages: Some(42),
+        max_bytes: Some(1024),
+        max_age: Some(Duration::from_secs(5)),
+        num_replicas: Some(3),
+        description: Some("order events".to_string()),
+    }
+    .into_async_nats();
+
+    assert_eq!(config.name, "orders");
+    assert_eq!(config.subjects, vec!["orders.*"]);
+    assert_eq!(
+        config.storage,
+        async_nats::jetstream::stream::StorageType::Memory
+    );
+    assert_eq!(
+        config.retention,
+        async_nats::jetstream::stream::RetentionPolicy::WorkQueue
+    );
+    assert_eq!(config.max_messages, 42);
+    assert_eq!(config.max_bytes, 1024);
+    assert_eq!(config.max_age, Duration::from_secs(5));
+    assert_eq!(config.num_replicas, 3);
+    assert_eq!(config.description.as_deref(), Some("order events"));
+}
+
+#[test]
+fn consumer_config_input_maps_to_async_nats_pull_config() {
+    let config = ConsumerConfigInput {
+        name: "durable".to_string(),
+        durable_name: Some("durable".to_string()),
+        filter_subject: Some("orders.created".to_string()),
+        deliver_policy: ConsumerDeliverPolicyKind::New,
+        ack_policy: ConsumerAckPolicyKind::All,
+        max_deliver: Some(5),
+        max_ack_pending: Some(128),
+        description: Some("worker".to_string()),
+    }
+    .into_async_nats_pull()
+    .expect("valid consumer config");
+
+    assert_eq!(config.name.as_deref(), Some("durable"));
+    assert_eq!(config.durable_name.as_deref(), Some("durable"));
+    assert_eq!(config.filter_subject, "orders.created");
+    assert_eq!(
+        config.deliver_policy,
+        async_nats::jetstream::consumer::DeliverPolicy::New
+    );
+    assert_eq!(
+        config.ack_policy,
+        async_nats::jetstream::consumer::AckPolicy::All
+    );
+    assert_eq!(config.max_deliver, 5);
+    assert_eq!(config.max_ack_pending, 128);
+    assert_eq!(config.description.as_deref(), Some("worker"));
+}
+
+#[test]
+fn consumer_deliver_policy_supports_all_pull_variants() {
+    let by_sequence = ConsumerConfigInput {
+        name: "sequence".to_string(),
+        durable_name: Some("sequence".to_string()),
+        filter_subject: None,
+        deliver_policy: ConsumerDeliverPolicyKind::ByStartSequence { start_sequence: 42 },
+        ack_policy: ConsumerAckPolicyKind::Explicit,
+        max_deliver: None,
+        max_ack_pending: None,
+        description: None,
+    }
+    .into_async_nats_pull()
+    .expect("valid sequence policy");
+    assert_eq!(
+        by_sequence.deliver_policy,
+        async_nats::jetstream::consumer::DeliverPolicy::ByStartSequence { start_sequence: 42 }
+    );
+
+    let by_time = ConsumerConfigInput {
+        name: "time".to_string(),
+        durable_name: Some("time".to_string()),
+        filter_subject: None,
+        deliver_policy: ConsumerDeliverPolicyKind::ByStartTime {
+            start_time: "1970-01-01T00:00:00Z".to_string(),
+        },
+        ack_policy: ConsumerAckPolicyKind::Explicit,
+        max_deliver: None,
+        max_ack_pending: None,
+        description: None,
+    }
+    .into_async_nats_pull()
+    .expect("valid start time policy");
+    assert!(matches!(
+        by_time.deliver_policy,
+        async_nats::jetstream::consumer::DeliverPolicy::ByStartTime { .. }
+    ));
+
+    let last_per_subject = ConsumerConfigInput {
+        name: "last-per-subject".to_string(),
+        durable_name: Some("last-per-subject".to_string()),
+        filter_subject: None,
+        deliver_policy: ConsumerDeliverPolicyKind::LastPerSubject,
+        ack_policy: ConsumerAckPolicyKind::Explicit,
+        max_deliver: None,
+        max_ack_pending: None,
+        description: None,
+    }
+    .into_async_nats_pull()
+    .expect("valid last-per-subject policy");
+    assert_eq!(
+        last_per_subject.deliver_policy,
+        async_nats::jetstream::consumer::DeliverPolicy::LastPerSubject
+    );
+}
+
+#[test]
+fn consumer_deliver_policy_rejects_invalid_start_time() {
+    let result = ConsumerConfigInput {
+        name: "time".to_string(),
+        durable_name: Some("time".to_string()),
+        filter_subject: None,
+        deliver_policy: ConsumerDeliverPolicyKind::ByStartTime {
+            start_time: "not-a-time".to_string(),
+        },
+        ack_policy: ConsumerAckPolicyKind::Explicit,
+        max_deliver: None,
+        max_ack_pending: None,
+        description: None,
+    }
+    .into_async_nats_pull();
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn bucket_config_inputs_map_to_async_nats_configs() {
+    let kv = KvBucketConfigInput {
+        bucket: "settings".to_string(),
+        history: 3,
+        storage: StorageKind::File,
+        max_value_size: Some(2048),
+        max_bytes: Some(4096),
+        max_age: Some(Duration::from_secs(60)),
+        num_replicas: Some(2),
+        description: Some("app settings".to_string()),
+    }
+    .into_async_nats();
+    assert_eq!(kv.bucket, "settings");
+    assert_eq!(kv.history, 3);
+    assert_eq!(kv.max_value_size, 2048);
+    assert_eq!(kv.max_bytes, 4096);
+    assert_eq!(kv.max_age, Duration::from_secs(60));
+    assert_eq!(kv.num_replicas, 2);
+    assert_eq!(kv.description, "app settings");
+
+    let object_store = ObjectStoreBucketConfigInput {
+        bucket: "files".to_string(),
+        storage: StorageKind::Memory,
+        max_bytes: Some(8192),
+        num_replicas: Some(1),
+        description: None,
+    }
+    .into_async_nats();
+    assert_eq!(object_store.bucket, "files");
+    assert_eq!(
+        object_store.storage,
+        async_nats::jetstream::stream::StorageType::Memory
+    );
+    assert_eq!(object_store.max_bytes, 8192);
+    assert_eq!(object_store.num_replicas, 1);
+    assert_eq!(object_store.description, None);
+}

--- a/crates/nats-backend/src/worker/consumers.rs
+++ b/crates/nats-backend/src/worker/consumers.rs
@@ -62,7 +62,14 @@ pub(crate) async fn handle_create_consumer(
         evt_tx,
         BackendOperation::CreateConsumer,
         |stream| async move {
-            match stream.create_consumer(config.into_async_nats_pull()).await {
+            let consumer_config = match config.into_async_nats_pull() {
+                Ok(config) => config,
+                Err(e) => {
+                    send_err(evt_tx, connection_id, BackendOperation::CreateConsumer, e).await;
+                    return;
+                }
+            };
+            match stream.create_consumer(consumer_config).await {
                 Ok(consumer) => {
                     let _ = evt_tx
                         .send(BackendEvent::ConsumerCreated {
@@ -142,7 +149,14 @@ pub(crate) async fn handle_update_consumer(
         evt_tx,
         BackendOperation::UpdateConsumer,
         |stream| async move {
-            match stream.update_consumer(config.into_async_nats_pull()).await {
+            let consumer_config = match config.into_async_nats_pull() {
+                Ok(config) => config,
+                Err(e) => {
+                    send_err(evt_tx, connection_id, BackendOperation::UpdateConsumer, e).await;
+                    return;
+                }
+            };
+            match stream.update_consumer(consumer_config).await {
                 Ok(consumer) => {
                     let _ = evt_tx
                         .send(BackendEvent::ConsumerUpdated {

--- a/crates/nats-backend/src/worker/consumers.rs
+++ b/crates/nats-backend/src/worker/consumers.rs
@@ -4,8 +4,8 @@ use futures_util::StreamExt;
 use tokio::sync::mpsc;
 
 use crate::event::{BackendEvent, BackendOperation};
+use crate::models::{ConsumerConfigInput, ConsumerInfo, StreamMessageInfo};
 
-use super::helpers::{consumer_info_to_json, raw_message_to_json};
 use super::state::WorkerState;
 
 static INSPECTOR_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -28,23 +28,20 @@ pub(crate) async fn handle_list_consumers(
             let mut list = Vec::new();
             while let Some(result) = consumers_iter.next().await {
                 match result {
-                    Ok(info) => list.push(consumer_info_to_json(&info)),
+                    Ok(info) => list.push(ConsumerInfo::from_info(&info)),
                     Err(e) => {
                         tracing::warn!(%e, "Error iterating consumers");
                         break;
                     }
                 }
             }
-            send_ok(
-                evt_tx,
-                connection_id,
-                BackendOperation::ListConsumers,
-                serde_json::json!({
-                    "stream": stream_name,
-                    "consumers": list,
-                }),
-            )
-            .await;
+            let _ = evt_tx
+                .send(BackendEvent::ConsumersListed {
+                    connection_id,
+                    stream: stream_name,
+                    consumers: list,
+                })
+                .await;
         },
     )
     .await;
@@ -54,9 +51,10 @@ pub(crate) async fn handle_create_consumer(
     state: &WorkerState,
     connection_id: u64,
     stream_name: String,
-    config: serde_json::Value,
+    config: ConsumerConfigInput,
     evt_tx: &mpsc::Sender<BackendEvent>,
 ) {
+    let event_stream_name = stream_name.clone();
     with_stream(
         state,
         connection_id,
@@ -64,33 +62,22 @@ pub(crate) async fn handle_create_consumer(
         evt_tx,
         BackendOperation::CreateConsumer,
         |stream| async move {
-            match serde_json::from_value::<async_nats::jetstream::consumer::pull::Config>(config) {
-                Ok(consumer_config) => match stream.create_consumer(consumer_config).await {
-                    Ok(consumer) => {
-                        send_ok(
-                            evt_tx,
+            match stream.create_consumer(config.into_async_nats_pull()).await {
+                Ok(consumer) => {
+                    let _ = evt_tx
+                        .send(BackendEvent::ConsumerCreated {
                             connection_id,
-                            BackendOperation::CreateConsumer,
-                            consumer_info_to_json(consumer.cached_info()),
-                        )
-                        .await
-                    }
-                    Err(e) => {
-                        send_err(
-                            evt_tx,
-                            connection_id,
-                            BackendOperation::CreateConsumer,
-                            e.to_string(),
-                        )
-                        .await
-                    }
-                },
+                            stream: event_stream_name,
+                            consumer: ConsumerInfo::from_info(consumer.cached_info()),
+                        })
+                        .await;
+                }
                 Err(e) => {
                     send_err(
                         evt_tx,
                         connection_id,
                         BackendOperation::CreateConsumer,
-                        format!("Invalid consumer config: {e}"),
+                        e.to_string(),
                     )
                     .await
                 }
@@ -117,16 +104,13 @@ pub(crate) async fn handle_delete_consumer(
         |stream| async move {
             match stream.delete_consumer(&name).await {
                 Ok(_) => {
-                    send_ok(
-                        evt_tx,
-                        connection_id,
-                        BackendOperation::DeleteConsumer,
-                        serde_json::json!({
-                            "stream": stream_name,
-                            "name": name,
-                        }),
-                    )
-                    .await
+                    let _ = evt_tx
+                        .send(BackendEvent::ConsumerDeleted {
+                            connection_id,
+                            stream: stream_name,
+                            name,
+                        })
+                        .await;
                 }
                 Err(e) => {
                     send_err(
@@ -147,9 +131,10 @@ pub(crate) async fn handle_update_consumer(
     state: &WorkerState,
     connection_id: u64,
     stream_name: String,
-    config: serde_json::Value,
+    config: ConsumerConfigInput,
     evt_tx: &mpsc::Sender<BackendEvent>,
 ) {
+    let event_stream_name = stream_name.clone();
     with_stream(
         state,
         connection_id,
@@ -157,33 +142,22 @@ pub(crate) async fn handle_update_consumer(
         evt_tx,
         BackendOperation::UpdateConsumer,
         |stream| async move {
-            match serde_json::from_value::<async_nats::jetstream::consumer::pull::Config>(config) {
-                Ok(consumer_config) => match stream.update_consumer(consumer_config).await {
-                    Ok(consumer) => {
-                        send_ok(
-                            evt_tx,
+            match stream.update_consumer(config.into_async_nats_pull()).await {
+                Ok(consumer) => {
+                    let _ = evt_tx
+                        .send(BackendEvent::ConsumerUpdated {
                             connection_id,
-                            BackendOperation::UpdateConsumer,
-                            consumer_info_to_json(consumer.cached_info()),
-                        )
-                        .await
-                    }
-                    Err(e) => {
-                        send_err(
-                            evt_tx,
-                            connection_id,
-                            BackendOperation::UpdateConsumer,
-                            e.to_string(),
-                        )
-                        .await
-                    }
-                },
+                            stream: event_stream_name,
+                            consumer: ConsumerInfo::from_info(consumer.cached_info()),
+                        })
+                        .await;
+                }
                 Err(e) => {
                     send_err(
                         evt_tx,
                         connection_id,
                         BackendOperation::UpdateConsumer,
-                        format!("Invalid consumer config: {e}"),
+                        e.to_string(),
                     )
                     .await
                 }
@@ -275,7 +249,9 @@ pub(crate) async fn handle_fetch_consumer_messages(
                     }
                 };
                 match async_nats::jetstream::message::StreamMessage::try_from(msg.message.clone()) {
-                    Ok(stream_msg) => messages.push(raw_message_to_json(&stream_msg)),
+                    Ok(stream_msg) => {
+                        messages.push(StreamMessageInfo::from_stream_message(&stream_msg))
+                    }
                     Err(e) => tracing::debug!(%e, "Failed to convert inspector message"),
                 }
                 if messages.len() >= batch {
@@ -285,17 +261,14 @@ pub(crate) async fn handle_fetch_consumer_messages(
             drop(fetch_stream);
             cleanup_inspector_consumer(&stream, &inspector_name).await;
 
-            send_ok(
-                evt_tx,
-                connection_id,
-                operation,
-                serde_json::json!({
-                    "stream": stream_name,
-                    "consumer": consumer_name,
-                    "messages": messages,
-                }),
-            )
-            .await;
+            let _ = evt_tx
+                .send(BackendEvent::ConsumerMessagesFetched {
+                    connection_id,
+                    stream: stream_name,
+                    consumer: consumer_name,
+                    messages,
+                })
+                .await;
         },
     )
     .await;
@@ -342,21 +315,6 @@ async fn with_stream<F, Fut>(
     }
 }
 
-async fn send_ok(
-    evt_tx: &mpsc::Sender<BackendEvent>,
-    connection_id: u64,
-    operation: BackendOperation,
-    data: serde_json::Value,
-) {
-    let _ = evt_tx
-        .send(BackendEvent::OperationResult {
-            connection_id,
-            operation,
-            data,
-        })
-        .await;
-}
-
 async fn send_err(
     evt_tx: &mpsc::Sender<BackendEvent>,
     connection_id: u64,
@@ -369,7 +327,7 @@ async fn send_err(
             backend_id: None,
             operation,
             message,
-            data: None,
+            context: None,
         })
         .await;
 }

--- a/crates/nats-backend/src/worker/helpers.rs
+++ b/crates/nats-backend/src/worker/helpers.rs
@@ -1,5 +1,3 @@
-use base64::Engine;
-
 pub fn build_header_map(headers: &[(String, String)]) -> async_nats::HeaderMap {
     let mut map = async_nats::HeaderMap::new();
     for (k, v) in headers {
@@ -19,85 +17,6 @@ pub fn extract_headers(headers: &Option<async_nats::HeaderMap>) -> Vec<(String, 
         }
     }
     result
-}
-
-pub(crate) fn raw_message_to_json(
-    msg: &async_nats::jetstream::message::StreamMessage,
-) -> serde_json::Value {
-    let payload_b64 = base64::engine::general_purpose::STANDARD.encode(&msg.payload);
-    let mut headers = Vec::new();
-    for (name, values) in msg.headers.iter() {
-        for value in values.iter() {
-            headers.push(serde_json::json!([name.to_string(), value.to_string()]));
-        }
-    }
-    serde_json::json!({
-        "sequence": msg.sequence,
-        "subject": msg.subject.to_string(),
-        "payload_base64": payload_b64,
-        "headers": headers,
-        "time": msg.time.format(&time::format_description::well_known::Rfc3339).unwrap_or_default(),
-    })
-}
-
-pub(crate) fn stream_info_to_json(info: &async_nats::jetstream::stream::Info) -> serde_json::Value {
-    let config_json = serde_json::to_value(&info.config).unwrap_or_default();
-    serde_json::json!({
-        "config": config_json,
-        "state": {
-            "messages": info.state.messages,
-            "bytes": info.state.bytes,
-            "first_sequence": info.state.first_sequence,
-            "last_sequence": info.state.last_sequence,
-            "consumer_count": info.state.consumer_count,
-        },
-    })
-}
-
-pub(crate) fn consumer_info_to_json(
-    info: &async_nats::jetstream::consumer::Info,
-) -> serde_json::Value {
-    let config_json = serde_json::to_value(&info.config).unwrap_or_default();
-    serde_json::json!({
-        "name": info.name,
-        "stream_name": info.stream_name,
-        "config": config_json,
-        "num_pending": info.num_pending,
-        "num_ack_pending": info.num_ack_pending,
-        "num_waiting": info.num_waiting,
-        "num_redelivered": info.num_redelivered,
-        "push_bound": info.push_bound,
-    })
-}
-
-pub(crate) fn kv_status_to_json(
-    status: &async_nats::jetstream::kv::bucket::Status,
-) -> serde_json::Value {
-    serde_json::json!({
-        "bucket": status.bucket(),
-        "values": status.values(),
-        "history": status.history(),
-        "max_age_secs": status.max_age().as_secs(),
-        "max_age_nanos": status.max_age().as_nanos() as u64,
-        "description": status.info.config.description,
-        "storage": format!("{:?}", status.info.config.storage),
-        "bytes": status.info.state.bytes,
-        "max_bytes": status.info.config.max_bytes,
-        "max_value_size": status.info.config.max_message_size,
-        "num_replicas": status.info.config.num_replicas,
-    })
-}
-
-pub(crate) fn kv_entry_to_json(entry: &async_nats::jetstream::kv::Entry) -> serde_json::Value {
-    serde_json::json!({
-        "bucket": entry.bucket,
-        "key": entry.key,
-        "value_base64": base64::engine::general_purpose::STANDARD.encode(&entry.value),
-        "revision": entry.revision,
-        "delta": entry.delta,
-        "created": entry.created.to_string(),
-        "operation": format!("{:?}", entry.operation),
-    })
 }
 
 #[cfg(test)]

--- a/crates/nats-backend/src/worker/kv.rs
+++ b/crates/nats-backend/src/worker/kv.rs
@@ -4,6 +4,7 @@ mod entries;
 use tokio::sync::mpsc;
 
 use crate::event::{BackendEvent, BackendOperation};
+use crate::models::BackendErrorContext;
 
 use super::state::WorkerState;
 
@@ -37,41 +38,25 @@ async fn open_store(
     evt_tx: &mpsc::Sender<BackendEvent>,
     operation: BackendOperation,
 ) -> Option<async_nats::jetstream::kv::Store> {
-    open_store_with_error_data(state, connection_id, bucket, evt_tx, operation, None).await
+    open_store_with_context(state, connection_id, bucket, evt_tx, operation, None).await
 }
 
-async fn open_store_with_error_data(
+async fn open_store_with_context(
     state: &WorkerState,
     connection_id: u64,
     bucket: &str,
     evt_tx: &mpsc::Sender<BackendEvent>,
     operation: BackendOperation,
-    error_data: Option<serde_json::Value>,
+    context: Option<BackendErrorContext>,
 ) -> Option<async_nats::jetstream::kv::Store> {
     let js = jetstream(state, connection_id, evt_tx, operation).await?;
     match js.get_key_value(bucket).await {
         Ok(store) => Some(store),
         Err(e) => {
-            send_err_with_data(evt_tx, connection_id, operation, e.to_string(), error_data).await;
+            send_err_with_context(evt_tx, connection_id, operation, e.to_string(), context).await;
             None
         }
     }
-}
-
-async fn send_ok(
-    evt_tx: &mpsc::Sender<BackendEvent>,
-    connection_id: u64,
-    operation: BackendOperation,
-    data: serde_json::Value,
-) {
-    tracing::debug!(connection_id, ?operation, "KV operation succeeded");
-    let _ = evt_tx
-        .send(BackendEvent::OperationResult {
-            connection_id,
-            operation,
-            data,
-        })
-        .await;
 }
 
 async fn send_err(
@@ -80,15 +65,15 @@ async fn send_err(
     operation: BackendOperation,
     message: String,
 ) {
-    send_err_with_data(evt_tx, connection_id, operation, message, None).await;
+    send_err_with_context(evt_tx, connection_id, operation, message, None).await;
 }
 
-async fn send_err_with_data(
+async fn send_err_with_context(
     evt_tx: &mpsc::Sender<BackendEvent>,
     connection_id: u64,
     operation: BackendOperation,
     message: String,
-    data: Option<serde_json::Value>,
+    context: Option<BackendErrorContext>,
 ) {
     tracing::warn!(connection_id, ?operation, %message, "KV operation failed");
     let _ = evt_tx
@@ -97,7 +82,7 @@ async fn send_err_with_data(
             backend_id: None,
             operation,
             message,
-            data,
+            context,
         })
         .await;
 }

--- a/crates/nats-backend/src/worker/kv/buckets.rs
+++ b/crates/nats-backend/src/worker/kv/buckets.rs
@@ -2,8 +2,8 @@ use futures_util::TryStreamExt;
 use tokio::sync::mpsc;
 
 use crate::event::{BackendEvent, BackendOperation};
+use crate::models::{KvBucketConfigInput, KvBucketInfo};
 
-use super::super::helpers::kv_status_to_json;
 use super::super::state::WorkerState;
 
 pub(crate) async fn handle_list_buckets(
@@ -32,7 +32,7 @@ pub(crate) async fn handle_list_buckets(
                 };
                 match js.get_key_value(bucket_name).await {
                     Ok(store) => match store.status().await {
-                        Ok(status) => buckets.push(kv_status_to_json(&status)),
+                        Ok(status) => buckets.push(KvBucketInfo::from_status(&status)),
                         Err(e) => {
                             tracing::warn!(bucket = bucket_name, %e, "Error loading KV status")
                         }
@@ -53,20 +53,19 @@ pub(crate) async fn handle_list_buckets(
             }
         }
     }
-    buckets.sort_by(|a, b| a["bucket"].as_str().cmp(&b["bucket"].as_str()));
-    super::send_ok(
-        evt_tx,
-        connection_id,
-        BackendOperation::ListKvBuckets,
-        serde_json::Value::Array(buckets),
-    )
-    .await;
+    buckets.sort_by(|a, b| a.bucket.cmp(&b.bucket));
+    let _ = evt_tx
+        .send(BackendEvent::KvBucketsListed {
+            connection_id,
+            buckets,
+        })
+        .await;
 }
 
 pub(crate) async fn handle_create_bucket(
     state: &WorkerState,
     connection_id: u64,
-    config: serde_json::Value,
+    config: KvBucketConfigInput,
     evt_tx: &mpsc::Sender<BackendEvent>,
 ) {
     let Some(js) = super::jetstream(
@@ -80,8 +79,7 @@ pub(crate) async fn handle_create_bucket(
         return;
     };
 
-    let bucket = config["bucket"].as_str().unwrap_or("").trim().to_string();
-    if bucket.is_empty() {
+    if config.bucket.trim().is_empty() {
         super::send_err(
             evt_tx,
             connection_id,
@@ -92,38 +90,15 @@ pub(crate) async fn handle_create_bucket(
         return;
     }
 
-    let storage = match config["storage"].as_str() {
-        Some("memory") | Some("Memory") => async_nats::jetstream::stream::StorageType::Memory,
-        _ => async_nats::jetstream::stream::StorageType::File,
-    };
-
-    let mut bucket_config = async_nats::jetstream::kv::Config {
-        bucket,
-        history: config["history"].as_i64().unwrap_or(1),
-        storage,
-        description: config["description"]
-            .as_str()
-            .unwrap_or_default()
-            .to_string(),
-        max_value_size: config["max_value_size"].as_i64().unwrap_or_default() as i32,
-        max_bytes: config["max_bytes"].as_i64().unwrap_or_default(),
-        num_replicas: config["num_replicas"].as_u64().unwrap_or(1) as usize,
-        ..Default::default()
-    };
-    if let Some(max_age) = config["max_age"].as_u64() {
-        bucket_config.max_age = std::time::Duration::from_nanos(max_age);
-    }
-
-    match js.create_key_value(bucket_config).await {
+    match js.create_key_value(config.into_async_nats()).await {
         Ok(store) => match store.status().await {
             Ok(status) => {
-                super::send_ok(
-                    evt_tx,
-                    connection_id,
-                    BackendOperation::CreateKvBucket,
-                    kv_status_to_json(&status),
-                )
-                .await
+                let _ = evt_tx
+                    .send(BackendEvent::KvBucketCreated {
+                        connection_id,
+                        bucket: KvBucketInfo::from_status(&status),
+                    })
+                    .await;
             }
             Err(e) => {
                 super::send_err(
@@ -166,13 +141,12 @@ pub(crate) async fn handle_delete_bucket(
 
     match js.delete_key_value(&bucket).await {
         Ok(_) => {
-            super::send_ok(
-                evt_tx,
-                connection_id,
-                BackendOperation::DeleteKvBucket,
-                serde_json::json!({ "bucket": bucket }),
-            )
-            .await
+            let _ = evt_tx
+                .send(BackendEvent::KvBucketDeleted {
+                    connection_id,
+                    bucket,
+                })
+                .await;
         }
         Err(e) => {
             super::send_err(
@@ -189,7 +163,7 @@ pub(crate) async fn handle_delete_bucket(
 pub(crate) async fn handle_update_bucket(
     state: &WorkerState,
     connection_id: u64,
-    config: serde_json::Value,
+    config: KvBucketConfigInput,
     evt_tx: &mpsc::Sender<BackendEvent>,
 ) {
     let Some(js) = super::jetstream(
@@ -203,8 +177,7 @@ pub(crate) async fn handle_update_bucket(
         return;
     };
 
-    let bucket = config["bucket"].as_str().unwrap_or("").trim().to_string();
-    if bucket.is_empty() {
+    if config.bucket.trim().is_empty() {
         super::send_err(
             evt_tx,
             connection_id,
@@ -215,38 +188,15 @@ pub(crate) async fn handle_update_bucket(
         return;
     }
 
-    let storage = match config["storage"].as_str() {
-        Some("memory") | Some("Memory") => async_nats::jetstream::stream::StorageType::Memory,
-        _ => async_nats::jetstream::stream::StorageType::File,
-    };
-
-    let mut bucket_config = async_nats::jetstream::kv::Config {
-        bucket,
-        history: config["history"].as_i64().unwrap_or(1),
-        storage,
-        description: config["description"]
-            .as_str()
-            .unwrap_or_default()
-            .to_string(),
-        max_value_size: config["max_value_size"].as_i64().unwrap_or_default() as i32,
-        max_bytes: config["max_bytes"].as_i64().unwrap_or_default(),
-        num_replicas: config["num_replicas"].as_u64().unwrap_or(1) as usize,
-        ..Default::default()
-    };
-    if let Some(max_age) = config["max_age"].as_u64() {
-        bucket_config.max_age = std::time::Duration::from_nanos(max_age);
-    }
-
-    match js.update_key_value(bucket_config).await {
+    match js.update_key_value(config.into_async_nats()).await {
         Ok(store) => match store.status().await {
             Ok(status) => {
-                super::send_ok(
-                    evt_tx,
-                    connection_id,
-                    BackendOperation::UpdateKvBucket,
-                    kv_status_to_json(&status),
-                )
-                .await
+                let _ = evt_tx
+                    .send(BackendEvent::KvBucketUpdated {
+                        connection_id,
+                        bucket: KvBucketInfo::from_status(&status),
+                    })
+                    .await;
             }
             Err(e) => {
                 super::send_err(

--- a/crates/nats-backend/src/worker/kv/entries.rs
+++ b/crates/nats-backend/src/worker/kv/entries.rs
@@ -3,11 +3,10 @@ use futures_util::TryStreamExt;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
+use super::super::state::WorkerState;
 use crate::cancellation::TaskCancellation;
 use crate::event::{BackendEvent, BackendOperation};
-
-use super::super::helpers::kv_entry_to_json;
-use super::super::state::WorkerState;
+use crate::models::{BackendErrorContext, KvEntryInfo, KvHistoryItem, KvKeyBatch};
 
 /// Spawn a task that streams key names in batches.
 /// Returns the JoinHandle so the caller can track/cancel it.
@@ -74,18 +73,20 @@ pub(crate) async fn handle_list_keys(
                 Ok(Some(key)) => {
                     batch.push(key);
                     if batch.len() >= BATCH_SIZE {
-                        let entries: Vec<serde_json::Value> = batch
-                            .drain(..)
-                            .map(|k| serde_json::json!({ "key": k }))
-                            .collect();
-                        total_keys += entries.len();
-                        tracing::debug!(connection_id, bucket = %bucket, generation, batch_size = entries.len(), total_keys, "Sending KV key batch");
-                        super::send_ok(
-                            &evt_tx,
-                            connection_id,
-                            BackendOperation::ListKvKeys,
-                            serde_json::json!({ "bucket": &bucket, "entries": entries, "done": false, "generation": generation }),
-                        ).await;
+                        let keys = std::mem::take(&mut batch);
+                        total_keys += keys.len();
+                        tracing::debug!(connection_id, bucket = %bucket, generation, batch_size = keys.len(), total_keys, "Sending KV key batch");
+                        let _ = evt_tx
+                            .send(BackendEvent::KvKeysListed {
+                                connection_id,
+                                batch: KvKeyBatch {
+                                    bucket: bucket.clone(),
+                                    keys,
+                                    done: false,
+                                    generation,
+                                },
+                            })
+                            .await;
                     }
                 }
                 Ok(None) => break,
@@ -104,29 +105,36 @@ pub(crate) async fn handle_list_keys(
 
         // Send remaining keys
         if !batch.is_empty() {
-            let entries: Vec<serde_json::Value> = batch
-                .drain(..)
-                .map(|k| serde_json::json!({ "key": k }))
-                .collect();
-            total_keys += entries.len();
-            tracing::debug!(connection_id, bucket = %bucket, generation, batch_size = entries.len(), total_keys, "Sending final KV key batch");
-            super::send_ok(
-                &evt_tx,
-                connection_id,
-                BackendOperation::ListKvKeys,
-                serde_json::json!({ "bucket": &bucket, "entries": entries, "done": false, "generation": generation }),
-            ).await;
+            let keys = std::mem::take(&mut batch);
+            total_keys += keys.len();
+            tracing::debug!(connection_id, bucket = %bucket, generation, batch_size = keys.len(), total_keys, "Sending final KV key batch");
+            let _ = evt_tx
+                .send(BackendEvent::KvKeysListed {
+                    connection_id,
+                    batch: KvKeyBatch {
+                        bucket: bucket.clone(),
+                        keys,
+                        done: false,
+                        generation,
+                    },
+                })
+                .await;
         }
 
         tracing::info!(connection_id, bucket = %bucket, generation, total_keys, "Completed KV key list task");
 
         // Signal completion
-        super::send_ok(
-            &evt_tx,
-            connection_id,
-            BackendOperation::ListKvKeys,
-            serde_json::json!({ "bucket": &bucket, "entries": [], "done": true, "generation": generation }),
-        ).await;
+        let _ = evt_tx
+            .send(BackendEvent::KvKeysListed {
+                connection_id,
+                batch: KvKeyBatch {
+                    bucket,
+                    keys: Vec::new(),
+                    done: true,
+                    generation,
+                },
+            })
+            .await;
     }))
 }
 
@@ -138,14 +146,17 @@ pub(crate) async fn handle_get_entry(
     evt_tx: &mpsc::Sender<BackendEvent>,
 ) {
     tracing::debug!(connection_id, bucket = %bucket, key = %key, "Fetching KV entry");
-    let error_data = serde_json::json!({ "bucket": &bucket, "key": &key });
-    let Some(store) = super::open_store_with_error_data(
+    let error_context = BackendErrorContext::KvEntry {
+        bucket: bucket.clone(),
+        key: key.clone(),
+    };
+    let Some(store) = super::open_store_with_context(
         state,
         connection_id,
         &bucket,
         evt_tx,
         BackendOperation::GetKvEntry,
-        Some(error_data.clone()),
+        Some(error_context.clone()),
     )
     .await
     else {
@@ -154,25 +165,24 @@ pub(crate) async fn handle_get_entry(
     match store.entry(&key).await {
         Ok(entry) => {
             tracing::debug!(connection_id, bucket = %bucket, key = %key, found = entry.is_some(), "Fetched KV entry");
-            let entry_json = match entry.as_ref().map(kv_entry_to_json) {
-                Some(v) => v,
-                None => serde_json::json!({ "key": key }),
-            };
-            super::send_ok(
-                evt_tx,
-                connection_id,
-                BackendOperation::GetKvEntry,
-                serde_json::json!({ "bucket": bucket, "entry": entry_json }),
-            )
-            .await;
+            let entry = entry
+                .as_ref()
+                .map(KvEntryInfo::from_entry)
+                .unwrap_or_else(|| KvEntryInfo::missing(bucket, key));
+            let _ = evt_tx
+                .send(BackendEvent::KvEntryFetched {
+                    connection_id,
+                    entry,
+                })
+                .await;
         }
         Err(e) => {
-            super::send_err_with_data(
+            super::send_err_with_context(
                 evt_tx,
                 connection_id,
                 BackendOperation::GetKvEntry,
                 e.to_string(),
-                Some(error_data),
+                Some(error_context),
             )
             .await
         }
@@ -203,7 +213,7 @@ pub(crate) async fn handle_get_history(
             let mut entries = Vec::new();
             loop {
                 match history.try_next().await {
-                    Ok(Some(entry)) => entries.push(kv_entry_to_json(&entry)),
+                    Ok(Some(entry)) => entries.push(KvHistoryItem::from_entry(&entry)),
                     Ok(None) => break,
                     Err(e) => {
                         super::send_err(
@@ -217,14 +227,15 @@ pub(crate) async fn handle_get_history(
                     }
                 }
             }
-            entries.sort_by(|a, b| b["revision"].as_u64().cmp(&a["revision"].as_u64()));
-            super::send_ok(
-                evt_tx,
-                connection_id,
-                BackendOperation::GetKvHistory,
-                serde_json::json!({ "bucket": bucket, "key": key, "history": entries }),
-            )
-            .await;
+            entries.sort_by_key(|entry| std::cmp::Reverse(entry.revision));
+            let _ = evt_tx
+                .send(BackendEvent::KvHistoryFetched {
+                    connection_id,
+                    bucket,
+                    key,
+                    history: entries,
+                })
+                .await;
         }
         Err(e) => {
             super::send_err(
@@ -259,14 +270,15 @@ pub(crate) async fn handle_put_entry(
         return;
     };
     match store.put(&key, Bytes::from(value)).await {
-        Ok(revision) => {
-            super::send_ok(
-                evt_tx,
-                connection_id,
-                BackendOperation::PutKvEntry,
-                serde_json::json!({ "bucket": bucket, "key": key, "revision": revision }),
-            )
-            .await
+        Ok(_revision) => {
+            let _ = evt_tx
+                .send(BackendEvent::KvEntryMutated {
+                    connection_id,
+                    operation: BackendOperation::PutKvEntry,
+                    bucket,
+                    key,
+                })
+                .await;
         }
         Err(e) => {
             super::send_err(
@@ -301,13 +313,14 @@ pub(crate) async fn handle_delete_entry(
     };
     match store.delete(&key).await {
         Ok(()) => {
-            super::send_ok(
-                evt_tx,
-                connection_id,
-                BackendOperation::DeleteKvEntry,
-                serde_json::json!({ "bucket": bucket, "key": key }),
-            )
-            .await
+            let _ = evt_tx
+                .send(BackendEvent::KvEntryMutated {
+                    connection_id,
+                    operation: BackendOperation::DeleteKvEntry,
+                    bucket,
+                    key,
+                })
+                .await;
         }
         Err(e) => {
             super::send_err(
@@ -342,13 +355,14 @@ pub(crate) async fn handle_purge_entry(
     };
     match store.purge(&key).await {
         Ok(()) => {
-            super::send_ok(
-                evt_tx,
-                connection_id,
-                BackendOperation::PurgeKvEntry,
-                serde_json::json!({ "bucket": bucket, "key": key }),
-            )
-            .await
+            let _ = evt_tx
+                .send(BackendEvent::KvEntryMutated {
+                    connection_id,
+                    operation: BackendOperation::PurgeKvEntry,
+                    bucket,
+                    key,
+                })
+                .await;
         }
         Err(e) => {
             super::send_err(

--- a/crates/nats-backend/src/worker/object_store/buckets.rs
+++ b/crates/nats-backend/src/worker/object_store/buckets.rs
@@ -2,6 +2,7 @@ use futures_util::TryStreamExt;
 use tokio::sync::mpsc;
 
 use crate::event::{BackendEvent, BackendOperation};
+use crate::models::{ObjectStoreBucketConfigInput, ObjectStoreBucketInfo};
 
 use super::super::state::WorkerState;
 
@@ -32,14 +33,10 @@ pub(crate) async fn handle_list_buckets(
                 match js.get_stream(&stream_name).await {
                     Ok(mut stream) => match stream.info().await {
                         Ok(info) => {
-                            buckets.push(serde_json::json!({
-                                "bucket": bucket_name,
-                                "description": info.config.description.as_deref().unwrap_or(""),
-                                "storage": format!("{:?}", info.config.storage),
-                                "bytes": info.state.bytes,
-                                "max_bytes": info.config.max_bytes,
-                                "messages": info.state.messages,
-                            }));
+                            buckets.push(ObjectStoreBucketInfo::from_stream_info(
+                                bucket_name.to_string(),
+                                info,
+                            ));
                         }
                         Err(e) => {
                             tracing::warn!(bucket = bucket_name, %e, "Error loading object store info")
@@ -64,20 +61,19 @@ pub(crate) async fn handle_list_buckets(
         }
     }
 
-    buckets.sort_by(|a, b| a["bucket"].as_str().cmp(&b["bucket"].as_str()));
-    super::send_ok(
-        evt_tx,
-        connection_id,
-        BackendOperation::ListObjectStoreBuckets,
-        serde_json::Value::Array(buckets),
-    )
-    .await;
+    buckets.sort_by(|a, b| a.bucket.cmp(&b.bucket));
+    let _ = evt_tx
+        .send(BackendEvent::ObjectStoreBucketsListed {
+            connection_id,
+            buckets,
+        })
+        .await;
 }
 
 pub(crate) async fn handle_create_bucket(
     state: &WorkerState,
     connection_id: u64,
-    config: serde_json::Value,
+    config: ObjectStoreBucketConfigInput,
     evt_tx: &mpsc::Sender<BackendEvent>,
 ) {
     let Some(js) = super::jetstream(
@@ -91,7 +87,7 @@ pub(crate) async fn handle_create_bucket(
         return;
     };
 
-    let bucket = config["bucket"].as_str().unwrap_or("").trim().to_string();
+    let bucket = config.bucket.trim().to_string();
     if bucket.is_empty() {
         super::send_err(
             evt_tx,
@@ -103,30 +99,26 @@ pub(crate) async fn handle_create_bucket(
         return;
     }
 
-    let storage = match config["storage"].as_str() {
-        Some("memory") | Some("Memory") => async_nats::jetstream::stream::StorageType::Memory,
-        _ => async_nats::jetstream::stream::StorageType::File,
-    };
-
-    let bucket_config = async_nats::jetstream::object_store::Config {
-        bucket: bucket.clone(),
-        description: config["description"].as_str().map(|s| s.to_string()),
-        max_bytes: config["max_bytes"].as_i64().unwrap_or_default(),
-        storage,
-        num_replicas: config["num_replicas"].as_u64().unwrap_or(1) as usize,
-        ..Default::default()
-    };
-
-    match js.create_object_store(bucket_config).await {
-        Ok(_store) => {
-            super::send_ok(
-                evt_tx,
-                connection_id,
-                BackendOperation::CreateObjectStoreBucket,
-                serde_json::json!({ "bucket": bucket }),
-            )
-            .await
-        }
+    match js.create_object_store(config.into_async_nats()).await {
+        Ok(_store) => match load_bucket_info(&js, &bucket).await {
+            Ok(info) => {
+                let _ = evt_tx
+                    .send(BackendEvent::ObjectStoreBucketCreated {
+                        connection_id,
+                        bucket: info,
+                    })
+                    .await;
+            }
+            Err(e) => {
+                super::send_err(
+                    evt_tx,
+                    connection_id,
+                    BackendOperation::CreateObjectStoreBucket,
+                    e,
+                )
+                .await
+            }
+        },
         Err(e) => {
             super::send_err(
                 evt_tx,
@@ -158,13 +150,12 @@ pub(crate) async fn handle_delete_bucket(
 
     match js.delete_object_store(&bucket).await {
         Ok(_) => {
-            super::send_ok(
-                evt_tx,
-                connection_id,
-                BackendOperation::DeleteObjectStoreBucket,
-                serde_json::json!({ "bucket": bucket }),
-            )
-            .await
+            let _ = evt_tx
+                .send(BackendEvent::ObjectStoreBucketDeleted {
+                    connection_id,
+                    bucket,
+                })
+                .await;
         }
         Err(e) => {
             super::send_err(
@@ -176,4 +167,20 @@ pub(crate) async fn handle_delete_bucket(
             .await
         }
     }
+}
+
+async fn load_bucket_info(
+    js: &async_nats::jetstream::Context,
+    bucket: &str,
+) -> Result<ObjectStoreBucketInfo, String> {
+    let stream_name = format!("OBJ_{bucket}");
+    let mut stream = js
+        .get_stream(&stream_name)
+        .await
+        .map_err(|e| e.to_string())?;
+    let info = stream.info().await.map_err(|e| e.to_string())?;
+    Ok(ObjectStoreBucketInfo::from_stream_info(
+        bucket.to_string(),
+        info,
+    ))
 }

--- a/crates/nats-backend/src/worker/object_store/mod.rs
+++ b/crates/nats-backend/src/worker/object_store/mod.rs
@@ -44,21 +44,6 @@ async fn open_store(
     }
 }
 
-async fn send_ok(
-    evt_tx: &mpsc::Sender<BackendEvent>,
-    connection_id: u64,
-    operation: BackendOperation,
-    data: serde_json::Value,
-) {
-    let _ = evt_tx
-        .send(BackendEvent::OperationResult {
-            connection_id,
-            operation,
-            data,
-        })
-        .await;
-}
-
 async fn send_err(
     evt_tx: &mpsc::Sender<BackendEvent>,
     connection_id: u64,
@@ -71,7 +56,7 @@ async fn send_err(
             backend_id: None,
             operation,
             message,
-            data: None,
+            context: None,
         })
         .await;
 }

--- a/crates/nats-backend/src/worker/object_store/objects.rs
+++ b/crates/nats-backend/src/worker/object_store/objects.rs
@@ -4,6 +4,7 @@ use futures_util::TryStreamExt;
 use tokio::sync::mpsc;
 
 use crate::event::{BackendEvent, BackendOperation};
+use crate::models::{ObjectStoreDownloadResult, ObjectStoreObjectInfo};
 
 use super::super::state::WorkerState;
 
@@ -47,7 +48,7 @@ pub(crate) async fn handle_list_objects(
                 if info.deleted {
                     continue;
                 }
-                objects.push(obj_info_to_json(&info));
+                objects.push(ObjectStoreObjectInfo::from_info(&info));
             }
             Ok(None) => break,
             Err(e) => {
@@ -63,14 +64,14 @@ pub(crate) async fn handle_list_objects(
         }
     }
 
-    objects.sort_by(|a, b| a["name"].as_str().cmp(&b["name"].as_str()));
-    super::send_ok(
-        evt_tx,
-        connection_id,
-        BackendOperation::ListObjects,
-        serde_json::json!({ "bucket": bucket, "objects": objects }),
-    )
-    .await;
+    objects.sort_by(|a, b| a.name.cmp(&b.name));
+    let _ = evt_tx
+        .send(BackendEvent::ObjectStoreObjectsListed {
+            connection_id,
+            bucket,
+            objects,
+        })
+        .await;
 }
 
 pub(crate) async fn handle_upload_object(
@@ -96,13 +97,12 @@ pub(crate) async fn handle_upload_object(
     let mut cursor = tokio::io::BufReader::new(std::io::Cursor::new(data));
     match store.put(name.as_str(), &mut cursor).await {
         Ok(info) => {
-            super::send_ok(
-                evt_tx,
-                connection_id,
-                BackendOperation::UploadObject,
-                obj_info_to_json(&info),
-            )
-            .await
+            let _ = evt_tx
+                .send(BackendEvent::ObjectStoreObjectUploaded {
+                    connection_id,
+                    object: ObjectStoreObjectInfo::from_info(&info),
+                })
+                .await;
         }
         Err(e) => {
             super::send_err(
@@ -167,18 +167,17 @@ pub(crate) async fn handle_download_object(
 
     match tokio::io::copy(&mut object, &mut writer).await {
         Ok(bytes_written) => {
-            super::send_ok(
-                evt_tx,
-                connection_id,
-                BackendOperation::DownloadObject,
-                serde_json::json!({
-                    "bucket": bucket,
-                    "name": name,
-                    "file_path": file_path.to_string_lossy(),
-                    "size": bytes_written,
-                }),
-            )
-            .await;
+            let _ = evt_tx
+                .send(BackendEvent::ObjectStoreObjectDownloaded {
+                    connection_id,
+                    result: ObjectStoreDownloadResult {
+                        bucket,
+                        name,
+                        file_path: file_path.to_string_lossy().to_string(),
+                        size: bytes_written,
+                    },
+                })
+                .await;
         }
         Err(e) => {
             // Clean up partial file on failure
@@ -215,13 +214,13 @@ pub(crate) async fn handle_delete_object(
 
     match store.delete(&name).await {
         Ok(_) => {
-            super::send_ok(
-                evt_tx,
-                connection_id,
-                BackendOperation::DeleteObject,
-                serde_json::json!({ "bucket": bucket, "name": name }),
-            )
-            .await
+            let _ = evt_tx
+                .send(BackendEvent::ObjectStoreObjectDeleted {
+                    connection_id,
+                    bucket,
+                    name,
+                })
+                .await;
         }
         Err(e) => {
             super::send_err(
@@ -233,16 +232,4 @@ pub(crate) async fn handle_delete_object(
             .await
         }
     }
-}
-
-fn obj_info_to_json(info: &async_nats::jetstream::object_store::ObjectInfo) -> serde_json::Value {
-    serde_json::json!({
-        "name": info.name,
-        "description": info.description,
-        "size": info.size,
-        "chunks": info.chunks,
-        "modified": info.modified.map(|t| t.to_string()),
-        "digest": info.digest,
-        "bucket": info.bucket,
-    })
 }

--- a/crates/nats-backend/src/worker/pubsub.rs
+++ b/crates/nats-backend/src/worker/pubsub.rs
@@ -39,15 +39,7 @@ pub(crate) async fn handle_publish(
             client.publish(subject, payload).await
         };
         match result {
-            Ok(()) => {
-                send_ok(
-                    evt_tx,
-                    connection_id,
-                    BackendOperation::Publish,
-                    serde_json::Value::Null,
-                )
-                .await
-            }
+            Ok(()) => send_ok(evt_tx, connection_id, BackendOperation::Publish).await,
             Err(e) => {
                 send_err(
                     evt_tx,
@@ -138,13 +130,7 @@ pub(crate) async fn handle_subscribe(
                             }
                         });
                         vacant.insert(handle);
-                        send_ok(
-                            evt_tx,
-                            connection_id,
-                            BackendOperation::Subscribe,
-                            serde_json::json!({ "subject": subject }),
-                        )
-                        .await;
+                        send_ok(evt_tx, connection_id, BackendOperation::Subscribe).await;
                     }
                     Err(e) => {
                         send_err(
@@ -182,13 +168,7 @@ pub(crate) async fn handle_unsubscribe(
         .remove(&(connection_id, backend_id, subject.clone()))
     {
         handle.abort();
-        send_ok(
-            evt_tx,
-            connection_id,
-            BackendOperation::Unsubscribe,
-            serde_json::json!({ "subject": subject }),
-        )
-        .await;
+        send_ok(evt_tx, connection_id, BackendOperation::Unsubscribe).await;
     } else {
         send_err(
             evt_tx,
@@ -286,13 +266,11 @@ async fn send_ok(
     evt_tx: &mpsc::Sender<BackendEvent>,
     connection_id: u64,
     operation: BackendOperation,
-    data: serde_json::Value,
 ) {
     let _ = evt_tx
-        .send(BackendEvent::OperationResult {
+        .send(BackendEvent::OperationSucceeded {
             connection_id,
             operation,
-            data,
         })
         .await;
 }
@@ -310,7 +288,7 @@ async fn send_err(
             backend_id,
             operation,
             message,
-            data: None,
+            context: None,
         })
         .await;
 }

--- a/crates/nats-backend/src/worker/server_info.rs
+++ b/crates/nats-backend/src/worker/server_info.rs
@@ -1,6 +1,7 @@
 use tokio::sync::mpsc;
 
 use crate::event::{BackendEvent, BackendOperation};
+use crate::models::{JetStreamAccountInfoSnapshot, ServerInfoSnapshot};
 
 use super::state::WorkerState;
 
@@ -21,21 +22,12 @@ pub(crate) async fn handle_get_server_info(
     };
 
     let info = client.server_info();
-    let data = serde_json::json!({
-        "server_id": info.server_id,
-        "server_name": info.server_name,
-        "version": info.version,
-        "host": info.host,
-        "port": info.port,
-        "proto": info.proto,
-        "go": info.go,
-        "max_payload": info.max_payload,
-        "client_id": info.client_id,
-        "auth_required": info.auth_required,
-        "tls_required": info.tls_required,
-        "connect_urls": info.connect_urls,
-    });
-    send_ok(evt_tx, connection_id, BackendOperation::ServerInfo, data).await;
+    let _ = evt_tx
+        .send(BackendEvent::ServerInfoLoaded {
+            connection_id,
+            info: ServerInfoSnapshot::from_info(&info),
+        })
+        .await;
 }
 
 pub(crate) async fn handle_get_jetstream_account_info(
@@ -57,32 +49,12 @@ pub(crate) async fn handle_get_jetstream_account_info(
     let js = async_nats::jetstream::new(client.clone());
     match js.query_account().await {
         Ok(account) => {
-            let data = serde_json::json!({
-                "memory": account.memory,
-                "storage": account.storage,
-                "streams": account.streams,
-                "consumers": account.consumers,
-                "domain": account.domain,
-                "limits": {
-                    "max_memory": account.limits.max_memory,
-                    "max_storage": account.limits.max_storage,
-                    "max_streams": account.limits.max_streams,
-                    "max_consumers": account.limits.max_consumers,
-                    "max_ack_pending": account.limits.max_ack_pending,
-                    "memory_max_stream_bytes": account.limits.memory_max_stream_bytes,
-                    "storage_max_stream_bytes": account.limits.storage_max_stream_bytes,
-                    "max_bytes_required": account.limits.max_bytes_required,
-                },
-                "api_total": account.requests.total,
-                "api_errors": account.requests.errors,
-            });
-            send_ok(
-                evt_tx,
-                connection_id,
-                BackendOperation::JetStreamAccountInfo,
-                data,
-            )
-            .await;
+            let _ = evt_tx
+                .send(BackendEvent::JetStreamAccountInfoLoaded {
+                    connection_id,
+                    info: JetStreamAccountInfoSnapshot::from_account(account),
+                })
+                .await;
         }
         Err(e) => {
             send_err(
@@ -94,21 +66,6 @@ pub(crate) async fn handle_get_jetstream_account_info(
             .await
         }
     }
-}
-
-async fn send_ok(
-    evt_tx: &mpsc::Sender<BackendEvent>,
-    connection_id: u64,
-    operation: BackendOperation,
-    data: serde_json::Value,
-) {
-    let _ = evt_tx
-        .send(BackendEvent::OperationResult {
-            connection_id,
-            operation,
-            data,
-        })
-        .await;
 }
 
 async fn send_err(
@@ -123,7 +80,7 @@ async fn send_err(
             backend_id: None,
             operation,
             message: message.to_string(),
-            data: None,
+            context: None,
         })
         .await;
 }

--- a/crates/nats-backend/src/worker/streams.rs
+++ b/crates/nats-backend/src/worker/streams.rs
@@ -1,10 +1,9 @@
-use base64::Engine;
 use futures_util::StreamExt;
 use tokio::sync::mpsc;
 
 use crate::event::{BackendEvent, BackendOperation};
+use crate::models::{StreamConfigInput, StreamInfo, StreamMessageInfo};
 
-use super::helpers::{raw_message_to_json, stream_info_to_json};
 use super::state::WorkerState;
 
 pub(crate) async fn handle_list_streams(
@@ -21,26 +20,25 @@ pub(crate) async fn handle_list_streams(
     let mut list = Vec::new();
     while let Some(result) = stream_iter.next().await {
         match result {
-            Ok(info) => list.push(stream_info_to_json(&info)),
+            Ok(info) => list.push(StreamInfo::from_info(&info)),
             Err(e) => {
                 tracing::warn!(%e, "Error iterating streams");
                 break;
             }
         }
     }
-    send_ok(
-        evt_tx,
-        connection_id,
-        BackendOperation::ListStreams,
-        serde_json::Value::Array(list),
-    )
-    .await;
+    let _ = evt_tx
+        .send(BackendEvent::StreamsListed {
+            connection_id,
+            streams: list,
+        })
+        .await;
 }
 
 pub(crate) async fn handle_create_stream(
     state: &WorkerState,
     connection_id: u64,
-    config: serde_json::Value,
+    config: StreamConfigInput,
     evt_tx: &mpsc::Sender<BackendEvent>,
 ) {
     let Some(js) = jetstream(state, connection_id, evt_tx, BackendOperation::CreateStream).await
@@ -48,33 +46,21 @@ pub(crate) async fn handle_create_stream(
         return;
     };
 
-    match serde_json::from_value::<async_nats::jetstream::stream::Config>(config) {
-        Ok(stream_config) => match js.create_stream(stream_config).await {
-            Ok(stream) => {
-                send_ok(
-                    evt_tx,
+    match js.create_stream(config.into_async_nats()).await {
+        Ok(stream) => {
+            let _ = evt_tx
+                .send(BackendEvent::StreamCreated {
                     connection_id,
-                    BackendOperation::CreateStream,
-                    stream_info_to_json(stream.cached_info()),
-                )
-                .await
-            }
-            Err(e) => {
-                send_err(
-                    evt_tx,
-                    connection_id,
-                    BackendOperation::CreateStream,
-                    e.to_string(),
-                )
-                .await
-            }
-        },
+                    stream: StreamInfo::from_info(stream.cached_info()),
+                })
+                .await;
+        }
         Err(e) => {
             send_err(
                 evt_tx,
                 connection_id,
                 BackendOperation::CreateStream,
-                format!("Invalid stream config: {e}"),
+                e.to_string(),
             )
             .await
         }
@@ -84,7 +70,7 @@ pub(crate) async fn handle_create_stream(
 pub(crate) async fn handle_update_stream(
     state: &WorkerState,
     connection_id: u64,
-    config: serde_json::Value,
+    config: StreamConfigInput,
     evt_tx: &mpsc::Sender<BackendEvent>,
 ) {
     let Some(js) = jetstream(state, connection_id, evt_tx, BackendOperation::UpdateStream).await
@@ -92,33 +78,21 @@ pub(crate) async fn handle_update_stream(
         return;
     };
 
-    match serde_json::from_value::<async_nats::jetstream::stream::Config>(config) {
-        Ok(stream_config) => match js.update_stream(stream_config).await {
-            Ok(info) => {
-                send_ok(
-                    evt_tx,
+    match js.update_stream(config.into_async_nats()).await {
+        Ok(info) => {
+            let _ = evt_tx
+                .send(BackendEvent::StreamUpdated {
                     connection_id,
-                    BackendOperation::UpdateStream,
-                    stream_info_to_json(&info),
-                )
-                .await
-            }
-            Err(e) => {
-                send_err(
-                    evt_tx,
-                    connection_id,
-                    BackendOperation::UpdateStream,
-                    e.to_string(),
-                )
-                .await
-            }
-        },
+                    stream: StreamInfo::from_info(&info),
+                })
+                .await;
+        }
         Err(e) => {
             send_err(
                 evt_tx,
                 connection_id,
                 BackendOperation::UpdateStream,
-                format!("Invalid stream config: {e}"),
+                e.to_string(),
             )
             .await
         }
@@ -138,13 +112,12 @@ pub(crate) async fn handle_delete_stream(
 
     match js.delete_stream(&name).await {
         Ok(_) => {
-            send_ok(
-                evt_tx,
-                connection_id,
-                BackendOperation::DeleteStream,
-                serde_json::json!({ "name": name }),
-            )
-            .await
+            let _ = evt_tx
+                .send(BackendEvent::StreamDeleted {
+                    connection_id,
+                    name,
+                })
+                .await;
         }
         Err(e) => {
             send_err(
@@ -185,13 +158,13 @@ pub(crate) async fn handle_purge_stream(
 
     match result {
         Ok(resp) => {
-            send_ok(
-                evt_tx,
-                connection_id,
-                BackendOperation::PurgeStream,
-                serde_json::json!({ "name": name, "purged": resp.purged }),
-            )
-            .await
+            let _ = evt_tx
+                .send(BackendEvent::StreamPurged {
+                    connection_id,
+                    name,
+                    purged: resp.purged,
+                })
+                .await;
         }
         Err(e) => {
             send_err(
@@ -266,7 +239,7 @@ pub(crate) async fn handle_get_messages(
             match stream.get_first_raw_message_by_subject(&filter, seq).await {
                 Ok(raw) => {
                     seq = raw.sequence + 1;
-                    messages.push(raw_message_to_json(&raw));
+                    messages.push(StreamMessageInfo::from_stream_message(&raw));
                 }
                 Err(_) => break,
             }
@@ -275,7 +248,7 @@ pub(crate) async fn handle_get_messages(
         let mut seq = first;
         while seq <= last && (messages.len() as u64) < params.batch_size {
             if let Ok(raw) = stream.get_raw_message(seq).await {
-                messages.push(raw_message_to_json(&raw));
+                messages.push(StreamMessageInfo::from_stream_message(&raw));
             }
             seq += 1;
         }
@@ -283,13 +256,13 @@ pub(crate) async fn handle_get_messages(
 
     let message_count = messages.len();
     tracing::info!(connection_id, stream = %params.stream_name, message_count, "Fetched stream messages");
-    send_ok(
-        evt_tx,
-        connection_id,
-        BackendOperation::GetStreamMessages,
-        serde_json::json!({ "stream": params.stream_name, "messages": messages }),
-    )
-    .await;
+    let _ = evt_tx
+        .send(BackendEvent::StreamMessagesFetched {
+            connection_id,
+            stream: params.stream_name,
+            messages,
+        })
+        .await;
 }
 
 async fn handle_get_messages_by_time(
@@ -374,32 +347,26 @@ async fn handle_get_messages_by_time(
                     .unwrap_or_else(|_| i.published.to_string())
             })
             .unwrap_or_default();
-        let payload_b64 =
-            base64::engine::general_purpose::STANDARD.encode(msg.message.payload.as_ref());
         let headers = super::helpers::extract_headers(&msg.message.headers);
-        let header_json: Vec<_> = headers
-            .iter()
-            .map(|(k, v)| serde_json::json!([k, v]))
-            .collect();
-        messages.push(serde_json::json!({
-            "sequence": seq,
-            "subject": msg.message.subject.to_string(),
-            "payload_base64": payload_b64,
-            "headers": header_json,
-            "time": time_val,
-        }));
+        messages.push(StreamMessageInfo {
+            sequence: seq,
+            subject: msg.message.subject.to_string(),
+            payload: msg.message.payload.to_vec(),
+            headers,
+            time: time_val,
+        });
     }
 
     // Ephemeral consumer auto-deletes on timeout; no explicit cleanup needed.
     let message_count = messages.len();
     tracing::info!(connection_id, stream = %stream_name, message_count, "Fetched stream messages by time");
-    send_ok(
-        evt_tx,
-        connection_id,
-        BackendOperation::GetStreamMessages,
-        serde_json::json!({ "stream": stream_name, "messages": messages }),
-    )
-    .await;
+    let _ = evt_tx
+        .send(BackendEvent::StreamMessagesFetched {
+            connection_id,
+            stream: stream_name.to_string(),
+            messages,
+        })
+        .await;
 }
 
 pub(crate) async fn handle_delete_message(
@@ -423,13 +390,13 @@ pub(crate) async fn handle_delete_message(
 
     match stream.delete_message(sequence).await {
         Ok(_) => {
-            send_ok(
-                evt_tx,
-                connection_id,
-                BackendOperation::DeleteStreamMessage,
-                serde_json::json!({ "stream": stream_name, "sequence": sequence }),
-            )
-            .await
+            let _ = evt_tx
+                .send(BackendEvent::StreamMessageDeleted {
+                    connection_id,
+                    stream: stream_name,
+                    sequence,
+                })
+                .await;
         }
         Err(e) => {
             send_err(
@@ -475,21 +442,6 @@ async fn open_stream(
     }
 }
 
-async fn send_ok(
-    evt_tx: &mpsc::Sender<BackendEvent>,
-    connection_id: u64,
-    operation: BackendOperation,
-    data: serde_json::Value,
-) {
-    let _ = evt_tx
-        .send(BackendEvent::OperationResult {
-            connection_id,
-            operation,
-            data,
-        })
-        .await;
-}
-
 async fn send_err(
     evt_tx: &mpsc::Sender<BackendEvent>,
     connection_id: u64,
@@ -502,7 +454,7 @@ async fn send_err(
             backend_id: None,
             operation,
             message,
-            data: None,
+            context: None,
         })
         .await;
 }

--- a/openspec/changes/typed-backend-domain-models/.openspec.yaml
+++ b/openspec/changes/typed-backend-domain-models/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/typed-backend-domain-models/design.md
+++ b/openspec/changes/typed-backend-domain-models/design.md
@@ -1,0 +1,62 @@
+## Context
+
+The app already has typed examples for internal data flow: pub/sub messages use `MessageData`, and metrics use `MetricsSnapshot` as a dedicated `BackendEvent`. Most JetStream, KV, Object Store, and Server Info workflows still use `OperationResult { data: serde_json::Value }`, then store those values in app state and read them from UI code with string keys.
+
+That pattern makes field semantics implicit. The KV status bug is the concrete failure mode: `async-nats` exposes `Status::values()` as stored messages including history, but the UI treated a JSON field named `values` as the current key count.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Move backend-derived domain data to typed structs and typed `BackendEvent` variants.
+- Keep UI/tab state typed for migrated domains.
+- Remove JSON field fallback from each migrated domain.
+- Keep file sizes bounded while touching large modules.
+
+**Non-Goals:**
+- Removing JSON from user payload formatting, JSON Schema, protobuf JSON templates, or external monitoring endpoint parsing.
+- Changing user-visible workflows beyond correcting mislabeled data and preserving existing behavior.
+- Persisting new data models to disk.
+
+## Decisions
+
+### 1. Use domain-specific typed events
+
+Each migrated domain gets typed event variants instead of adding more cases to `OperationResult(Value)`. This follows the metrics implementation and keeps the compiler responsible for field presence and naming.
+
+Alternatives considered:
+- Keep `OperationResult` and deserialize in the app: still leaves a stringly typed boundary.
+- One giant `BackendResult` enum with nested JSON payloads: centralizes routing but does not remove the leak.
+
+### 2. Migrate by vertical slice
+
+The implementation order is KV, Object Store, Server Info, Stream/Consumer, then command config inputs. Each slice must finish cleanly before moving on: backend result, app state, and UI rendering for that slice no longer use JSON DTOs.
+
+Alternatives considered:
+- Big-bang migration: cleaner final diff but too large to review safely.
+- Only fix KV: leaves the same failure pattern elsewhere.
+
+### 3. Typed command configs come after typed results
+
+Result data caused the current bug and has the broadest UI exposure. Command config structs are still important, but they are migrated after result paths are stable so the app can keep compiling through smaller slices.
+
+### 4. JSON is allowed only at explicit dynamic boundaries
+
+Allowed JSON boundaries are payload formatter input/output, JSON Schema documents, protobuf JSON template generation, and parser internals for external JSON APIs. Domain state and UI renderers should not use `serde_json::Value` for backend-derived resource metadata.
+
+## Risks / Trade-offs
+
+- **Large diff surface** -> Migrate by domain and validate each slice before continuing.
+- **Temporary old path remains for unmigrated domains** -> Mark tasks so each migrated domain removes its own fallback, then delete or isolate the generic path at the end.
+- **File size pressure** -> Split large files when touched, especially tab state and action modules.
+- **Semantic drift during conversion** -> Preserve current display behavior with tests before replacing JSON helpers.
+
+## Migration Plan
+
+1. Add OpenSpec requirements and task list.
+2. Migrate KV models/events/state/UI and validate.
+3. Repeat for Object Store and Server Info.
+4. Repeat for Stream/Consumer.
+5. Replace command config JSON inputs with typed structs.
+6. Remove or isolate the generic JSON operation result and error context path.
+
+Rollback is normal source rollback; no persisted data migration is introduced.

--- a/openspec/changes/typed-backend-domain-models/proposal.md
+++ b/openspec/changes/typed-backend-domain-models/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+easy-nats currently routes most backend operation results through `serde_json::Value`, then stores and reads those values in app state and UI code with string keys. This leaks backend/library payload shapes into UI behavior, as shown by the KV `values` field being displayed as current key count even though it represents stored historical messages.
+
+## What Changes
+
+- Replace backend/app domain operation results with typed Rust structs and event variants.
+- Keep JSON only where it is part of the user-facing data domain: payload formatting, JSON Schema validation/templates, protobuf JSON templates, and external monitoring endpoint parsing.
+- Migrate by vertical slice: KV, Object Store, Server Info, Stream/Consumer, then command config inputs.
+- Remove JSON fallbacks from each migrated domain; unmigrated domains may temporarily continue using the old generic operation result path only until their slice is migrated.
+- Split oversized files touched by the migration so domain state and UI code remain bounded and maintainable.
+
+## Capabilities
+
+### New Capabilities
+- `backend-operation-contract`: Defines typed backend/app command and result contracts for internal domain data.
+
+### Modified Capabilities
+- `workspace-ui`: Resource lists and tab states use typed backend-derived domain models instead of dynamic JSON values.
+
+## Impact
+
+- `crates/nats-backend`: add domain result/config structs, typed backend events, and worker conversions from async-nats types.
+- `crates/app/src/app`: update event handling, resource lists, editors, and operation result routing to use typed data.
+- `crates/app/src/tabs`: update tab state and renderers to consume typed domain models and split oversized state/UI modules where touched.
+- Existing dirty KV display fixes are folded into the typed KV slice and should not leave JSON compatibility fallbacks behind.

--- a/openspec/changes/typed-backend-domain-models/specs/backend-operation-contract/spec.md
+++ b/openspec/changes/typed-backend-domain-models/specs/backend-operation-contract/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Typed domain operation results
+Backend operation results for internal resource domains SHALL be represented by Rust structs and `BackendEvent` variants instead of `serde_json::Value` payloads.
+
+#### Scenario: KV bucket status uses typed data
+- **WHEN** the backend reports KV bucket status
+- **THEN** the event exposes typed fields for bucket name, stored historical value count, history depth, storage, byte usage, and limits without requiring the app to read JSON keys
+
+#### Scenario: Migrated domains remove JSON fallbacks
+- **WHEN** a domain slice has been migrated to typed events
+- **THEN** that domain no longer accepts fallback JSON field names for the same data
+
+### Requirement: Explicit dynamic JSON boundaries
+The system SHALL allow `serde_json::Value` only for explicitly dynamic data boundaries: user payload formatting, JSON Schema documents, protobuf JSON templates, and parser internals for external JSON APIs.
+
+#### Scenario: JSON Schema remains dynamic
+- **WHEN** the app loads and validates a user-provided JSON Schema
+- **THEN** schema parsing may continue to use `serde_json::Value`
+
+#### Scenario: Domain metadata is not dynamic JSON
+- **WHEN** the app stores backend-derived stream, KV, object store, consumer, or server metadata
+- **THEN** the stored value is a typed domain model rather than `serde_json::Value`
+
+### Requirement: Typed command configuration inputs
+Create and update commands for backend-managed resources SHALL use typed config structs instead of generic JSON config payloads.
+
+#### Scenario: KV bucket update uses typed config
+- **WHEN** the app sends a KV bucket create or update request
+- **THEN** the backend receives a typed KV bucket config model and performs conversion to async-nats config inside the backend layer
+
+#### Scenario: Consumer edit does not keep original JSON config
+- **WHEN** the user edits a consumer
+- **THEN** the editor retains a typed editable config snapshot rather than the raw consumer JSON returned by the backend
+
+### Requirement: Typed error context
+Backend errors that need context for app cleanup SHALL carry typed error context instead of `Option<serde_json::Value>`.
+
+#### Scenario: KV entry request failure identifies target
+- **WHEN** a KV entry fetch fails
+- **THEN** the error event includes typed bucket and key context so the app clears only matching loading or scan state

--- a/openspec/changes/typed-backend-domain-models/specs/workspace-ui/spec.md
+++ b/openspec/changes/typed-backend-domain-models/specs/workspace-ui/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Resource state uses typed backend models
+The workspace UI SHALL store backend-derived resource lists and tab state as typed domain models rather than dynamic JSON values.
+
+#### Scenario: KV tab displays typed bucket status
+- **WHEN** the user opens a KV bucket tab
+- **THEN** the tab state stores typed bucket status and displays current key count separately from stored historical value count
+
+#### Scenario: Object Store tab displays typed metadata
+- **WHEN** the user opens an Object Store bucket tab
+- **THEN** bucket and object metadata are read from typed fields rather than JSON key lookups
+
+#### Scenario: Stream tab displays typed messages and consumers
+- **WHEN** the user views stream messages or consumers
+- **THEN** message and consumer UI code reads typed fields rather than `serde_json::Value` keys
+
+### Requirement: Search workspace consumes typed source snapshots
+The Search Workspace SHALL build searchable source snapshots from typed tab state instead of directly inspecting backend JSON payloads.
+
+#### Scenario: Stream result navigation uses typed sequence
+- **WHEN** a search result points to a stream message
+- **THEN** the workspace locates the message through a typed sequence field rather than `msg["sequence"]`
+
+#### Scenario: KV value search uses typed history items
+- **WHEN** KV value search includes history data
+- **THEN** searchable text comes from typed KV history items rather than dynamic JSON values
+
+### Requirement: Large touched UI files stay bounded
+Rust source files modified by this change SHALL remain at or below 700 lines by splitting domain state, action, or renderer code into focused modules when necessary.
+
+#### Scenario: KV migration touches a 700-line file
+- **WHEN** the KV typed migration modifies the existing KV tab renderer
+- **THEN** the implementation splits enough responsibility into focused modules so the modified file does not exceed 700 lines

--- a/openspec/changes/typed-backend-domain-models/tasks.md
+++ b/openspec/changes/typed-backend-domain-models/tasks.md
@@ -1,0 +1,48 @@
+## 1. Typed KV Models and Events
+
+- [x] 1.1 Add typed KV bucket, entry, history, key batch, and error context models to `nats-backend`.
+- [x] 1.2 Replace backend KV JSON result payloads with typed backend events.
+- [x] 1.3 Replace app KV resource lists, tab state, and UI rendering with typed KV models.
+- [x] 1.4 Remove KV JSON fallback field reads and keep current key count separate from stored historical value count.
+- [x] 1.5 Add or update KV tests and run KV-focused validation.
+
+## 2. Typed Object Store Models and Events
+
+- [x] 2.1 Add typed Object Store bucket, object, transfer result, and error context models.
+- [x] 2.2 Replace Object Store backend JSON result payloads with typed backend events.
+- [x] 2.3 Replace app Object Store resource lists, tab state, and UI rendering with typed models.
+- [x] 2.4 Add or update Object Store tests and run focused validation.
+
+## 3. Typed Server Info Models and Events
+
+- [x] 3.1 Add typed server info and JetStream account info view models.
+- [x] 3.2 Replace Server Info backend JSON result payloads with typed backend events.
+- [x] 3.3 Replace app Server Info state and UI rendering with typed models.
+- [x] 3.4 Add or update Server Info tests and run focused validation.
+
+## 4. Typed Stream and Consumer Models and Events
+
+- [x] 4.1 Add typed stream info, stream message, consumer info, consumer message batch, and stream operation result models.
+- [x] 4.2 Replace stream and consumer backend JSON result payloads with typed backend events.
+- [x] 4.3 Replace app stream lists, tab state, consumer caches, and UI rendering with typed models.
+- [x] 4.4 Update Search Workspace stream snapshots and navigation to consume typed fields.
+- [x] 4.5 Add or update stream/consumer/search tests and run focused validation.
+
+## 5. Typed Command Config Inputs
+
+- [x] 5.1 Add typed create/update config structs for streams, consumers, KV buckets, and Object Store buckets.
+- [x] 5.2 Update app editors/actions to emit typed config structs instead of `serde_json::Value`.
+- [x] 5.3 Update backend workers to convert typed configs into async-nats configs.
+- [x] 5.4 Replace `ConsumerEditEditor.original_config` with a typed editable config snapshot.
+- [x] 5.5 Add or update command config tests and run focused validation.
+
+## 6. Generic JSON Result Cleanup
+
+- [x] 6.1 Remove or strictly isolate `OperationResult { data: serde_json::Value }`.
+- [x] 6.2 Replace `Error { data: Option<serde_json::Value> }` with typed `BackendErrorContext`.
+- [x] 6.3 Verify only explicitly dynamic JSON boundaries retain `serde_json::Value`.
+
+## 7. File Size and Full Validation
+
+- [x] 7.1 Split oversized touched files so modified Rust files stay at or below 700 lines.
+- [x] 7.2 Run full formatting, tests, clippy, and OpenSpec validation.


### PR DESCRIPTION
## Summary
- Migrates the internal backend/app operation contracts from `serde_json::Value` payloads to typed Rust domain models.
- Converts KV, Object Store, Server Info, Stream, and Consumer result flows to typed backend events and typed app state while keeping naturally dynamic JSON boundaries for payload formatting, JSON Schema, protobuf templates, and monitoring JSON parsing.
- Adds and applies the `typed-backend-domain-models` OpenSpec change with proposal, design, spec deltas, and tasks.
- Fixes the KV display semantics so `Values Stored` represents stored historical values, while the current key count is displayed separately from loaded key state.
- Supports all JetStream consumer deliver policies in typed consumer creation and preserves them when editing existing consumers.
- Splits touched oversized files so modified Rust sources stay within the repository line-count constraint.

## Testing
- `cargo fmt --all -- --check`
- `cargo test -p easy-nats -p nats-backend`
- `cargo clippy -p nats-backend -p easy-nats --all-targets -- -D warnings`
- `openspec validate typed-backend-domain-models`