### PR TITLE
Fix WorkQueue preview and KV lazy loading

### DIFF
--- a/assets/i18n/consumer.yaml
+++ b/assets/i18n/consumer.yaml
@@ -125,3 +125,6 @@ fetched_messages:
 fetching:
   en: "Fetching..."
   zh: "获取中..."
+workqueue_preview_unsupported:
+  en: "Safe non-destructive preview is unavailable for WorkQueue streams because NATS does not allow another filtered inspector consumer with overlapping subjects."
+  zh: "WorkQueue 流无法使用安全的非破坏性预览，因为 NATS 不允许创建另一个主题过滤范围重叠的检查器消费者。"

--- a/crates/app/src/app/actions.rs
+++ b/crates/app/src/app/actions.rs
@@ -224,8 +224,10 @@ impl EasyNatsApp {
             state.load_generation = new_gen;
             state.keys.clear();
             state.fetched_values.clear();
+            state.invalidate_filtered_key_cache();
             state.value_search_cursor = 0;
             state.value_search_scanning = 0;
+            state.value_search_pending.clear();
             state.search_generation = state.search_generation.wrapping_add(1);
             state.keys_complete = false;
             self.backend.send(BackendCommand::ListKvKeys {

--- a/crates/app/src/app/kv_results.rs
+++ b/crates/app/src/app/kv_results.rs
@@ -87,10 +87,12 @@ impl EasyNatsApp {
             {
                 state.keys.extend(batch.keys.clone());
                 if !batch.keys.is_empty() {
+                    state.invalidate_filtered_key_cache();
                     state.search_generation = state.search_generation.wrapping_add(1);
                 }
                 if batch.done {
                     state.keys.sort();
+                    state.invalidate_filtered_key_cache();
                     state.keys_complete = true;
                     state.loading_entries = false;
                     state.search_generation = state.search_generation.wrapping_add(1);
@@ -115,6 +117,7 @@ impl EasyNatsApp {
                 state
                     .fetched_values
                     .insert(entry_key.to_string(), entry_value.clone());
+                state.invalidate_filtered_key_cache();
                 state.search_generation = state.search_generation.wrapping_add(1);
                 if state.value_search_pending.remove(entry_key) {
                     state.value_search_scanning = state.value_search_pending.len();
@@ -150,6 +153,8 @@ impl EasyNatsApp {
                 && state.selected_key.as_deref() == Some(key.as_str())
             {
                 state.history = history.clone();
+                state.invalidate_filtered_key_cache();
+                state.search_generation = state.search_generation.wrapping_add(1);
                 state.loading_history = false;
             }
         }
@@ -183,6 +188,7 @@ impl EasyNatsApp {
                 state.load_generation = new_gen;
                 state.keys.clear();
                 state.fetched_values.clear();
+                state.invalidate_filtered_key_cache();
                 state.value_search_cursor = 0;
                 state.value_search_scanning = 0;
                 state.value_search_pending.clear();
@@ -258,7 +264,7 @@ impl EasyNatsApp {
                     Some(BackendErrorContext::KvEntry { bucket, key }) => {
                         (Some(bucket.as_str()), Some(key.as_str()))
                     }
-                    None => (None, None),
+                    _ => (None, None),
                 };
                 for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
                     if let TabKind::KvBucket {

--- a/crates/app/src/app/operation_results.rs
+++ b/crates/app/src/app/operation_results.rs
@@ -1,5 +1,6 @@
 use nats_backend::{BackendErrorContext, BackendOperation};
 
+use crate::i18n::t;
 use crate::tabs::TabKind;
 use crate::toast::ToastLevel;
 
@@ -87,7 +88,56 @@ impl EasyNatsApp {
             self.clear_server_info_loading_on_error(cid, operation);
         }
 
-        self.toasts
-            .push(ToastLevel::Error, format!("{operation}: {message}"));
+        self.toasts.push(
+            ToastLevel::Error,
+            operation_error_message(operation, message, context),
+        );
+    }
+}
+
+fn operation_error_message(
+    operation: BackendOperation,
+    message: &str,
+    context: Option<&BackendErrorContext>,
+) -> String {
+    if operation == BackendOperation::FetchConsumerMessages
+        && matches!(
+            context,
+            Some(BackendErrorContext::WorkQueueConsumerPreview { reason, .. })
+                if reason == "workqueue_inspector_not_supported"
+        )
+    {
+        return format!(
+            "{operation}: {}",
+            t("consumer.workqueue_preview_unsupported")
+        );
+    }
+
+    format!("{operation}: {message}")
+}
+
+#[cfg(test)]
+mod tests {
+    use nats_backend::{BackendErrorContext, BackendOperation};
+
+    use super::*;
+
+    #[test]
+    fn workqueue_fetch_limitation_hides_raw_server_error() {
+        let context = BackendErrorContext::WorkQueueConsumerPreview {
+            stream: "ORDERS".to_string(),
+            consumer: "worker-a".to_string(),
+            reason: "workqueue_inspector_not_supported".to_string(),
+        };
+
+        let message = operation_error_message(
+            BackendOperation::FetchConsumerMessages,
+            "Failed to create inspector consumer: JetStream error: filtered consumer not unique on workqueue stream",
+            Some(&context),
+        );
+
+        assert!(!message.contains("filtered consumer not unique"));
+        assert!(!message.contains("Failed to create inspector consumer"));
+        assert!(message.contains("fetch_consumer_messages"));
     }
 }

--- a/crates/app/src/tabs/kv.rs
+++ b/crates/app/src/tabs/kv.rs
@@ -1,5 +1,5 @@
 use eframe::egui;
-use nats_backend::{BackendCommand, BackendHandle, KvBucketInfo, KvHistoryItem};
+use nats_backend::{BackendCommand, BackendHandle, KvBucketInfo};
 
 use crate::format;
 use crate::i18n::t;
@@ -7,10 +7,11 @@ use crate::schema::{MessageSchemaManager, kv_subject};
 use crate::tabs::guard::TabGuard;
 
 use super::common::{
-    KV_VALUE_SEARCH_BATCH, SearchStatus, auto_refresh_ui, format_bytes, matches_query,
-    render_search_row,
+    KV_VALUE_SEARCH_BATCH, SearchStatus, auto_refresh_ui, format_bytes, render_search_row,
 };
 use super::types::{KvBucketState, TabAction};
+
+mod key_filter;
 
 #[allow(clippy::too_many_arguments)]
 pub fn kv_bucket_ui(
@@ -50,8 +51,10 @@ pub fn kv_bucket_ui(
         state.load_generation = new_gen;
         state.keys.clear();
         state.fetched_values.clear();
+        key_filter::invalidate(state);
         state.value_search_cursor = 0;
         state.value_search_scanning = 0;
+        state.value_search_pending.clear();
         state.search_generation = state.search_generation.wrapping_add(1);
         backend.send(BackendCommand::ListKvKeys {
             connection_id,
@@ -137,7 +140,6 @@ fn render_key_list(
             });
         }
     });
-    let search_status = kv_search_status(state);
     let search_changed = render_search_row(
         ui,
         ("kv_search", bucket_name),
@@ -149,7 +151,9 @@ fn render_key_list(
     if search_changed {
         state.search_more_requested = false;
         state.value_search_cursor = 0;
+        key_filter::invalidate(state);
     }
+    let search_status = kv_search_status(state);
     if state.search.is_active() {
         ui.horizontal_wrapped(|ui| {
             if let Some(text) = search_status.text() {
@@ -174,43 +178,48 @@ fn render_key_list(
         });
     }
 
+    let row_count = key_filter::filtered_row_count(state);
+    if row_count == 0 {
+        ui.label(t("kv.no_keys"));
+        return;
+    }
+
     egui::ScrollArea::vertical()
         .id_salt(("kv_keys", connection_id, bucket_name))
-        .show(ui, |ui| {
-            let filtered = filtered_keys(state);
-
-            if filtered.is_empty() {
-                ui.label(t("kv.no_keys"));
-            } else {
-                for key in &filtered {
-                    if ui
-                        .selectable_label(
-                            state.selected_key.as_deref() == Some(key.as_str()),
-                            key.as_str(),
-                        )
-                        .clicked()
-                    {
-                        state.selected_key = Some(key.clone());
-                        state.show_history = false;
-                        // Clear editor state and request entry details
-                        state.entry_key.clear();
-                        state.entry_value.clear();
-                        state.entry_revision = None;
-                        state.entry_operation = None;
-                        state.entry_created = None;
-                        state.loading_entry = true;
-                        backend.send(BackendCommand::GetKvEntry {
-                            connection_id,
-                            bucket: bucket_name.to_string(),
-                            key: key.clone(),
-                        });
-                        backend.send(BackendCommand::GetKvHistory {
-                            connection_id,
-                            bucket: bucket_name.to_string(),
-                            key: key.clone(),
-                        });
-                        state.loading_history = true;
-                    }
+        .show_rows(ui, 22.0, row_count, |ui, row_range| {
+            let key_indices = key_filter::visible_key_indices(state, row_range);
+            for key_index in key_indices {
+                let Some(key) = state.keys.get(key_index).cloned() else {
+                    continue;
+                };
+                if ui
+                    .selectable_label(
+                        state.selected_key.as_deref() == Some(key.as_str()),
+                        key.as_str(),
+                    )
+                    .clicked()
+                {
+                    state.selected_key = Some(key.clone());
+                    key_filter::invalidate(state);
+                    state.show_history = false;
+                    // Clear editor state and request entry details
+                    state.entry_key.clear();
+                    state.entry_value.clear();
+                    state.entry_revision = None;
+                    state.entry_operation = None;
+                    state.entry_created = None;
+                    state.loading_entry = true;
+                    backend.send(BackendCommand::GetKvEntry {
+                        connection_id,
+                        bucket: bucket_name.to_string(),
+                        key: key.clone(),
+                    });
+                    backend.send(BackendCommand::GetKvHistory {
+                        connection_id,
+                        bucket: bucket_name.to_string(),
+                        key: key.clone(),
+                    });
+                    state.loading_history = true;
                 }
             }
         });
@@ -272,6 +281,7 @@ fn scan_next_kv_values(
     state.value_search_cursor = end;
     state.value_search_scanning += keys.len();
     for key in keys {
+        state.value_search_pending.insert(key.clone());
         backend.send(BackendCommand::GetKvEntry {
             connection_id,
             bucket: bucket_name.to_string(),
@@ -280,42 +290,15 @@ fn scan_next_kv_values(
     }
 }
 
-fn kv_search_status(state: &KvBucketState) -> SearchStatus {
+fn kv_search_status(state: &mut KvBucketState) -> SearchStatus {
     if !state.search.is_active() {
         return SearchStatus::Inactive;
     }
-    let matches = filtered_keys(state).len();
+    let matches = key_filter::filtered_row_count(state);
     SearchStatus::Showing {
         matches,
         capped: false,
     }
-}
-
-fn filtered_keys(state: &KvBucketState) -> Vec<String> {
-    let query = state.search.normalized_query();
-    state
-        .keys
-        .iter()
-        .filter(|key| {
-            if query.is_empty() || (!state.search.primary && !state.search.secondary) {
-                return true;
-            }
-            let key_matches = state.search.primary && matches_query(key, &query);
-            let fetched_value_matches = state.search.secondary
-                && state
-                    .fetched_values
-                    .get(key.as_str())
-                    .is_some_and(|value| matches_query(value, &query));
-            let history_matches = state.search.secondary
-                && state.selected_key.as_deref() == Some(key.as_str())
-                && state
-                    .history
-                    .iter()
-                    .any(|item| matches_query(&searchable_kv_history_item(item), &query));
-            key_matches || fetched_value_matches || history_matches
-        })
-        .cloned()
-        .collect()
 }
 
 fn normalized_entry_key(key: &str) -> String {
@@ -333,8 +316,10 @@ fn refresh_kv_keys(
     state.load_generation = new_gen;
     state.keys.clear();
     state.fetched_values.clear();
+    key_filter::invalidate(state);
     state.value_search_cursor = 0;
     state.value_search_scanning = 0;
+    state.value_search_pending.clear();
     state.search_generation = state.search_generation.wrapping_add(1);
     state.keys_complete = false;
     state.loading_entries = true;
@@ -601,10 +586,6 @@ fn current_kv_count_text(state: &KvBucketState) -> String {
     format!("{}{}", state.keys.len(), suffix)
 }
 
-fn searchable_kv_history_item(item: &KvHistoryItem) -> String {
-    String::from_utf8_lossy(&item.value).into_owned()
-}
-
 fn kv_bucket_info_panel(ui: &mut egui::Ui, info: &KvBucketInfo, state: &KvBucketState) {
     egui::Grid::new("kv_bucket_info_grid")
         .num_columns(2)
@@ -642,7 +623,7 @@ mod tests {
         state.search.primary = true;
         state.search.secondary = false;
 
-        assert_eq!(filtered_keys(&state), vec!["users.alice".to_string()]);
+        assert_eq!(key_filter::visible_key_indices(&mut state, 0..1), vec![0]);
     }
 
     #[test]
@@ -681,7 +662,7 @@ mod tests {
         state.search.primary = false;
         state.search.secondary = true;
 
-        assert_eq!(filtered_keys(&state), vec!["users.bob".to_string()]);
+        assert_eq!(key_filter::visible_key_indices(&mut state, 0..1), vec![1]);
     }
 
     #[test]

--- a/crates/app/src/tabs/kv/key_filter.rs
+++ b/crates/app/src/tabs/kv/key_filter.rs
@@ -1,0 +1,163 @@
+use std::ops::Range;
+
+use crate::tabs::common::matches_query;
+use crate::tabs::types::{CachedKvKeyRows, KvBucketState, SearchCacheKey};
+
+pub(crate) fn invalidate(state: &mut KvBucketState) {
+    state.invalidate_filtered_key_cache();
+}
+
+pub(crate) fn filtered_row_count(state: &mut KvBucketState) -> usize {
+    if !state.search.is_active() {
+        return state.keys.len();
+    }
+    filtered_key_indices(state).len()
+}
+
+pub(crate) fn visible_key_indices(
+    state: &mut KvBucketState,
+    row_range: Range<usize>,
+) -> Vec<usize> {
+    if !state.search.is_active() {
+        let start = row_range.start.min(state.keys.len());
+        let end = row_range.end.min(state.keys.len());
+        return (start..end).collect();
+    }
+
+    let rows = filtered_key_indices(state);
+    let start = row_range.start.min(rows.len());
+    let end = row_range.end.min(rows.len());
+    rows[start..end].to_vec()
+}
+
+fn filtered_key_indices(state: &mut KvBucketState) -> &[usize] {
+    let cache_key = SearchCacheKey::from_state(&state.search);
+    let selected_key = state.selected_key.clone();
+    let needs_refresh = match &state.cached_filtered_keys {
+        Some(cached) => {
+            cached.generation != state.search_generation
+                || cached.cache_key != cache_key
+                || cached.selected_key != selected_key
+        }
+        None => true,
+    };
+
+    if needs_refresh {
+        let query = cache_key.query.as_str();
+        let rows = state
+            .keys
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, key)| {
+                let key_matches = cache_key.primary && matches_query(key, query);
+                let fetched_value_matches = cache_key.secondary
+                    && state
+                        .fetched_values
+                        .get(key.as_str())
+                        .is_some_and(|value| matches_query(value, query));
+                let history_matches = cache_key.secondary
+                    && selected_key.as_deref() == Some(key.as_str())
+                    && state
+                        .history
+                        .iter()
+                        .any(|item| matches_query(&searchable_kv_history_item(item), query));
+                (key_matches || fetched_value_matches || history_matches).then_some(idx)
+            })
+            .collect();
+
+        state.cached_filtered_keys = Some(CachedKvKeyRows {
+            generation: state.search_generation,
+            cache_key,
+            selected_key,
+            rows,
+        });
+    }
+
+    &state
+        .cached_filtered_keys
+        .as_ref()
+        .expect("filtered key cache is built")
+        .rows
+}
+
+fn searchable_kv_history_item(item: &nats_backend::KvHistoryItem) -> String {
+    String::from_utf8_lossy(&item.value).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tabs::types::KvBucketState;
+
+    use super::*;
+
+    #[test]
+    fn inactive_search_counts_loaded_keys_without_filter_cache() {
+        let mut state = KvBucketState {
+            keys: (0..300_000).map(|idx| format!("key.{idx}")).collect(),
+            ..Default::default()
+        };
+
+        assert_eq!(filtered_row_count(&mut state), 300_000);
+        assert_eq!(
+            visible_key_indices(&mut state, 20..25),
+            vec![20, 21, 22, 23, 24]
+        );
+        assert!(state.cached_filtered_keys.is_none());
+    }
+
+    #[test]
+    fn active_key_search_caches_matching_indices() {
+        let mut state = KvBucketState {
+            keys: vec![
+                "orders.1".to_string(),
+                "users.alice".to_string(),
+                "orders.2".to_string(),
+            ],
+            ..Default::default()
+        };
+        state.search.query = "orders".to_string();
+        state.search.primary = true;
+        state.search.secondary = false;
+
+        assert_eq!(visible_key_indices(&mut state, 0..2), vec![0, 2]);
+        assert_eq!(filtered_row_count(&mut state), 2);
+        assert!(state.cached_filtered_keys.is_some());
+    }
+
+    #[test]
+    fn fetched_value_generation_refreshes_cached_matches() {
+        let mut state = KvBucketState {
+            keys: vec!["users.alice".to_string(), "users.bob".to_string()],
+            ..Default::default()
+        };
+        state.search.query = "42".to_string();
+        state.search.primary = false;
+        state.search.secondary = true;
+
+        assert_eq!(filtered_row_count(&mut state), 0);
+
+        state
+            .fetched_values
+            .insert("users.bob".to_string(), "balance: 42".to_string());
+        state.search_generation = state.search_generation.wrapping_add(1);
+
+        assert_eq!(visible_key_indices(&mut state, 0..1), vec![1]);
+        assert_eq!(filtered_row_count(&mut state), 1);
+    }
+
+    #[test]
+    fn invalidate_drops_cached_filtered_indices() {
+        let mut state = KvBucketState {
+            keys: vec!["orders.1".to_string()],
+            ..Default::default()
+        };
+        state.search.query = "orders".to_string();
+
+        assert_eq!(filtered_row_count(&mut state), 1);
+        assert!(state.cached_filtered_keys.is_some());
+
+        invalidate(&mut state);
+
+        assert!(state.cached_filtered_keys.is_none());
+    }
+}

--- a/crates/app/src/tabs/types.rs
+++ b/crates/app/src/tabs/types.rs
@@ -187,6 +187,14 @@ pub type CachedSubscriberRows = (u64, Option<String>, SearchCacheKey, Vec<Subscr
 pub type StreamListRow = (usize, String);
 pub type CachedStreamRows = (u64, SearchCacheKey, Vec<StreamListRow>);
 
+#[derive(Debug, Clone)]
+pub struct CachedKvKeyRows {
+    pub generation: u64,
+    pub cache_key: SearchCacheKey,
+    pub selected_key: Option<String>,
+    pub rows: Vec<usize>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SearchCacheKey {
     pub query: String,
@@ -559,6 +567,7 @@ pub struct KvBucketState {
     pub loading_history: bool,
     pub load_generation: u64,
     pub search_generation: u64,
+    pub cached_filtered_keys: Option<CachedKvKeyRows>,
     pub entry_key: String,
     pub entry_value: String,
     pub fetched_values: HashMap<String, String>,
@@ -591,6 +600,7 @@ impl Default for KvBucketState {
             loading_history: false,
             load_generation: 0,
             search_generation: 0,
+            cached_filtered_keys: None,
             entry_key: String::new(),
             entry_value: String::new(),
             fetched_values: HashMap::new(),
@@ -605,6 +615,12 @@ impl Default for KvBucketState {
             editor_proto_view: ProtoViewState::default(),
             history_proto_view: ProtoViewState::default(),
         }
+    }
+}
+
+impl KvBucketState {
+    pub(crate) fn invalidate_filtered_key_cache(&mut self) {
+        self.cached_filtered_keys = None;
     }
 }
 

--- a/crates/nats-backend/src/models.rs
+++ b/crates/nats-backend/src/models.rs
@@ -241,7 +241,15 @@ pub struct ConsumerInfo {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BackendErrorContext {
-    KvEntry { bucket: String, key: String },
+    KvEntry {
+        bucket: String,
+        key: String,
+    },
+    WorkQueueConsumerPreview {
+        stream: String,
+        consumer: String,
+        reason: String,
+    },
 }
 
 impl StorageKind {

--- a/crates/nats-backend/src/worker/consumers.rs
+++ b/crates/nats-backend/src/worker/consumers.rs
@@ -4,11 +4,13 @@ use futures_util::StreamExt;
 use tokio::sync::mpsc;
 
 use crate::event::{BackendEvent, BackendOperation};
-use crate::models::{ConsumerConfigInput, ConsumerInfo, StreamMessageInfo};
+use crate::models::{BackendErrorContext, ConsumerConfigInput, ConsumerInfo, StreamMessageInfo};
 
 use super::state::WorkerState;
 
 static INSPECTOR_COUNTER: AtomicU64 = AtomicU64::new(0);
+const WORKQUEUE_INSPECTOR_UNSUPPORTED_REASON: &str = "workqueue_inspector_not_supported";
+const WORKQUEUE_INSPECTOR_UNSUPPORTED_MESSAGE: &str = "Safe WorkQueue preview is unavailable because NATS does not allow a second overlapping filtered consumer on a WorkQueue stream";
 
 pub(crate) async fn handle_list_consumers(
     state: &WorkerState,
@@ -197,7 +199,29 @@ pub(crate) async fn handle_fetch_consumer_messages(
         &lookup,
         evt_tx,
         operation,
-        |stream| async move {
+        |mut stream| async move {
+            let is_workqueue = match stream.info().await {
+                Ok(info) => is_workqueue_retention(info.config.retention),
+                Err(e) => {
+                    send_err(evt_tx, connection_id, operation, e.to_string()).await;
+                    return;
+                }
+            };
+            if is_workqueue {
+                send_err_with_context(
+                    evt_tx,
+                    connection_id,
+                    operation,
+                    WORKQUEUE_INSPECTOR_UNSUPPORTED_MESSAGE.to_string(),
+                    Some(workqueue_preview_limitation_context(
+                        &stream_name,
+                        &consumer_name,
+                    )),
+                )
+                .await;
+                return;
+            }
+
             // Get the original consumer info to read its filter subjects
             let original = match stream.consumer_info(&consumer_name).await {
                 Ok(info) => info,
@@ -211,15 +235,7 @@ pub(crate) async fn handle_fetch_consumer_messages(
             let filter = original.config.filter_subject.clone();
             let filters = original.config.filter_subjects.clone();
             let unique_id = INSPECTOR_COUNTER.fetch_add(1, Ordering::Relaxed);
-            let inspector_config = async_nats::jetstream::consumer::pull::Config {
-                name: Some(format!("_easynats_inspect_{unique_id}")),
-                filter_subject: filter,
-                filter_subjects: filters,
-                deliver_policy: async_nats::jetstream::consumer::DeliverPolicy::All,
-                memory_storage: true,
-                inactive_threshold: std::time::Duration::from_secs(10),
-                ..Default::default()
-            };
+            let inspector_config = inspector_consumer_config(filter, filters, unique_id);
 
             let inspector = match stream.create_consumer(inspector_config).await {
                 Ok(c) => c,
@@ -288,6 +304,40 @@ pub(crate) async fn handle_fetch_consumer_messages(
     .await;
 }
 
+fn is_workqueue_retention(policy: async_nats::jetstream::stream::RetentionPolicy) -> bool {
+    matches!(
+        policy,
+        async_nats::jetstream::stream::RetentionPolicy::WorkQueue
+    )
+}
+
+fn workqueue_preview_limitation_context(
+    stream_name: &str,
+    consumer_name: &str,
+) -> BackendErrorContext {
+    BackendErrorContext::WorkQueueConsumerPreview {
+        stream: stream_name.to_string(),
+        consumer: consumer_name.to_string(),
+        reason: WORKQUEUE_INSPECTOR_UNSUPPORTED_REASON.to_string(),
+    }
+}
+
+fn inspector_consumer_config(
+    filter_subject: String,
+    filter_subjects: Vec<String>,
+    unique_id: u64,
+) -> async_nats::jetstream::consumer::pull::Config {
+    async_nats::jetstream::consumer::pull::Config {
+        name: Some(format!("_easynats_inspect_{unique_id}")),
+        filter_subject,
+        filter_subjects,
+        deliver_policy: async_nats::jetstream::consumer::DeliverPolicy::All,
+        memory_storage: true,
+        inactive_threshold: std::time::Duration::from_secs(10),
+        ..Default::default()
+    }
+}
+
 async fn cleanup_inspector_consumer(
     stream: &async_nats::jetstream::stream::Stream,
     consumer_name: &str,
@@ -335,13 +385,72 @@ async fn send_err(
     operation: BackendOperation,
     message: String,
 ) {
+    send_err_with_context(evt_tx, connection_id, operation, message, None).await;
+}
+
+async fn send_err_with_context(
+    evt_tx: &mpsc::Sender<BackendEvent>,
+    connection_id: u64,
+    operation: BackendOperation,
+    message: String,
+    context: Option<BackendErrorContext>,
+) {
     let _ = evt_tx
         .send(BackendEvent::Error {
             connection_id: Some(connection_id),
             backend_id: None,
             operation,
             message,
-            context: None,
+            context,
         })
         .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use async_nats::jetstream::stream::RetentionPolicy;
+
+    use super::*;
+
+    #[test]
+    fn workqueue_retention_is_detected_before_inspector_creation() {
+        assert!(is_workqueue_retention(RetentionPolicy::WorkQueue));
+        assert!(!is_workqueue_retention(RetentionPolicy::Limits));
+        assert!(!is_workqueue_retention(RetentionPolicy::Interest));
+    }
+
+    #[test]
+    fn workqueue_preview_limitation_context_has_stable_reason() {
+        let context = workqueue_preview_limitation_context("ORDERS", "worker-a");
+
+        assert_eq!(
+            context,
+            BackendErrorContext::WorkQueueConsumerPreview {
+                stream: "ORDERS".to_string(),
+                consumer: "worker-a".to_string(),
+                reason: WORKQUEUE_INSPECTOR_UNSUPPORTED_REASON.to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn inspector_config_mirrors_consumer_filter_and_uses_traceable_name() {
+        let config = inspector_consumer_config(
+            "orders.*".to_string(),
+            vec!["orders.created".to_string(), "orders.updated".to_string()],
+            42,
+        );
+
+        assert_eq!(config.name.as_deref(), Some("_easynats_inspect_42"));
+        assert_eq!(config.filter_subject, "orders.*");
+        assert_eq!(
+            config.filter_subjects,
+            vec!["orders.created".to_string(), "orders.updated".to_string()]
+        );
+        assert!(config.memory_storage);
+        assert_eq!(
+            config.inactive_threshold,
+            std::time::Duration::from_secs(10)
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Return a structured WorkQueue preview limitation before creating an overlapping inspector consumer.
- Map that limitation to localized UI copy instead of surfacing the raw JetStream error.
- Virtualize large KV key lists with `show_rows` and cache filtered row indices for active searches.
- Invalidate the KV filtered-key cache when key batches, fetched values, history, selection, or refresh state changes.