### PR TITLE
Add client status tab

### DIFF
--- a/assets/i18n/common.yaml
+++ b/assets/i18n/common.yaml
@@ -59,6 +59,9 @@ tab_object_store:
 tab_metrics:
   en: "Metrics"
   zh: "监控指标"
+tab_clients:
+  en: "Clients"
+  zh: "客户端"
 tab_search_workspace:
   en: "Search"
   zh: "搜索"

--- a/assets/i18n/metrics.yaml
+++ b/assets/i18n/metrics.yaml
@@ -128,3 +128,139 @@ series_js_memory:
 series_js_storage:
   en: "JetStream Storage"
   zh: "JetStream 存储"
+
+client_refresh:
+  en: "Refresh clients"
+  zh: "刷新客户端"
+client_previous:
+  en: "Previous page"
+  zh: "上一页"
+client_next:
+  en: "Next page"
+  zh: "下一页"
+client_loading:
+  en: "Loading clients..."
+  zh: "正在加载客户端..."
+client_not_loaded:
+  en: "No client status page loaded yet."
+  zh: "尚未加载客户端状态页。"
+client_empty:
+  en: "No clients match the current query."
+  zh: "当前查询没有匹配的客户端。"
+client_error_stale:
+  en: "Showing last successful client page"
+  zh: "当前展示的是最近一次成功客户端页"
+client_error_unavailable:
+  en: "Client status is currently unavailable"
+  zh: "当前无法获取客户端状态"
+client_page_summary:
+  en: "Rows"
+  zh: "行"
+client_select_hint:
+  en: "Click a client row to inspect details"
+  zh: "点击客户端行以查看详情"
+client_detail:
+  en: "Client Detail"
+  zh: "客户端详情"
+client_detail_loading:
+  en: "Loading client detail..."
+  zh: "正在加载客户端详情..."
+client_detail_stale:
+  en: "Selected client is not present in the latest page."
+  zh: "所选客户端不在最新页面中。"
+client_subscriptions:
+  en: "Subscriptions"
+  zh: "订阅"
+client_no_subscriptions:
+  en: "No subscription details returned for this client."
+  zh: "该客户端未返回订阅详情。"
+client_missing:
+  en: "n/a"
+  zh: "无"
+
+client_state_open:
+  en: "Open"
+  zh: "打开"
+client_state_closed:
+  en: "Closed"
+  zh: "已关闭"
+client_state_any:
+  en: "Any"
+  zh: "全部"
+
+client_sort_cid:
+  en: "Client ID"
+  zh: "客户端 ID"
+client_sort_start:
+  en: "Start"
+  zh: "开始时间"
+client_sort_subs:
+  en: "Subscriptions"
+  zh: "订阅数"
+client_sort_pending:
+  en: "Pending bytes"
+  zh: "待发送字节"
+client_sort_in_msgs:
+  en: "In messages"
+  zh: "入消息"
+client_sort_out_msgs:
+  en: "Out messages"
+  zh: "出消息"
+client_sort_in_bytes:
+  en: "In bytes"
+  zh: "入字节"
+client_sort_out_bytes:
+  en: "Out bytes"
+  zh: "出字节"
+client_sort_last:
+  en: "Last activity"
+  zh: "最后活动"
+client_sort_idle:
+  en: "Idle"
+  zh: "空闲"
+client_sort_uptime:
+  en: "Uptime"
+  zh: "运行时长"
+client_sort_stop:
+  en: "Stop"
+  zh: "停止时间"
+client_sort_reason:
+  en: "Reason"
+  zh: "原因"
+
+client_col_client:
+  en: "Client"
+  zh: "客户端"
+client_col_state:
+  en: "State"
+  zh: "状态"
+client_col_identity:
+  en: "Identity"
+  zh: "身份"
+client_col_address:
+  en: "Address"
+  zh: "地址"
+client_col_uptime_idle:
+  en: "Uptime / Idle"
+  zh: "运行 / 空闲"
+client_col_subs:
+  en: "Subs"
+  zh: "订阅"
+client_col_pending:
+  en: "Pending"
+  zh: "待发送"
+client_col_msgs:
+  en: "In / Out Msgs"
+  zh: "入 / 出消息"
+client_col_bytes:
+  en: "In / Out Bytes"
+  zh: "入 / 出字节"
+client_col_activity:
+  en: "Last Activity"
+  zh: "最后活动"
+client_col_rtt:
+  en: "RTT"
+  zh: "RTT"
+client_col_reason:
+  en: "Close Reason"
+  zh: "关闭原因"

--- a/assets/i18n/sidebar.yaml
+++ b/assets/i18n/sidebar.yaml
@@ -22,6 +22,9 @@ section_object_store:
 section_metrics:
   en: "Metrics"
   zh: "监控指标"
+section_clients:
+  en: "Clients"
+  zh: "客户端"
 
 # Resource openers
 open_publisher:

--- a/crates/app/src/app/actions.rs
+++ b/crates/app/src/app/actions.rs
@@ -11,7 +11,8 @@ use tokio_util::sync::CancellationToken;
 use crate::schema::kv_subject;
 use crate::settings::PubSubTabMode;
 use crate::tabs::{
-    MetricsState, PublisherState, SubscriberState, TabGuard, TabKind, next_backend_id,
+    ClientStatusState, MetricsState, PublisherState, SubscriberState, TabGuard, TabKind,
+    next_backend_id,
 };
 
 use super::{model::EasyNatsApp, util::same_tab};
@@ -298,6 +299,33 @@ impl EasyNatsApp {
             connection_id,
             connection_name,
             state: MetricsState::with_endpoint(endpoint),
+        };
+        self.open_or_focus_tab_kind(tab);
+    }
+
+    pub(crate) fn open_or_focus_clients_tab(&mut self, connection_id: u64) {
+        let connection_name = self.conn_name(connection_id);
+        let endpoint = self
+            .connection_metrics_endpoint(connection_id)
+            .unwrap_or_default();
+
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::Clients {
+                connection_id: existing_id,
+                connection_name: existing_name,
+                state,
+            } = tab
+                && *existing_id == connection_id
+            {
+                *existing_name = connection_name.clone();
+                state.set_endpoint(endpoint.clone());
+            }
+        }
+
+        let tab = TabKind::Clients {
+            connection_id,
+            connection_name,
+            state: ClientStatusState::with_endpoint(endpoint),
         };
         self.open_or_focus_tab_kind(tab);
     }

--- a/crates/app/src/app/actions/tests.rs
+++ b/crates/app/src/app/actions/tests.rs
@@ -78,6 +78,21 @@ fn count_metrics_tabs(app: &EasyNatsApp, connection_id: u64) -> usize {
         .count()
 }
 
+fn count_clients_tabs(app: &EasyNatsApp, connection_id: u64) -> usize {
+    app.dock_state
+        .iter_all_tabs()
+        .filter(|(_, tab)| {
+            matches!(
+                tab,
+                TabKind::Clients {
+                    connection_id: existing_id,
+                    ..
+                } if *existing_id == connection_id
+            )
+        })
+        .count()
+}
+
 #[test]
 fn publisher_reuses_existing_tab_when_configured() {
     let mut app = test_app(PubSubTabMode::ReuseExisting);
@@ -107,4 +122,15 @@ fn metrics_tab_focuses_existing_tab_for_same_connection() {
     app.open_or_focus_metrics_tab(7);
 
     assert_eq!(count_metrics_tabs(&app, 7), 1);
+}
+
+#[test]
+fn clients_tab_focuses_existing_tab_for_same_connection() {
+    let mut app = test_app(PubSubTabMode::NewTab);
+    push_metrics_connection(&mut app, 7);
+
+    app.open_or_focus_clients_tab(7);
+    app.open_or_focus_clients_tab(7);
+
+    assert_eq!(count_clients_tabs(&app, 7), 1);
 }

--- a/crates/app/src/app/events.rs
+++ b/crates/app/src/app/events.rs
@@ -127,6 +127,24 @@ impl EasyNatsApp {
                 } => {
                     self.apply_metrics_snapshot(connection_id, *snapshot);
                 }
+                BackendEvent::ClientStatusPageLoaded {
+                    connection_id,
+                    page,
+                } => {
+                    self.apply_client_status_page(connection_id, *page);
+                }
+                BackendEvent::ClientStatusDetailLoaded {
+                    connection_id,
+                    detail,
+                } => {
+                    self.apply_client_status_detail(connection_id, *detail);
+                }
+                BackendEvent::ClientStatusError {
+                    connection_id,
+                    error,
+                } => {
+                    self.apply_client_status_error(connection_id, *error);
+                }
                 BackendEvent::KvBucketsListed {
                     connection_id,
                     buckets,

--- a/crates/app/src/app/metrics_results.rs
+++ b/crates/app/src/app/metrics_results.rs
@@ -1,4 +1,6 @@
-use nats_backend::MetricsSnapshot;
+use nats_backend::{
+    ClientStatusDetail, ClientStatusPage, ClientStatusRequestError, MetricsSnapshot,
+};
 
 use crate::tabs::TabKind;
 
@@ -15,6 +17,56 @@ impl EasyNatsApp {
                 && *cid == connection_id
             {
                 state.apply_snapshot(snapshot.clone());
+            }
+        }
+    }
+
+    pub(crate) fn apply_client_status_page(&mut self, connection_id: u64, page: ClientStatusPage) {
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::Clients {
+                connection_id: cid,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+            {
+                state.apply_page(page.clone());
+            }
+        }
+    }
+
+    pub(crate) fn apply_client_status_detail(
+        &mut self,
+        connection_id: u64,
+        detail: ClientStatusDetail,
+    ) {
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::Clients {
+                connection_id: cid,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+            {
+                state.apply_detail(detail.clone());
+            }
+        }
+    }
+
+    pub(crate) fn apply_client_status_error(
+        &mut self,
+        connection_id: u64,
+        error: ClientStatusRequestError,
+    ) {
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::Clients {
+                connection_id: cid,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+            {
+                state.apply_error(error.clone());
             }
         }
     }

--- a/crates/app/src/app/sidebar.rs
+++ b/crates/app/src/app/sidebar.rs
@@ -22,6 +22,7 @@ pub(crate) enum SidebarAction {
     OpenObjStoreBucketCreate(u64),
     OpenServerInfo(u64),
     OpenMetrics(u64),
+    OpenClients(u64),
 }
 
 pub(crate) fn render_sidebar(app: &mut EasyNatsApp, ui: &mut egui::Ui) {
@@ -179,6 +180,7 @@ fn render_resource_tree(
         render_kv_section(app, ui, id, name, action);
         render_obj_store_section(app, ui, id, name, action);
         render_metrics_entry(app, ui, id, action);
+        render_clients_entry(app, ui, id, action);
         if render_sidebar_leaf(ui, "ℹ", t("server_info.title")).clicked() {
             *action = Some(SidebarAction::OpenServerInfo(id));
         }
@@ -197,6 +199,21 @@ fn render_metrics_entry(
 
     if render_sidebar_leaf(ui, "◔", t("sidebar.section_metrics")).clicked() {
         *action = Some(SidebarAction::OpenMetrics(id));
+    }
+}
+
+fn render_clients_entry(
+    app: &mut EasyNatsApp,
+    ui: &mut egui::Ui,
+    id: u64,
+    action: &mut Option<SidebarAction>,
+) {
+    if app.connection_metrics_endpoint(id).is_none() {
+        return;
+    }
+
+    if render_sidebar_leaf(ui, "@", t("sidebar.section_clients")).clicked() {
+        *action = Some(SidebarAction::OpenClients(id));
     }
 }
 
@@ -438,6 +455,9 @@ fn apply_sidebar_action(app: &mut EasyNatsApp, action: Option<SidebarAction>) {
         }
         Some(SidebarAction::OpenMetrics(id)) => {
             app.open_or_focus_metrics_tab(id);
+        }
+        Some(SidebarAction::OpenClients(id)) => {
+            app.open_or_focus_clients_tab(id);
         }
         None => {}
     }

--- a/crates/app/src/app/util.rs
+++ b/crates/app/src/app/util.rs
@@ -58,6 +58,14 @@ pub(crate) fn same_tab(a: &TabKind, b: &TabKind) -> bool {
                 connection_id: a2, ..
             },
         ) => a1 == a2,
+        (
+            TabKind::Clients {
+                connection_id: a1, ..
+            },
+            TabKind::Clients {
+                connection_id: a2, ..
+            },
+        ) => a1 == a2,
         (TabKind::SearchWorkspace { .. }, TabKind::SearchWorkspace { .. }) => true,
         (TabKind::MessageSchemas { .. }, TabKind::MessageSchemas { .. }) => true,
         (TabKind::Settings, TabKind::Settings) => true,

--- a/crates/app/src/tabs/metrics.rs
+++ b/crates/app/src/tabs/metrics.rs
@@ -33,7 +33,6 @@ pub fn metrics_ui(
         }
     });
     ui.add_space(6.0);
-
     ui.horizontal_wrapped(|ui| {
         auto_refresh_ui(ui, "metrics_auto_refresh", &mut state.auto_refresh);
         if let Some((label, fill)) = status_badge(state, ui.visuals()) {

--- a/crates/app/src/tabs/metrics_clients.rs
+++ b/crates/app/src/tabs/metrics_clients.rs
@@ -1,0 +1,651 @@
+use std::time::Duration;
+
+use eframe::egui;
+use egui::RichText;
+use nats_backend::{
+    BackendCommand, BackendHandle, ClientConnectionState, ClientStatusQuery, ClientStatusRow,
+    ClientStatusSort,
+};
+
+use crate::i18n::t;
+
+use super::common::{auto_refresh_ui, format_bytes};
+use super::types::ClientStatusState;
+
+pub(crate) fn clients_ui(
+    ui: &mut egui::Ui,
+    connection_id: u64,
+    state: &mut ClientStatusState,
+    backend: &BackendHandle,
+) {
+    ui.heading(t("common.tab_clients"));
+    ui.add_space(6.0);
+
+    if !state.endpoint_configured() {
+        render_empty_state(ui, t("metrics.no_endpoint"));
+        return;
+    }
+
+    maybe_start_initial_client_refresh(connection_id, state, backend);
+    render_client_controls(ui, connection_id, state, backend);
+    handle_client_auto_refresh(ui, connection_id, state, backend);
+    ui.add_space(10.0);
+
+    if let Some(error) = state.error() {
+        let text = if state.is_stale() {
+            t("metrics.client_error_stale")
+        } else {
+            t("metrics.client_error_unavailable")
+        };
+        ui.label(
+            RichText::new(format!("{text}: {}", error.message))
+                .color(ui.visuals().warn_fg_color)
+                .strong(),
+        );
+        ui.add_space(6.0);
+    }
+
+    if state.loading && state.page().is_none() {
+        render_loading_state(ui, t("metrics.client_loading"));
+        return;
+    }
+
+    if let Some(page) = state.page() {
+        let page_total = page.total;
+        let page_offset = page.offset;
+        let page_limit = page.limit;
+        let rows = page.clients.clone();
+
+        ui.horizontal_wrapped(|ui| {
+            ui.weak(format!(
+                "{} {}-{} / {}",
+                t("metrics.client_page_summary"),
+                page_offset.saturating_add(1),
+                page_offset.saturating_add(rows.len()),
+                page_total
+            ));
+        });
+        ui.add_space(6.0);
+
+        let selected = render_client_table(ui, state.selected_client_id(), &rows);
+        if let Some(client_id) = selected {
+            start_client_detail_refresh(connection_id, state, backend, client_id);
+        }
+
+        ui.add_space(12.0);
+        render_client_detail(ui, state);
+
+        if page_total == 0 || page_limit == 0 || rows.is_empty() && !state.loading {
+            render_empty_state(ui, t("metrics.client_empty"));
+        }
+    } else if !state.loading {
+        render_empty_state(ui, t("metrics.client_not_loaded"));
+    }
+}
+
+fn render_client_controls(
+    ui: &mut egui::Ui,
+    connection_id: u64,
+    state: &mut ClientStatusState,
+    backend: &BackendHandle,
+) {
+    let mut trigger_refresh = false;
+    ui.horizontal_wrapped(|ui| {
+        auto_refresh_ui(ui, "clients_auto_refresh", &mut state.auto_refresh);
+
+        let mut selected_state = state.query().state;
+        egui::ComboBox::from_id_salt("clients_state")
+            .width(90.0)
+            .selected_text(client_state_label(selected_state))
+            .show_ui(ui, |ui| {
+                ui.selectable_value(
+                    &mut selected_state,
+                    ClientConnectionState::Open,
+                    client_state_label(ClientConnectionState::Open),
+                );
+                ui.selectable_value(
+                    &mut selected_state,
+                    ClientConnectionState::Closed,
+                    client_state_label(ClientConnectionState::Closed),
+                );
+                ui.selectable_value(
+                    &mut selected_state,
+                    ClientConnectionState::Any,
+                    client_state_label(ClientConnectionState::Any),
+                );
+            });
+        if selected_state != state.query().state {
+            state.set_state(selected_state);
+            trigger_refresh = true;
+        }
+
+        let mut selected_sort = state.query().sort;
+        egui::ComboBox::from_id_salt("clients_sort")
+            .width(120.0)
+            .selected_text(client_sort_label(selected_sort))
+            .show_ui(ui, |ui| {
+                for sort in client_sort_options(state.query().state) {
+                    ui.selectable_value(&mut selected_sort, sort, client_sort_label(sort));
+                }
+            });
+        if selected_sort != state.query().sort {
+            state.set_sort(selected_sort);
+            trigger_refresh = true;
+        }
+
+        let mut selected_page_size = state.query().page_size;
+        egui::ComboBox::from_id_salt("clients_page_size")
+            .width(72.0)
+            .selected_text(selected_page_size.to_string())
+            .show_ui(ui, |ui| {
+                for page_size in ClientStatusQuery::PAGE_SIZE_OPTIONS {
+                    ui.selectable_value(&mut selected_page_size, page_size, page_size.to_string());
+                }
+            });
+        if selected_page_size != state.query().page_size {
+            state.set_page_size(selected_page_size);
+            trigger_refresh = true;
+        }
+
+        if ui
+            .add_enabled(!state.loading, egui::Button::new("↻"))
+            .on_hover_text(t("metrics.client_refresh"))
+            .clicked()
+        {
+            trigger_refresh = true;
+        }
+
+        let has_previous = state.query().offset > 0;
+        if ui
+            .add_enabled(has_previous && !state.loading, egui::Button::new("←"))
+            .on_hover_text(t("metrics.client_previous"))
+            .clicked()
+        {
+            state.previous_page();
+            trigger_refresh = true;
+        }
+
+        let has_next = state
+            .page()
+            .is_some_and(|page| page.offset.saturating_add(page.limit) < page.total as usize);
+        if ui
+            .add_enabled(has_next && !state.loading, egui::Button::new("→"))
+            .on_hover_text(t("metrics.client_next"))
+            .clicked()
+        {
+            state.next_page();
+            trigger_refresh = true;
+        }
+
+        if state.loading {
+            ui.spinner();
+        }
+    });
+
+    if trigger_refresh {
+        start_client_page_refresh(connection_id, state, backend);
+    }
+}
+
+fn maybe_start_initial_client_refresh(
+    connection_id: u64,
+    state: &mut ClientStatusState,
+    backend: &BackendHandle,
+) {
+    if state.page().is_none()
+        && state.error().is_none()
+        && !state.loading
+        && state.endpoint_configured()
+    {
+        start_client_page_refresh(connection_id, state, backend);
+    }
+}
+
+fn handle_client_auto_refresh(
+    ui: &mut egui::Ui,
+    connection_id: u64,
+    state: &mut ClientStatusState,
+    backend: &BackendHandle,
+) {
+    if state.should_refresh() {
+        start_client_page_refresh(connection_id, state, backend);
+    }
+
+    if state.auto_refresh.enabled {
+        ui.ctx().request_repaint_after(Duration::from_secs(1));
+    }
+}
+
+fn start_client_page_refresh(
+    connection_id: u64,
+    state: &mut ClientStatusState,
+    backend: &BackendHandle,
+) {
+    state.begin_page_refresh();
+    backend.send(BackendCommand::FetchClientStatusPage {
+        connection_id,
+        endpoint: state.endpoint().to_string(),
+        query: state.query().clone(),
+    });
+}
+
+fn start_client_detail_refresh(
+    connection_id: u64,
+    state: &mut ClientStatusState,
+    backend: &BackendHandle,
+    client_id: u64,
+) {
+    state.begin_detail_refresh(client_id);
+    backend.send(BackendCommand::FetchClientStatusDetail {
+        connection_id,
+        endpoint: state.endpoint().to_string(),
+        query: state.detail_query(client_id),
+    });
+}
+
+fn render_client_table(
+    ui: &mut egui::Ui,
+    selected_client_id: Option<u64>,
+    rows: &[ClientStatusRow],
+) -> Option<u64> {
+    let mut selected = None;
+    egui::ScrollArea::both()
+        .id_salt("metrics_client_table_scroll")
+        .auto_shrink([false, false])
+        .max_height(260.0)
+        .show(ui, |ui| {
+            render_table_header(ui);
+            for (row_index, row) in rows.iter().enumerate() {
+                if render_client_row(ui, row_index, selected_client_id, row) {
+                    selected = Some(row.client_id);
+                }
+            }
+        });
+    selected
+}
+
+fn render_table_header(ui: &mut egui::Ui) {
+    ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = CLIENT_TABLE_SPACING;
+        for column in CLIENT_TABLE_COLUMNS {
+            ui.add_sized(
+                [column.width, CLIENT_TABLE_ROW_HEIGHT],
+                egui::Label::new(RichText::new(t(column.label_key)).strong()).truncate(),
+            )
+            .on_hover_text(t(column.label_key));
+        }
+    });
+}
+
+fn render_client_row(
+    ui: &mut egui::Ui,
+    row_index: usize,
+    selected_client_id: Option<u64>,
+    row: &ClientStatusRow,
+) -> bool {
+    let selected = selected_client_id == Some(row.client_id);
+    let cells = [
+        row.client_id.to_string(),
+        client_state_label(row.state).to_string(),
+        identity_label(row),
+        row.remote_address().unwrap_or_else(missing_label),
+        format!(
+            "{} / {}",
+            row.uptime.as_deref().unwrap_or(t("metrics.client_missing")),
+            row.idle.as_deref().unwrap_or(t("metrics.client_missing"))
+        ),
+        format_opt_count(row.subscriptions),
+        row.pending_bytes
+            .map(format_bytes)
+            .unwrap_or_else(missing_label),
+        format!(
+            "{} / {}",
+            format_opt_count(row.in_msgs),
+            format_opt_count(row.out_msgs)
+        ),
+        format!(
+            "{} / {}",
+            row.in_bytes.map(format_bytes).unwrap_or_else(missing_label),
+            row.out_bytes
+                .map(format_bytes)
+                .unwrap_or_else(missing_label)
+        ),
+        row.last_activity
+            .as_deref()
+            .unwrap_or(t("metrics.client_missing"))
+            .to_string(),
+        row.rtt
+            .as_deref()
+            .unwrap_or(t("metrics.client_missing"))
+            .to_string(),
+        row.closed_reason
+            .as_deref()
+            .unwrap_or(t("metrics.client_missing"))
+            .to_string(),
+    ];
+
+    let row_size = egui::vec2(client_table_width(), CLIENT_TABLE_ROW_HEIGHT);
+    let (row_rect, _) = ui.allocate_exact_size(row_size, egui::Sense::hover());
+    let hovered = ui.rect_contains_pointer(row_rect);
+    if let Some(fill) = client_row_fill(ui, selected, hovered, row_index) {
+        ui.painter().rect_filled(row_rect, 2.0, fill);
+    }
+
+    ui.scope_builder(
+        egui::UiBuilder::new()
+            .max_rect(row_rect)
+            .layout(egui::Layout::left_to_right(egui::Align::Center)),
+        |ui| {
+            ui.spacing_mut().item_spacing.x = CLIENT_TABLE_SPACING;
+            let text_color = if selected {
+                Some(ui.visuals().selection.stroke.color)
+            } else {
+                None
+            };
+            for (cell, column) in cells.into_iter().zip(CLIENT_TABLE_COLUMNS) {
+                let mut text = RichText::new(cell);
+                if column.monospace {
+                    text = text.monospace();
+                }
+                if let Some(color) = text_color {
+                    text = text.color(color);
+                }
+                ui.add_sized(
+                    [column.width, CLIENT_TABLE_ROW_HEIGHT],
+                    egui::Label::new(text).truncate(),
+                );
+            }
+        },
+    );
+
+    ui.interact(
+        row_rect,
+        ui.id().with(("client_row", row.client_id, row_index)),
+        egui::Sense::click(),
+    )
+    .on_hover_text(t("metrics.client_select_hint"))
+    .clicked()
+}
+
+#[derive(Clone, Copy)]
+struct ClientTableColumn {
+    label_key: &'static str,
+    width: f32,
+    monospace: bool,
+}
+
+const CLIENT_TABLE_ROW_HEIGHT: f32 = 24.0;
+const CLIENT_TABLE_SPACING: f32 = 14.0;
+const CLIENT_TABLE_COLUMNS: &[ClientTableColumn] = &[
+    ClientTableColumn {
+        label_key: "metrics.client_col_client",
+        width: 72.0,
+        monospace: true,
+    },
+    ClientTableColumn {
+        label_key: "metrics.client_col_state",
+        width: 90.0,
+        monospace: false,
+    },
+    ClientTableColumn {
+        label_key: "metrics.client_col_identity",
+        width: 210.0,
+        monospace: false,
+    },
+    ClientTableColumn {
+        label_key: "metrics.client_col_address",
+        width: 170.0,
+        monospace: true,
+    },
+    ClientTableColumn {
+        label_key: "metrics.client_col_uptime_idle",
+        width: 120.0,
+        monospace: false,
+    },
+    ClientTableColumn {
+        label_key: "metrics.client_col_subs",
+        width: 72.0,
+        monospace: true,
+    },
+    ClientTableColumn {
+        label_key: "metrics.client_col_pending",
+        width: 110.0,
+        monospace: false,
+    },
+    ClientTableColumn {
+        label_key: "metrics.client_col_msgs",
+        width: 125.0,
+        monospace: true,
+    },
+    ClientTableColumn {
+        label_key: "metrics.client_col_bytes",
+        width: 135.0,
+        monospace: false,
+    },
+    ClientTableColumn {
+        label_key: "metrics.client_col_activity",
+        width: 230.0,
+        monospace: true,
+    },
+    ClientTableColumn {
+        label_key: "metrics.client_col_rtt",
+        width: 90.0,
+        monospace: true,
+    },
+    ClientTableColumn {
+        label_key: "metrics.client_col_reason",
+        width: 140.0,
+        monospace: false,
+    },
+];
+
+fn client_table_width() -> f32 {
+    let column_width: f32 = CLIENT_TABLE_COLUMNS.iter().map(|column| column.width).sum();
+    let spacing = CLIENT_TABLE_SPACING * CLIENT_TABLE_COLUMNS.len().saturating_sub(1) as f32;
+    column_width + spacing
+}
+
+fn client_row_fill(
+    ui: &egui::Ui,
+    selected: bool,
+    hovered: bool,
+    row_index: usize,
+) -> Option<egui::Color32> {
+    if selected {
+        return Some(ui.visuals().selection.bg_fill.gamma_multiply(0.65));
+    }
+
+    if hovered {
+        return Some(ui.visuals().widgets.hovered.bg_fill.gamma_multiply(0.35));
+    }
+
+    if row_index % 2 == 1 {
+        return Some(ui.visuals().faint_bg_color);
+    }
+
+    None
+}
+
+fn render_client_detail(ui: &mut egui::Ui, state: &mut ClientStatusState) {
+    ui.separator();
+    ui.horizontal(|ui| {
+        ui.label(RichText::new(t("metrics.client_detail")).strong());
+        if state.detail_loading {
+            ui.spinner();
+        }
+        if state.selected_client_id().is_some() && ui.small_button(t("common.clear")).clicked() {
+            state.clear_selected_client();
+        }
+    });
+    ui.add_space(4.0);
+
+    if state.detail_loading && state.detail().is_none() {
+        render_loading_state(ui, t("metrics.client_detail_loading"));
+        return;
+    }
+
+    let Some(detail) = state.detail() else {
+        ui.weak(t("metrics.client_select_hint"));
+        return;
+    };
+
+    if state.selected_detail_stale() {
+        ui.label(RichText::new(t("metrics.client_detail_stale")).color(ui.visuals().warn_fg_color));
+        ui.add_space(4.0);
+    }
+
+    let client = &detail.client;
+    egui::Grid::new("metrics_client_detail_grid")
+        .num_columns(2)
+        .spacing([12.0, 4.0])
+        .show(ui, |ui| {
+            detail_row(
+                ui,
+                t("metrics.client_col_client"),
+                &client.client_id.to_string(),
+            );
+            detail_row(
+                ui,
+                t("metrics.client_col_state"),
+                client_state_label(client.state),
+            );
+            detail_row(
+                ui,
+                t("metrics.client_col_identity"),
+                &identity_label(client),
+            );
+            detail_row(
+                ui,
+                t("metrics.client_col_address"),
+                &client.remote_address().unwrap_or_else(missing_label),
+            );
+            detail_row(
+                ui,
+                t("metrics.client_col_uptime_idle"),
+                &format!(
+                    "{} / {}",
+                    client
+                        .uptime
+                        .as_deref()
+                        .unwrap_or(t("metrics.client_missing")),
+                    client
+                        .idle
+                        .as_deref()
+                        .unwrap_or(t("metrics.client_missing"))
+                ),
+            );
+            detail_row(
+                ui,
+                t("metrics.client_col_pending"),
+                &format_opt_count(client.pending_bytes),
+            );
+            detail_row(
+                ui,
+                t("metrics.client_col_activity"),
+                client
+                    .last_activity
+                    .as_deref()
+                    .unwrap_or(t("metrics.client_missing")),
+            );
+            detail_row(
+                ui,
+                t("metrics.client_col_rtt"),
+                client.rtt.as_deref().unwrap_or(t("metrics.client_missing")),
+            );
+        });
+
+    ui.add_space(8.0);
+    ui.label(RichText::new(t("metrics.client_subscriptions")).strong());
+    if client.subscription_details.is_empty() {
+        ui.weak(t("metrics.client_no_subscriptions"));
+    } else {
+        egui::ScrollArea::vertical()
+            .id_salt("metrics_client_subscriptions")
+            .max_height(120.0)
+            .show(ui, |ui| {
+                for subscription in &client.subscription_details {
+                    ui.monospace(&subscription.subject);
+                }
+            });
+    }
+}
+
+fn detail_row(ui: &mut egui::Ui, label: &str, value: &str) {
+    ui.weak(label);
+    ui.label(value);
+    ui.end_row();
+}
+
+fn identity_label(row: &ClientStatusRow) -> String {
+    let mut parts = Vec::new();
+    if let Some(name) = &row.name {
+        parts.push(name.clone());
+    }
+    if let Some(user) = &row.user {
+        parts.push(user.clone());
+    }
+    if let Some(account) = &row.account {
+        parts.push(format!("@{account}"));
+    }
+    if parts.is_empty() {
+        missing_label()
+    } else {
+        parts.join(" ")
+    }
+}
+
+fn client_state_label(state: ClientConnectionState) -> &'static str {
+    match state {
+        ClientConnectionState::Open => t("metrics.client_state_open"),
+        ClientConnectionState::Closed => t("metrics.client_state_closed"),
+        ClientConnectionState::Any => t("metrics.client_state_any"),
+    }
+}
+
+fn client_sort_label(sort: ClientStatusSort) -> &'static str {
+    match sort {
+        ClientStatusSort::Cid => t("metrics.client_sort_cid"),
+        ClientStatusSort::Start => t("metrics.client_sort_start"),
+        ClientStatusSort::Subscriptions => t("metrics.client_sort_subs"),
+        ClientStatusSort::PendingBytes => t("metrics.client_sort_pending"),
+        ClientStatusSort::InMessages => t("metrics.client_sort_in_msgs"),
+        ClientStatusSort::OutMessages => t("metrics.client_sort_out_msgs"),
+        ClientStatusSort::InBytes => t("metrics.client_sort_in_bytes"),
+        ClientStatusSort::OutBytes => t("metrics.client_sort_out_bytes"),
+        ClientStatusSort::LastActivity => t("metrics.client_sort_last"),
+        ClientStatusSort::Idle => t("metrics.client_sort_idle"),
+        ClientStatusSort::Uptime => t("metrics.client_sort_uptime"),
+        ClientStatusSort::Stop => t("metrics.client_sort_stop"),
+        ClientStatusSort::Reason => t("metrics.client_sort_reason"),
+    }
+}
+
+fn client_sort_options(state: ClientConnectionState) -> impl Iterator<Item = ClientStatusSort> {
+    ClientStatusSort::ALL
+        .into_iter()
+        .filter(move |sort| sort.is_allowed_for_state(state))
+}
+
+fn format_opt_count(value: Option<u64>) -> String {
+    value.map_or_else(missing_label, |value| value.to_string())
+}
+
+fn missing_label() -> String {
+    t("metrics.client_missing").to_string()
+}
+
+fn render_loading_state(ui: &mut egui::Ui, message: &str) {
+    ui.vertical_centered(|ui| {
+        ui.add_space(16.0);
+        ui.spinner();
+        ui.add_space(6.0);
+        ui.label(message);
+    });
+}
+
+fn render_empty_state(ui: &mut egui::Ui, message: &str) {
+    ui.vertical_centered(|ui| {
+        ui.add_space(16.0);
+        ui.weak(message);
+    });
+}

--- a/crates/app/src/tabs/mod.rs
+++ b/crates/app/src/tabs/mod.rs
@@ -4,6 +4,7 @@ mod kv;
 pub(crate) mod log_viewer;
 mod message_schemas;
 mod metrics;
+mod metrics_clients;
 mod object_store;
 mod publisher;
 mod search_workspace;
@@ -20,6 +21,7 @@ pub use guard::{TabGuard, next_backend_id, next_generation};
 pub use kv::kv_bucket_ui;
 pub use message_schemas::message_schemas_ui;
 pub use metrics::metrics_ui;
+pub(crate) use metrics_clients::clients_ui;
 pub use object_store::obj_store_bucket_ui;
 pub use publisher::publisher_ui;
 pub(crate) use search_workspace::{search_workspace_ui, source_snapshot_from_tab};
@@ -27,8 +29,8 @@ pub use server_info::server_info_ui;
 pub use stream::stream_ui;
 pub use subscriber::subscriber_ui;
 pub use types::{
-    AppTabViewer, KvBucketState, MessageSchemasState, MetricsState, ObjectStoreBucketState,
-    PublisherState, ReceivedMessage, ResponseData, SearchResultLocator, SearchSourceId,
-    SearchSourceSnapshot, SearchWorkspaceState, ServerInfoState, StreamState, SubscriberState,
-    TabAction, TabKind,
+    AppTabViewer, ClientStatusState, KvBucketState, MessageSchemasState, MetricsState,
+    ObjectStoreBucketState, PublisherState, ReceivedMessage, ResponseData, SearchResultLocator,
+    SearchSourceId, SearchSourceSnapshot, SearchWorkspaceState, ServerInfoState, StreamState,
+    SubscriberState, TabAction, TabKind,
 };

--- a/crates/app/src/tabs/types.rs
+++ b/crates/app/src/tabs/types.rs
@@ -1,6 +1,8 @@
+mod client_status_state;
 mod metrics_state;
 mod tab_kind;
 
+pub use client_status_state::ClientStatusState;
 pub use metrics_state::MetricsState;
 pub use tab_kind::{AppTabViewer, TabKind};
 

--- a/crates/app/src/tabs/types/client_status_state.rs
+++ b/crates/app/src/tabs/types/client_status_state.rs
@@ -1,0 +1,630 @@
+use std::time::Instant;
+
+use nats_backend::{
+    ClientConnectionState, ClientStatusDetail, ClientStatusPage, ClientStatusQuery,
+    ClientStatusRequestError, ClientStatusSort,
+};
+
+use super::AutoRefresh;
+
+#[derive(Debug, Default)]
+pub struct ClientStatusState {
+    endpoint: String,
+    query: ClientStatusQuery,
+    page: Option<Box<ClientStatusPage>>,
+    detail: Option<Box<ClientStatusDetail>>,
+    error: Option<Box<ClientStatusRequestError>>,
+    selected_client_id: Option<u64>,
+    selected_detail_stale: bool,
+    pub loading: bool,
+    pub detail_loading: bool,
+    pub auto_refresh: AutoRefresh,
+}
+
+impl ClientStatusState {
+    pub fn with_endpoint(endpoint: String) -> Self {
+        let mut state = Self {
+            endpoint: normalize_monitoring_endpoint(endpoint),
+            ..Default::default()
+        };
+        state.auto_refresh.enabled = true;
+        state.auto_refresh.interval_secs = 5;
+        state
+    }
+
+    pub fn endpoint(&self) -> &str {
+        self.endpoint.as_str()
+    }
+
+    pub fn endpoint_configured(&self) -> bool {
+        !self.endpoint.trim().is_empty()
+    }
+
+    pub fn set_endpoint(&mut self, endpoint: String) {
+        let endpoint = normalize_monitoring_endpoint(endpoint);
+        if self.endpoint == endpoint {
+            return;
+        }
+        self.endpoint = endpoint;
+        self.clear_status();
+    }
+
+    pub fn query(&self) -> &ClientStatusQuery {
+        &self.query
+    }
+
+    pub fn detail_query(&self, client_id: u64) -> ClientStatusQuery {
+        let mut query = self.query.clone();
+        query.client_id = Some(client_id);
+        query.include_subscriptions = true;
+        query.include_auth = true;
+        query
+    }
+
+    pub fn set_state(&mut self, state: ClientConnectionState) {
+        if self.query.state != state {
+            self.query.state = state;
+            if !self.query.sort.is_allowed_for_state(state) {
+                self.query.sort = ClientStatusSort::Cid;
+            }
+            self.query.offset = 0;
+            self.clear_result_for_query_change();
+        }
+    }
+
+    pub fn set_sort(&mut self, sort: ClientStatusSort) {
+        let sort = if sort.is_allowed_for_state(self.query.state) {
+            sort
+        } else {
+            ClientStatusSort::Cid
+        };
+        if self.query.sort != sort {
+            self.query.sort = sort;
+            self.clear_result_for_query_change();
+        }
+    }
+
+    pub fn set_page_size(&mut self, page_size: usize) {
+        let page_size = page_size.clamp(1, ClientStatusQuery::MAX_PAGE_SIZE);
+        if self.query.page_size != page_size {
+            self.query.page_size = page_size;
+            self.query.offset = 0;
+            self.clear_result_for_query_change();
+        }
+    }
+
+    pub fn next_page(&mut self) {
+        self.query.offset = self.query.offset.saturating_add(self.query.page_size);
+        self.clear_result_for_query_change();
+    }
+
+    pub fn previous_page(&mut self) {
+        self.query.offset = self.query.offset.saturating_sub(self.query.page_size);
+        self.clear_result_for_query_change();
+    }
+
+    pub fn begin_page_refresh(&mut self) {
+        self.loading = true;
+        self.error = None;
+        self.auto_refresh.mark_refreshed();
+    }
+
+    pub fn begin_detail_refresh(&mut self, client_id: u64) {
+        self.select_client(client_id);
+        self.detail_loading = true;
+        self.error = None;
+    }
+
+    pub fn apply_page(&mut self, page: ClientStatusPage) {
+        if !self.endpoint_matches(&page.endpoint) || page.query != self.query {
+            return;
+        }
+
+        self.loading = false;
+        self.error = None;
+        if let Some(selected_id) = self.selected_client_id {
+            let still_visible = page
+                .clients
+                .iter()
+                .any(|client| client.client_id == selected_id);
+            self.selected_detail_stale = !still_visible && self.detail.is_some();
+        }
+        self.page = Some(Box::new(page));
+    }
+
+    pub fn apply_detail(&mut self, detail: ClientStatusDetail) {
+        let client_id = detail.query.client_id.unwrap_or(detail.client.client_id);
+        if !self.endpoint_matches(&detail.endpoint) || self.selected_client_id != Some(client_id) {
+            return;
+        }
+
+        self.detail_loading = false;
+        self.selected_detail_stale = false;
+        self.error = None;
+        self.detail = Some(Box::new(detail));
+    }
+
+    pub fn apply_error(&mut self, error: ClientStatusRequestError) {
+        if let Some(client_id) = error.query.client_id {
+            if !self.endpoint_matches(&error.endpoint) || self.selected_client_id != Some(client_id)
+            {
+                return;
+            }
+            self.detail_loading = false;
+            if self.detail.is_some() {
+                self.selected_detail_stale = true;
+            }
+        } else {
+            if !self.endpoint_matches(&error.endpoint) || error.query != self.query {
+                return;
+            }
+            self.loading = false;
+        }
+        self.error = Some(Box::new(error));
+    }
+
+    pub fn select_client(&mut self, client_id: u64) {
+        if self.selected_client_id == Some(client_id) {
+            return;
+        }
+        self.selected_client_id = Some(client_id);
+        self.detail = None;
+        self.detail_loading = false;
+        self.selected_detail_stale = false;
+    }
+
+    pub fn clear_selected_client(&mut self) {
+        self.selected_client_id = None;
+        self.detail = None;
+        self.detail_loading = false;
+        self.selected_detail_stale = false;
+    }
+
+    pub fn page(&self) -> Option<&ClientStatusPage> {
+        self.page.as_deref()
+    }
+
+    pub fn detail(&self) -> Option<&ClientStatusDetail> {
+        self.detail.as_deref()
+    }
+
+    pub fn error(&self) -> Option<&ClientStatusRequestError> {
+        self.error.as_deref()
+    }
+
+    pub fn selected_client_id(&self) -> Option<u64> {
+        self.selected_client_id
+    }
+
+    pub fn selected_detail_stale(&self) -> bool {
+        self.selected_detail_stale
+    }
+
+    pub fn is_stale(&self) -> bool {
+        self.error.is_some() && self.page.is_some()
+    }
+
+    pub fn should_refresh(&self) -> bool {
+        self.endpoint_configured() && !self.loading && self.auto_refresh.should_refresh()
+    }
+
+    fn clear_status(&mut self) {
+        self.query = ClientStatusQuery::default();
+        self.page = None;
+        self.detail = None;
+        self.error = None;
+        self.selected_client_id = None;
+        self.selected_detail_stale = false;
+        self.loading = false;
+        self.detail_loading = false;
+        self.auto_refresh.last_refresh = Instant::now();
+    }
+
+    fn clear_result_for_query_change(&mut self) {
+        self.page = None;
+        self.detail = None;
+        self.error = None;
+        self.selected_client_id = None;
+        self.selected_detail_stale = false;
+        self.loading = false;
+        self.detail_loading = false;
+    }
+
+    fn endpoint_matches(&self, endpoint: &str) -> bool {
+        normalize_monitoring_endpoint(endpoint) == self.endpoint
+    }
+}
+
+fn normalize_monitoring_endpoint(endpoint: impl AsRef<str>) -> String {
+    let endpoint = endpoint.as_ref();
+    endpoint.trim().trim_end_matches('/').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, SystemTime};
+
+    use nats_backend::{
+        ClientConnectionState, ClientStatusDetail, ClientStatusPage, ClientStatusQuery,
+        ClientStatusRequestError, ClientStatusRow, ClientStatusSort,
+    };
+
+    use super::ClientStatusState;
+
+    fn sample_client_row(client_id: u64) -> ClientStatusRow {
+        ClientStatusRow {
+            client_id,
+            state: ClientConnectionState::Open,
+            name: Some(format!("client-{client_id}")),
+            account: Some("APP".to_string()),
+            user: Some("alice".to_string()),
+            ip: Some("127.0.0.1".to_string()),
+            port: Some(4200),
+            uptime: Some("1m".to_string()),
+            idle: Some("1s".to_string()),
+            last_activity: Some("2026-05-07T10:00:00Z".to_string()),
+            rtt: Some("1ms".to_string()),
+            subscriptions: Some(3),
+            pending_bytes: Some(0),
+            in_msgs: Some(10),
+            out_msgs: Some(11),
+            in_bytes: Some(100),
+            out_bytes: Some(110),
+            language: Some("rust".to_string()),
+            version: Some("1.0.0".to_string()),
+            closed_at: None,
+            closed_reason: None,
+            subscription_details: Vec::new(),
+        }
+    }
+
+    fn sample_client_page(endpoint: &str, clients: Vec<ClientStatusRow>) -> ClientStatusPage {
+        ClientStatusPage {
+            endpoint: endpoint.to_string(),
+            collected_at: SystemTime::UNIX_EPOCH,
+            query: ClientStatusQuery::default(),
+            total: clients.len() as u64,
+            offset: 0,
+            limit: 100,
+            clients,
+        }
+    }
+
+    fn sample_client_page_with_query(
+        endpoint: &str,
+        query: ClientStatusQuery,
+        clients: Vec<ClientStatusRow>,
+    ) -> ClientStatusPage {
+        ClientStatusPage {
+            endpoint: endpoint.to_string(),
+            collected_at: SystemTime::UNIX_EPOCH,
+            query,
+            total: clients.len() as u64,
+            offset: 0,
+            limit: 100,
+            clients,
+        }
+    }
+
+    fn sample_client_detail(endpoint: &str, client_id: u64) -> ClientStatusDetail {
+        ClientStatusDetail {
+            endpoint: endpoint.to_string(),
+            collected_at: SystemTime::UNIX_EPOCH,
+            query: ClientStatusQuery::detail(client_id),
+            client: sample_client_row(client_id),
+        }
+    }
+
+    #[test]
+    fn client_status_state_clears_result_when_endpoint_changes() {
+        let mut state = ClientStatusState::with_endpoint("http://localhost:8222".to_string());
+        state.apply_page(sample_client_page(
+            "http://localhost:8222",
+            vec![sample_client_row(1)],
+        ));
+        state.select_client(1);
+        state.apply_detail(sample_client_detail("http://localhost:8222", 1));
+
+        state.set_endpoint("http://localhost:9222".to_string());
+
+        assert_eq!(state.endpoint(), "http://localhost:9222");
+        assert!(state.page().is_none());
+        assert!(state.detail().is_none());
+        assert_eq!(state.selected_client_id(), None);
+    }
+
+    #[test]
+    fn client_status_endpoint_is_normalized_for_page_responses() {
+        let mut state = ClientStatusState::with_endpoint(" http://localhost:8222/ ".to_string());
+        state.begin_page_refresh();
+
+        state.apply_page(sample_client_page(
+            "http://localhost:8222",
+            vec![sample_client_row(1)],
+        ));
+
+        assert_eq!(state.endpoint(), "http://localhost:8222");
+        assert_eq!(state.page().unwrap().clients.len(), 1);
+        assert!(!state.loading);
+    }
+
+    #[test]
+    fn stale_client_status_page_response_is_ignored() {
+        let mut state = ClientStatusState::with_endpoint("http://localhost:8222".to_string());
+        state.set_state(ClientConnectionState::Closed);
+        state.begin_page_refresh();
+
+        state.apply_page(sample_client_page(
+            "http://localhost:8222",
+            vec![sample_client_row(1)],
+        ));
+
+        assert_eq!(state.query().state, ClientConnectionState::Closed);
+        assert!(state.page().is_none());
+        assert!(state.loading);
+    }
+
+    #[test]
+    fn stale_client_status_page_response_from_old_endpoint_is_ignored() {
+        let mut state = ClientStatusState::with_endpoint("http://localhost:8222".to_string());
+        state.set_endpoint("http://localhost:9222".to_string());
+        state.begin_page_refresh();
+
+        state.apply_page(sample_client_page(
+            "http://localhost:8222",
+            vec![sample_client_row(1)],
+        ));
+
+        assert_eq!(state.endpoint(), "http://localhost:9222");
+        assert!(state.page().is_none());
+        assert!(state.loading);
+    }
+
+    #[test]
+    fn matching_client_status_page_response_is_applied() {
+        let mut state = ClientStatusState::with_endpoint("http://localhost:8222".to_string());
+        state.set_state(ClientConnectionState::Closed);
+        state.begin_page_refresh();
+
+        state.apply_page(sample_client_page_with_query(
+            "http://localhost:8222",
+            state.query().clone(),
+            vec![sample_client_row(1)],
+        ));
+
+        assert_eq!(state.query().state, ClientConnectionState::Closed);
+        assert_eq!(state.page().unwrap().clients.len(), 1);
+        assert!(!state.loading);
+    }
+
+    #[test]
+    fn selected_client_detail_becomes_stale_when_refreshed_page_omits_client() {
+        let mut state = ClientStatusState::with_endpoint("http://localhost:8222".to_string());
+        state.apply_page(sample_client_page(
+            "http://localhost:8222",
+            vec![sample_client_row(1)],
+        ));
+        state.select_client(1);
+        state.apply_detail(sample_client_detail("http://localhost:8222", 1));
+
+        state.apply_page(sample_client_page(
+            "http://localhost:8222",
+            vec![sample_client_row(2)],
+        ));
+
+        assert_eq!(state.selected_client_id(), Some(1));
+        assert!(state.selected_detail_stale());
+        assert_eq!(state.detail().unwrap().client.client_id, 1);
+    }
+
+    #[test]
+    fn stale_client_detail_response_is_ignored_after_clear() {
+        let mut state = ClientStatusState::with_endpoint("http://localhost:8222".to_string());
+        state.begin_detail_refresh(1);
+        state.clear_selected_client();
+
+        state.apply_detail(sample_client_detail("http://localhost:8222", 1));
+
+        assert_eq!(state.selected_client_id(), None);
+        assert!(state.detail().is_none());
+        assert!(!state.detail_loading);
+    }
+
+    #[test]
+    fn stale_client_detail_response_does_not_overwrite_new_selection() {
+        let mut state = ClientStatusState::with_endpoint("http://localhost:8222".to_string());
+        state.begin_detail_refresh(1);
+        state.begin_detail_refresh(2);
+
+        state.apply_detail(sample_client_detail("http://localhost:8222", 1));
+
+        assert_eq!(state.selected_client_id(), Some(2));
+        assert!(state.detail().is_none());
+        assert!(state.detail_loading);
+    }
+
+    #[test]
+    fn stale_client_detail_response_from_old_endpoint_is_ignored() {
+        let mut state = ClientStatusState::with_endpoint("http://localhost:8222".to_string());
+        state.set_endpoint("http://localhost:9222".to_string());
+        state.begin_detail_refresh(1);
+
+        state.apply_detail(sample_client_detail("http://localhost:8222", 1));
+
+        assert_eq!(state.endpoint(), "http://localhost:9222");
+        assert_eq!(state.selected_client_id(), Some(1));
+        assert!(state.detail().is_none());
+        assert!(state.detail_loading);
+    }
+
+    #[test]
+    fn client_status_error_does_not_clear_last_page() {
+        let mut state = ClientStatusState::with_endpoint("http://localhost:8222".to_string());
+        state.apply_page(sample_client_page(
+            "http://localhost:8222",
+            vec![sample_client_row(1)],
+        ));
+
+        state.apply_error(ClientStatusRequestError {
+            endpoint: "http://localhost:8222".to_string(),
+            collected_at: SystemTime::UNIX_EPOCH + Duration::from_secs(5),
+            query: ClientStatusQuery::default(),
+            message: "timeout".to_string(),
+        });
+
+        assert_eq!(state.page().unwrap().clients.len(), 1);
+        assert_eq!(state.error().unwrap().message, "timeout");
+        assert!(state.is_stale());
+    }
+
+    #[test]
+    fn stale_client_status_page_error_is_ignored() {
+        let mut state = ClientStatusState::with_endpoint("http://localhost:8222".to_string());
+        state.set_state(ClientConnectionState::Closed);
+        state.begin_page_refresh();
+
+        state.apply_error(ClientStatusRequestError {
+            endpoint: "http://localhost:8222".to_string(),
+            collected_at: SystemTime::UNIX_EPOCH + Duration::from_secs(5),
+            query: ClientStatusQuery::default(),
+            message: "timeout".to_string(),
+        });
+
+        assert!(state.error().is_none());
+        assert!(state.loading);
+    }
+
+    #[test]
+    fn stale_client_status_page_error_from_old_endpoint_is_ignored() {
+        let mut state = ClientStatusState::with_endpoint("http://localhost:8222".to_string());
+        state.set_endpoint("http://localhost:9222".to_string());
+        state.begin_page_refresh();
+
+        state.apply_error(ClientStatusRequestError {
+            endpoint: "http://localhost:8222".to_string(),
+            collected_at: SystemTime::UNIX_EPOCH + Duration::from_secs(5),
+            query: ClientStatusQuery::default(),
+            message: "timeout".to_string(),
+        });
+
+        assert!(state.error().is_none());
+        assert!(state.loading);
+    }
+
+    #[test]
+    fn client_status_detail_error_clears_detail_loading() {
+        let mut state = ClientStatusState::with_endpoint("http://localhost:8222".to_string());
+        state.begin_detail_refresh(1);
+
+        state.apply_error(ClientStatusRequestError {
+            endpoint: "http://localhost:8222".to_string(),
+            collected_at: SystemTime::UNIX_EPOCH + Duration::from_secs(5),
+            query: ClientStatusQuery::detail(1),
+            message: "missing".to_string(),
+        });
+
+        assert!(!state.detail_loading);
+        assert_eq!(state.selected_client_id(), Some(1));
+        assert_eq!(state.error().unwrap().message, "missing");
+    }
+
+    #[test]
+    fn stale_client_status_detail_error_is_ignored() {
+        let mut state = ClientStatusState::with_endpoint("http://localhost:8222".to_string());
+        state.begin_detail_refresh(1);
+        state.begin_detail_refresh(2);
+
+        state.apply_error(ClientStatusRequestError {
+            endpoint: "http://localhost:8222".to_string(),
+            collected_at: SystemTime::UNIX_EPOCH + Duration::from_secs(5),
+            query: ClientStatusQuery::detail(1),
+            message: "missing".to_string(),
+        });
+
+        assert!(state.error().is_none());
+        assert_eq!(state.selected_client_id(), Some(2));
+        assert!(state.detail_loading);
+    }
+
+    #[test]
+    fn stale_client_status_detail_error_from_old_endpoint_is_ignored() {
+        let mut state = ClientStatusState::with_endpoint("http://localhost:8222".to_string());
+        state.set_endpoint("http://localhost:9222".to_string());
+        state.begin_detail_refresh(1);
+
+        state.apply_error(ClientStatusRequestError {
+            endpoint: "http://localhost:8222".to_string(),
+            collected_at: SystemTime::UNIX_EPOCH + Duration::from_secs(5),
+            query: ClientStatusQuery::detail(1),
+            message: "missing".to_string(),
+        });
+
+        assert!(state.error().is_none());
+        assert_eq!(state.selected_client_id(), Some(1));
+        assert!(state.detail_loading);
+    }
+
+    #[test]
+    fn client_status_query_change_resets_page_and_selection() {
+        let mut state = ClientStatusState::with_endpoint("http://localhost:8222".to_string());
+        state.apply_page(sample_client_page(
+            "http://localhost:8222",
+            vec![sample_client_row(1)],
+        ));
+        state.select_client(1);
+
+        state.set_state(ClientConnectionState::Closed);
+
+        assert_eq!(state.query().state, ClientConnectionState::Closed);
+        assert_eq!(state.query().offset, 0);
+        assert!(state.page().is_none());
+        assert_eq!(state.selected_client_id(), None);
+    }
+
+    #[test]
+    fn client_status_detail_query_preserves_current_state() {
+        let mut state = ClientStatusState::with_endpoint("http://localhost:8222".to_string());
+        state.set_state(ClientConnectionState::Closed);
+
+        let query = state.detail_query(7);
+
+        assert_eq!(query.client_id, Some(7));
+        assert_eq!(query.state, ClientConnectionState::Closed);
+        assert!(query.include_subscriptions);
+        assert!(query.include_auth);
+    }
+
+    #[test]
+    fn client_status_rejects_closed_only_sort_outside_closed_state() {
+        let mut state = ClientStatusState::with_endpoint("http://localhost:8222".to_string());
+
+        state.set_sort(ClientStatusSort::Stop);
+
+        assert_eq!(state.query().sort, ClientStatusSort::Cid);
+    }
+
+    #[test]
+    fn client_status_resets_closed_only_sort_when_leaving_closed_state() {
+        let mut state = ClientStatusState::with_endpoint("http://localhost:8222".to_string());
+        state.set_state(ClientConnectionState::Closed);
+        state.set_sort(ClientStatusSort::Reason);
+
+        state.set_state(ClientConnectionState::Any);
+
+        assert_eq!(state.query().state, ClientConnectionState::Any);
+        assert_eq!(state.query().sort, ClientStatusSort::Cid);
+    }
+
+    #[test]
+    fn client_status_auto_refresh_uses_own_timer() {
+        let mut state = ClientStatusState::with_endpoint("http://localhost:8222".to_string());
+        state.auto_refresh.enabled = true;
+        state.auto_refresh.interval_secs = 0;
+
+        assert!(state.should_refresh());
+
+        state.loading = true;
+
+        assert!(!state.should_refresh());
+    }
+}

--- a/crates/app/src/tabs/types/metrics_state.rs
+++ b/crates/app/src/tabs/types/metrics_state.rs
@@ -8,7 +8,7 @@ use super::AutoRefresh;
 #[derive(Debug, Default)]
 pub struct MetricsState {
     endpoint: String,
-    latest_attempt: Option<MetricsSnapshot>,
+    latest_attempt: Option<Box<MetricsSnapshot>>,
     history: VecDeque<MetricsSnapshot>,
     pub loading: bool,
     pub auto_refresh: AutoRefresh,
@@ -60,7 +60,7 @@ impl MetricsState {
             }
             self.history.push_back(snapshot.clone());
         }
-        self.latest_attempt = Some(snapshot);
+        self.latest_attempt = Some(Box::new(snapshot));
     }
 
     pub fn has_never_loaded(&self) -> bool {
@@ -68,12 +68,12 @@ impl MetricsState {
     }
 
     pub fn latest_attempt(&self) -> Option<&MetricsSnapshot> {
-        self.latest_attempt.as_ref()
+        self.latest_attempt.as_deref()
     }
 
     pub fn latest_data(&self) -> Option<&MetricsSnapshot> {
         self.latest_attempt
-            .as_ref()
+            .as_deref()
             .filter(|snapshot| snapshot.has_any_data())
             .or_else(|| self.history.back())
     }
@@ -84,7 +84,7 @@ impl MetricsState {
 
     pub fn is_stale(&self) -> bool {
         self.latest_attempt
-            .as_ref()
+            .as_deref()
             .is_some_and(|snapshot| !snapshot.has_any_data())
             && !self.history.is_empty()
     }

--- a/crates/app/src/tabs/types/tab_kind.rs
+++ b/crates/app/src/tabs/types/tab_kind.rs
@@ -7,9 +7,9 @@ use crate::schema::MessageSchemaManager;
 use crate::theme::ThemeId;
 
 use super::{
-    KvBucketState, MessageSchemasState, MetricsState, ObjectStoreBucketState, PublisherState,
-    SearchSourceSnapshot, SearchWorkspaceState, ServerInfoState, StreamState, SubscriberState,
-    TabAction,
+    ClientStatusState, KvBucketState, MessageSchemasState, MetricsState, ObjectStoreBucketState,
+    PublisherState, SearchSourceSnapshot, SearchWorkspaceState, ServerInfoState, StreamState,
+    SubscriberState, TabAction,
 };
 use crate::tabs::guard::TabGuard;
 
@@ -62,6 +62,11 @@ pub enum TabKind {
         connection_id: u64,
         connection_name: String,
         state: MetricsState,
+    },
+    Clients {
+        connection_id: u64,
+        connection_name: String,
+        state: ClientStatusState,
     },
     SearchWorkspace {
         state: SearchWorkspaceState,
@@ -130,6 +135,9 @@ impl TabKind {
             TabKind::Metrics {
                 connection_name, ..
             } => format!("{} ({})", t("common.tab_metrics"), connection_name),
+            TabKind::Clients {
+                connection_name, ..
+            } => format!("{} ({})", t("common.tab_clients"), connection_name),
             TabKind::SearchWorkspace { .. } => t("common.tab_search_workspace").to_string(),
             TabKind::MessageSchemas { .. } => t("common.tab_message_schemas").to_string(),
             TabKind::Settings => t("settings.title").to_string(),
@@ -171,6 +179,9 @@ impl TabKind {
             }
             TabKind::Metrics { connection_id, .. } => {
                 egui::Id::new(("tab:metrics", *connection_id))
+            }
+            TabKind::Clients { connection_id, .. } => {
+                egui::Id::new(("tab:clients", *connection_id))
             }
             TabKind::SearchWorkspace { .. } => egui::Id::new("tab:search-workspace"),
             TabKind::MessageSchemas { .. } => egui::Id::new("tab:message-schemas"),

--- a/crates/app/src/tabs/viewer.rs
+++ b/crates/app/src/tabs/viewer.rs
@@ -2,7 +2,7 @@ use eframe::egui;
 
 use crate::i18n::t;
 use crate::tabs::{
-    kv_bucket_ui, message_schemas_ui, metrics_ui, obj_store_bucket_ui, publisher_ui,
+    clients_ui, kv_bucket_ui, message_schemas_ui, metrics_ui, obj_store_bucket_ui, publisher_ui,
     search_workspace_ui, server_info_ui, stream_ui, subscriber_ui,
 };
 
@@ -46,6 +46,7 @@ fn tab_scope_id(tab: &TabKind) -> String {
         } => format!("obj:{connection_id}:{bucket_name}"),
         TabKind::ServerInfo { connection_id, .. } => format!("srvinfo:{connection_id}"),
         TabKind::Metrics { connection_id, .. } => format!("metrics:{connection_id}"),
+        TabKind::Clients { connection_id, .. } => format!("clients:{connection_id}"),
         TabKind::SearchWorkspace { .. } => "search-workspace".into(),
         TabKind::MessageSchemas { .. } => "message-schemas".into(),
         TabKind::Settings => "settings".into(),
@@ -183,6 +184,13 @@ fn render_tab_body(viewer: &mut AppTabViewer<'_>, ui: &mut egui::Ui, tab: &mut T
             ..
         } => {
             metrics_ui(ui, *connection_id, state, viewer.backend);
+        }
+        TabKind::Clients {
+            connection_id,
+            state,
+            ..
+        } => {
+            clients_ui(ui, *connection_id, state, viewer.backend);
         }
         TabKind::SearchWorkspace { state } => {
             search_workspace_ui(ui, state, viewer.search_sources, viewer.actions);

--- a/crates/nats-backend/src/command.rs
+++ b/crates/nats-backend/src/command.rs
@@ -3,6 +3,7 @@ use crate::connection::ConnectionConfig;
 use crate::models::{
     ConsumerConfigInput, KvBucketConfigInput, ObjectStoreBucketConfigInput, StreamConfigInput,
 };
+use crate::monitoring::ClientStatusQuery;
 
 /// Commands sent from the UI thread to the async backend worker.
 #[derive(Debug)]
@@ -191,5 +192,15 @@ pub enum BackendCommand {
     FetchMetrics {
         connection_id: u64,
         endpoint: String,
+    },
+    FetchClientStatusPage {
+        connection_id: u64,
+        endpoint: String,
+        query: ClientStatusQuery,
+    },
+    FetchClientStatusDetail {
+        connection_id: u64,
+        endpoint: String,
+        query: ClientStatusQuery,
     },
 }

--- a/crates/nats-backend/src/event.rs
+++ b/crates/nats-backend/src/event.rs
@@ -3,7 +3,9 @@ use crate::models::{
     KvHistoryItem, KvKeyBatch, ObjectStoreBucketInfo, ObjectStoreDownloadResult,
     ObjectStoreObjectInfo, ServerInfoSnapshot, StreamInfo, StreamMessageInfo,
 };
-use crate::monitoring::MetricsSnapshot;
+use crate::monitoring::{
+    ClientStatusDetail, ClientStatusPage, ClientStatusRequestError, MetricsSnapshot,
+};
 
 #[derive(Debug, Clone)]
 pub struct MessageData {
@@ -51,6 +53,8 @@ pub enum BackendOperation {
     DeleteObject,
     ServerInfo,
     JetStreamAccountInfo,
+    FetchClientStatusPage,
+    FetchClientStatusDetail,
 }
 
 impl BackendOperation {
@@ -91,6 +95,8 @@ impl BackendOperation {
             Self::DeleteObject => "delete_object",
             Self::ServerInfo => "server_info",
             Self::JetStreamAccountInfo => "jetstream_account_info",
+            Self::FetchClientStatusPage => "fetch_client_status_page",
+            Self::FetchClientStatusDetail => "fetch_client_status_detail",
         }
     }
 }
@@ -125,6 +131,18 @@ pub enum BackendEvent {
     MetricsSnapshot {
         connection_id: u64,
         snapshot: Box<MetricsSnapshot>,
+    },
+    ClientStatusPageLoaded {
+        connection_id: u64,
+        page: Box<ClientStatusPage>,
+    },
+    ClientStatusDetailLoaded {
+        connection_id: u64,
+        detail: Box<ClientStatusDetail>,
+    },
+    ClientStatusError {
+        connection_id: u64,
+        error: Box<ClientStatusRequestError>,
     },
     KvBucketsListed {
         connection_id: u64,

--- a/crates/nats-backend/src/lib.rs
+++ b/crates/nats-backend/src/lib.rs
@@ -26,6 +26,8 @@ pub use models::{
 };
 pub use models::{ObjectStoreBucketInfo, ObjectStoreDownloadResult, ObjectStoreObjectInfo};
 pub use monitoring::{
+    ClientConnectionState, ClientStatusDetail, ClientStatusPage, ClientStatusQuery,
+    ClientStatusRequestError, ClientStatusRow, ClientStatusSort, ClientStatusSubscription,
     ConnzMetrics, JetStreamMetrics, MetricsHealth, MetricsSection, MetricsSectionError,
     MetricsSnapshot, VarzMetrics,
 };

--- a/crates/nats-backend/src/monitoring.rs
+++ b/crates/nats-backend/src/monitoring.rs
@@ -57,6 +57,195 @@ pub struct ConnzMetrics {
     pub total_connections: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClientConnectionState {
+    Open,
+    Closed,
+    Any,
+}
+
+impl ClientConnectionState {
+    pub const fn as_connz_param(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Closed => "closed",
+            Self::Any => "any",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClientStatusSort {
+    Cid,
+    Start,
+    Subscriptions,
+    PendingBytes,
+    InMessages,
+    OutMessages,
+    InBytes,
+    OutBytes,
+    LastActivity,
+    Idle,
+    Uptime,
+    Stop,
+    Reason,
+}
+
+impl ClientStatusSort {
+    pub const ALL: [Self; 13] = [
+        Self::Cid,
+        Self::Start,
+        Self::Subscriptions,
+        Self::PendingBytes,
+        Self::InMessages,
+        Self::OutMessages,
+        Self::InBytes,
+        Self::OutBytes,
+        Self::LastActivity,
+        Self::Idle,
+        Self::Uptime,
+        Self::Stop,
+        Self::Reason,
+    ];
+
+    pub const fn as_connz_param(self) -> &'static str {
+        match self {
+            Self::Cid => "cid",
+            Self::Start => "start",
+            Self::Subscriptions => "subs",
+            Self::PendingBytes => "pending",
+            Self::InMessages => "msgs_from",
+            Self::OutMessages => "msgs_to",
+            Self::InBytes => "bytes_from",
+            Self::OutBytes => "bytes_to",
+            Self::LastActivity => "last",
+            Self::Idle => "idle",
+            Self::Uptime => "uptime",
+            Self::Stop => "stop",
+            Self::Reason => "reason",
+        }
+    }
+
+    pub const fn is_allowed_for_state(self, state: ClientConnectionState) -> bool {
+        match self {
+            Self::Stop | Self::Reason => matches!(state, ClientConnectionState::Closed),
+            _ => true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientStatusQuery {
+    pub state: ClientConnectionState,
+    pub sort: ClientStatusSort,
+    pub page_size: usize,
+    pub offset: usize,
+    pub client_id: Option<u64>,
+    pub include_subscriptions: bool,
+    pub include_auth: bool,
+}
+
+impl Default for ClientStatusQuery {
+    fn default() -> Self {
+        Self {
+            state: ClientConnectionState::Open,
+            sort: ClientStatusSort::Cid,
+            page_size: 100,
+            offset: 0,
+            client_id: None,
+            include_subscriptions: false,
+            include_auth: true,
+        }
+    }
+}
+
+impl ClientStatusQuery {
+    pub const PAGE_SIZE_OPTIONS: [usize; 4] = [50, 100, 250, 500];
+    pub const MAX_PAGE_SIZE: usize = 500;
+
+    pub fn with_page(mut self, page_size: usize, offset: usize) -> Self {
+        self.page_size = page_size.clamp(1, Self::MAX_PAGE_SIZE);
+        self.offset = offset;
+        self
+    }
+
+    pub fn detail(client_id: u64) -> Self {
+        Self {
+            client_id: Some(client_id),
+            include_subscriptions: true,
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientStatusSubscription {
+    pub subject: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientStatusRow {
+    pub client_id: u64,
+    pub state: ClientConnectionState,
+    pub name: Option<String>,
+    pub account: Option<String>,
+    pub user: Option<String>,
+    pub ip: Option<String>,
+    pub port: Option<u16>,
+    pub uptime: Option<String>,
+    pub idle: Option<String>,
+    pub last_activity: Option<String>,
+    pub rtt: Option<String>,
+    pub subscriptions: Option<u64>,
+    pub pending_bytes: Option<u64>,
+    pub in_msgs: Option<u64>,
+    pub out_msgs: Option<u64>,
+    pub in_bytes: Option<u64>,
+    pub out_bytes: Option<u64>,
+    pub language: Option<String>,
+    pub version: Option<String>,
+    pub closed_at: Option<String>,
+    pub closed_reason: Option<String>,
+    pub subscription_details: Vec<ClientStatusSubscription>,
+}
+
+impl ClientStatusRow {
+    pub fn remote_address(&self) -> Option<String> {
+        match (&self.ip, self.port) {
+            (Some(ip), Some(port)) => Some(format!("{ip}:{port}")),
+            (Some(ip), None) => Some(ip.clone()),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClientStatusPage {
+    pub endpoint: String,
+    pub collected_at: SystemTime,
+    pub query: ClientStatusQuery,
+    pub total: u64,
+    pub offset: usize,
+    pub limit: usize,
+    pub clients: Vec<ClientStatusRow>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClientStatusDetail {
+    pub endpoint: String,
+    pub collected_at: SystemTime,
+    pub query: ClientStatusQuery,
+    pub client: ClientStatusRow,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClientStatusRequestError {
+    pub endpoint: String,
+    pub collected_at: SystemTime,
+    pub query: ClientStatusQuery,
+    pub message: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct JetStreamMetrics {
     pub memory_bytes: u64,

--- a/crates/nats-backend/src/worker/metrics.rs
+++ b/crates/nats-backend/src/worker/metrics.rs
@@ -6,8 +6,10 @@ use tokio::sync::mpsc;
 
 use crate::event::BackendEvent;
 use crate::monitoring::{
-    ConnzMetrics, JetStreamMetrics, MetricsHealth, MetricsSection, MetricsSectionError,
-    MetricsSnapshot, VarzMetrics,
+    ClientConnectionState, ClientStatusDetail, ClientStatusPage, ClientStatusQuery,
+    ClientStatusRequestError, ClientStatusRow, ClientStatusSubscription, ConnzMetrics,
+    JetStreamMetrics, MetricsHealth, MetricsSection, MetricsSectionError, MetricsSnapshot,
+    VarzMetrics,
 };
 
 use super::state::WorkerState;
@@ -133,8 +135,7 @@ async fn fetch_varz(client: &reqwest::Client, base_url: Url) -> Result<VarzMetri
 }
 
 async fn fetch_connz(client: &reqwest::Client, base_url: Url) -> Result<ConnzMetrics, String> {
-    let mut url = join_url(base_url, "connz")?;
-    url.query_pairs_mut().append_pair("limit", "1");
+    let url = build_connz_summary_url(base_url)?;
     let raw = fetch_json::<ConnzResponse>(client, url).await?;
     let open_connections = raw.num_connections.or(raw.total).unwrap_or_default();
     let total_connections = raw.total.unwrap_or(open_connections);
@@ -142,6 +143,155 @@ async fn fetch_connz(client: &reqwest::Client, base_url: Url) -> Result<ConnzMet
         open_connections,
         total_connections,
     })
+}
+
+pub(crate) async fn handle_fetch_client_status_page(
+    state: &WorkerState,
+    connection_id: u64,
+    endpoint: String,
+    query: ClientStatusQuery,
+    evt_tx: &mpsc::Sender<BackendEvent>,
+) {
+    tracing::info!(
+        connection_id,
+        state = ?query.state,
+        sort = ?query.sort,
+        limit = query.page_size,
+        offset = query.offset,
+        "Fetching client status page"
+    );
+    let endpoint = endpoint.trim().trim_end_matches('/').to_string();
+    let base_url = match Url::parse(&endpoint) {
+        Ok(url) => url,
+        Err(_) => {
+            send_client_status_error(
+                evt_tx,
+                connection_id,
+                endpoint,
+                query,
+                "Invalid monitoring endpoint URL".to_string(),
+            )
+            .await;
+            return;
+        }
+    };
+
+    let url = match build_client_status_page_url(base_url, &query) {
+        Ok(url) => url,
+        Err(message) => {
+            send_client_status_error(evt_tx, connection_id, endpoint, query, message).await;
+            return;
+        }
+    };
+
+    match fetch_json::<ConnzResponse>(&state.http_client, url).await {
+        Ok(raw) => {
+            let page = normalize_client_status_page(endpoint, SystemTime::now(), query, raw);
+            let _ = evt_tx
+                .send(BackendEvent::ClientStatusPageLoaded {
+                    connection_id,
+                    page: Box::new(page),
+                })
+                .await;
+        }
+        Err(message) => {
+            send_client_status_error(evt_tx, connection_id, endpoint, query, message).await;
+        }
+    }
+}
+
+pub(crate) async fn handle_fetch_client_status_detail(
+    state: &WorkerState,
+    connection_id: u64,
+    endpoint: String,
+    query: ClientStatusQuery,
+    evt_tx: &mpsc::Sender<BackendEvent>,
+) {
+    tracing::info!(
+        connection_id,
+        client_id = query.client_id,
+        include_subscriptions = query.include_subscriptions,
+        "Fetching client status detail"
+    );
+    let endpoint = endpoint.trim().trim_end_matches('/').to_string();
+    let base_url = match Url::parse(&endpoint) {
+        Ok(url) => url,
+        Err(_) => {
+            send_client_status_error(
+                evt_tx,
+                connection_id,
+                endpoint,
+                query,
+                "Invalid monitoring endpoint URL".to_string(),
+            )
+            .await;
+            return;
+        }
+    };
+
+    let url = match build_client_status_detail_url(base_url, &query) {
+        Ok(url) => url,
+        Err(message) => {
+            send_client_status_error(evt_tx, connection_id, endpoint, query, message).await;
+            return;
+        }
+    };
+
+    match fetch_json::<ConnzResponse>(&state.http_client, url).await {
+        Ok(raw) => {
+            match normalize_client_status_detail(
+                endpoint.clone(),
+                SystemTime::now(),
+                query.clone(),
+                raw,
+            ) {
+                Ok(detail) => {
+                    let _ = evt_tx
+                        .send(BackendEvent::ClientStatusDetailLoaded {
+                            connection_id,
+                            detail: Box::new(detail),
+                        })
+                        .await;
+                }
+                Err(message) => {
+                    send_client_status_error(evt_tx, connection_id, endpoint, query, message).await;
+                }
+            }
+        }
+        Err(message) => {
+            send_client_status_error(evt_tx, connection_id, endpoint, query, message).await;
+        }
+    }
+}
+
+async fn send_client_status_error(
+    evt_tx: &mpsc::Sender<BackendEvent>,
+    connection_id: u64,
+    endpoint: String,
+    query: ClientStatusQuery,
+    message: String,
+) {
+    tracing::warn!(
+        connection_id,
+        state = ?query.state,
+        sort = ?query.sort,
+        limit = query.page_size,
+        offset = query.offset,
+        has_client_id = query.client_id.is_some(),
+        %message,
+        "Client status request failed"
+    );
+    let _ = evt_tx
+        .send(BackendEvent::ClientStatusError {
+            connection_id,
+            error: Box::new(ClientStatusRequestError {
+                endpoint,
+                collected_at: SystemTime::now(),
+                query,
+                message,
+            }),
+        })
+        .await;
 }
 
 async fn fetch_jsz(client: &reqwest::Client, base_url: Url) -> Result<JetStreamMetrics, String> {
@@ -194,6 +344,135 @@ fn join_url(mut base_url: Url, path: &str) -> Result<Url, String> {
     Ok(base_url)
 }
 
+fn build_connz_summary_url(base_url: Url) -> Result<Url, String> {
+    let mut url = join_url(base_url, "connz")?;
+    url.query_pairs_mut().append_pair("limit", "1");
+    Ok(url)
+}
+
+fn build_client_status_page_url(base_url: Url, query: &ClientStatusQuery) -> Result<Url, String> {
+    let mut url = join_url(base_url, "connz")?;
+    let limit = query.page_size.clamp(1, ClientStatusQuery::MAX_PAGE_SIZE);
+    {
+        let mut pairs = url.query_pairs_mut();
+        pairs.append_pair("limit", &limit.to_string());
+        pairs.append_pair("offset", &query.offset.to_string());
+        pairs.append_pair("sort", query.sort.as_connz_param());
+        pairs.append_pair("state", query.state.as_connz_param());
+        if query.include_auth {
+            pairs.append_pair("auth", "1");
+        }
+    }
+    Ok(url)
+}
+
+fn build_client_status_detail_url(base_url: Url, query: &ClientStatusQuery) -> Result<Url, String> {
+    let Some(client_id) = query.client_id else {
+        return Err("Client detail request requires a client ID".to_string());
+    };
+    let mut url = join_url(base_url, "connz")?;
+    {
+        let mut pairs = url.query_pairs_mut();
+        pairs.append_pair("cid", &client_id.to_string());
+        pairs.append_pair("state", query.state.as_connz_param());
+        if query.include_subscriptions {
+            pairs.append_pair("subs", "1");
+        }
+        if query.include_auth {
+            pairs.append_pair("auth", "1");
+        }
+    }
+    Ok(url)
+}
+
+fn normalize_client_status_page(
+    endpoint: String,
+    collected_at: SystemTime,
+    query: ClientStatusQuery,
+    raw: ConnzResponse,
+) -> ClientStatusPage {
+    let total = raw.total.unwrap_or(raw.num_connections.unwrap_or_default());
+    let offset = raw.offset.unwrap_or(query.offset);
+    let limit = raw.limit.unwrap_or(query.page_size);
+    let clients = raw
+        .connections
+        .into_iter()
+        .map(|client| normalize_client_status_row(client, query.state))
+        .collect();
+
+    ClientStatusPage {
+        endpoint,
+        collected_at,
+        query,
+        total,
+        offset,
+        limit,
+        clients,
+    }
+}
+
+fn normalize_client_status_detail(
+    endpoint: String,
+    collected_at: SystemTime,
+    query: ClientStatusQuery,
+    raw: ConnzResponse,
+) -> Result<ClientStatusDetail, String> {
+    let client = raw
+        .connections
+        .into_iter()
+        .next()
+        .map(|client| normalize_client_status_row(client, query.state))
+        .ok_or_else(|| "Client was not found in monitoring response".to_string())?;
+    Ok(ClientStatusDetail {
+        endpoint,
+        collected_at,
+        query,
+        client,
+    })
+}
+
+fn normalize_client_status_row(
+    raw: ConnzConnection,
+    query_state: ClientConnectionState,
+) -> ClientStatusRow {
+    let state = match query_state {
+        ClientConnectionState::Any if raw.stop.is_some() || raw.reason.is_some() => {
+            ClientConnectionState::Closed
+        }
+        ClientConnectionState::Any => ClientConnectionState::Open,
+        other => other,
+    };
+    let subscription_details = raw
+        .subscriptions_list
+        .into_iter()
+        .map(|subject| ClientStatusSubscription { subject })
+        .collect();
+    ClientStatusRow {
+        client_id: raw.cid,
+        state,
+        name: raw.name,
+        account: raw.account,
+        user: raw.user.or(raw.username).or(raw.authorized_user),
+        ip: raw.ip,
+        port: raw.port,
+        uptime: raw.uptime,
+        idle: raw.idle,
+        last_activity: raw.last_activity.or(raw.last),
+        rtt: raw.rtt,
+        subscriptions: raw.subscriptions.or(raw.num_subscriptions),
+        pending_bytes: raw.pending_bytes,
+        in_msgs: raw.in_msgs,
+        out_msgs: raw.out_msgs,
+        in_bytes: raw.in_bytes,
+        out_bytes: raw.out_bytes,
+        language: raw.lang.or(raw.language),
+        version: raw.version,
+        closed_at: raw.stop,
+        closed_reason: raw.reason,
+        subscription_details,
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct HealthzResponse {
     status: Option<String>,
@@ -223,6 +502,42 @@ struct VarzResponse {
 struct ConnzResponse {
     num_connections: Option<u64>,
     total: Option<u64>,
+    offset: Option<usize>,
+    limit: Option<usize>,
+    #[serde(default)]
+    connections: Vec<ConnzConnection>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ConnzConnection {
+    #[serde(default)]
+    cid: u64,
+    name: Option<String>,
+    account: Option<String>,
+    user: Option<String>,
+    username: Option<String>,
+    authorized_user: Option<String>,
+    ip: Option<String>,
+    port: Option<u16>,
+    uptime: Option<String>,
+    idle: Option<String>,
+    last_activity: Option<String>,
+    last: Option<String>,
+    rtt: Option<String>,
+    subscriptions: Option<u64>,
+    num_subscriptions: Option<u64>,
+    pending_bytes: Option<u64>,
+    in_msgs: Option<u64>,
+    out_msgs: Option<u64>,
+    in_bytes: Option<u64>,
+    out_bytes: Option<u64>,
+    lang: Option<String>,
+    language: Option<String>,
+    version: Option<String>,
+    stop: Option<String>,
+    reason: Option<String>,
+    #[serde(default, alias = "subs")]
+    subscriptions_list: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -241,3 +556,6 @@ struct JszApi {
     total: Option<u64>,
     errors: Option<u64>,
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/nats-backend/src/worker/metrics/tests.rs
+++ b/crates/nats-backend/src/worker/metrics/tests.rs
@@ -1,0 +1,227 @@
+use std::time::SystemTime;
+
+use reqwest::Url;
+
+use crate::monitoring::{
+    ClientConnectionState, ClientStatusQuery, ClientStatusSort, ClientStatusSubscription,
+};
+
+use super::{
+    ConnzResponse, build_client_status_detail_url, build_client_status_page_url,
+    normalize_client_status_detail, normalize_client_status_page,
+};
+
+#[test]
+fn default_client_status_page_query_is_open_and_bounded() {
+    let query = ClientStatusQuery::default();
+    let url =
+        build_client_status_page_url(Url::parse("http://localhost:8222").unwrap(), &query).unwrap();
+
+    assert_eq!(query.state, ClientConnectionState::Open);
+    assert_eq!(query.sort, ClientStatusSort::Cid);
+    assert_eq!(query.page_size, 100);
+    assert_eq!(query.offset, 0);
+    assert_eq!(query.client_id, None);
+    assert!(query.include_auth);
+    assert!(!query.include_subscriptions);
+    assert_eq!(
+        url.as_str(),
+        "http://localhost:8222/connz?limit=100&offset=0&sort=cid&state=open&auth=1"
+    );
+}
+
+#[test]
+fn client_status_page_query_uses_filter_sort_limit_and_offset() {
+    let query = ClientStatusQuery {
+        state: ClientConnectionState::Closed,
+        sort: ClientStatusSort::PendingBytes,
+        page_size: 250,
+        offset: 500,
+        client_id: None,
+        include_subscriptions: false,
+        include_auth: true,
+    };
+    let url = build_client_status_page_url(
+        Url::parse("http://localhost:8222/nested/path").unwrap(),
+        &query,
+    )
+    .unwrap();
+
+    assert_eq!(
+        url.as_str(),
+        "http://localhost:8222/connz?limit=250&offset=500&sort=pending&state=closed&auth=1"
+    );
+}
+
+#[test]
+fn selected_client_detail_query_requests_subscriptions_for_only_that_client() {
+    let query = ClientStatusQuery::detail(42);
+    let url = build_client_status_detail_url(Url::parse("http://localhost:8222").unwrap(), &query)
+        .unwrap();
+
+    assert_eq!(query.client_id, Some(42));
+    assert!(query.include_subscriptions);
+    assert_eq!(
+        url.as_str(),
+        "http://localhost:8222/connz?cid=42&state=open&subs=1&auth=1"
+    );
+}
+
+#[test]
+fn selected_client_detail_query_preserves_state_filter() {
+    let query = ClientStatusQuery {
+        state: ClientConnectionState::Closed,
+        ..ClientStatusQuery::detail(42)
+    };
+    let url = build_client_status_detail_url(Url::parse("http://localhost:8222").unwrap(), &query)
+        .unwrap();
+
+    assert_eq!(
+        url.as_str(),
+        "http://localhost:8222/connz?cid=42&state=closed&subs=1&auth=1"
+    );
+}
+
+#[test]
+fn connz_open_page_is_normalized_into_client_rows() {
+    let raw: ConnzResponse = serde_json::from_str(
+        r#"{
+            "num_connections": 2,
+            "total": 12,
+            "offset": 100,
+            "limit": 2,
+            "connections": [
+                {
+                    "cid": 41,
+                    "name": "orders-api",
+                    "account": "APP",
+                    "user": "alice",
+                    "ip": "127.0.0.1",
+                    "port": 52310,
+                    "uptime": "2m",
+                    "idle": "1s",
+                    "last_activity": "2026-05-07T10:00:00Z",
+                    "rtt": "500µs",
+                    "subscriptions": 5,
+                    "pending_bytes": 7,
+                    "in_msgs": 11,
+                    "out_msgs": 13,
+                    "in_bytes": 17,
+                    "out_bytes": 19,
+                    "lang": "rust",
+                    "version": "1.0.0"
+                },
+                {
+                    "cid": 42
+                }
+            ]
+        }"#,
+    )
+    .unwrap();
+
+    let page = normalize_client_status_page(
+        "http://localhost:8222".to_string(),
+        SystemTime::UNIX_EPOCH,
+        ClientStatusQuery::default(),
+        raw,
+    );
+
+    assert_eq!(page.total, 12);
+    assert_eq!(page.offset, 100);
+    assert_eq!(page.limit, 2);
+    assert_eq!(page.clients.len(), 2);
+    let first = &page.clients[0];
+    assert_eq!(first.client_id, 41);
+    assert_eq!(first.state, ClientConnectionState::Open);
+    assert_eq!(first.name.as_deref(), Some("orders-api"));
+    assert_eq!(first.account.as_deref(), Some("APP"));
+    assert_eq!(first.user.as_deref(), Some("alice"));
+    assert_eq!(first.remote_address(), Some("127.0.0.1:52310".to_string()));
+    assert_eq!(first.subscriptions, Some(5));
+    assert_eq!(first.pending_bytes, Some(7));
+    assert_eq!(first.in_msgs, Some(11));
+    assert_eq!(first.out_msgs, Some(13));
+    assert_eq!(first.in_bytes, Some(17));
+    assert_eq!(first.out_bytes, Some(19));
+    assert_eq!(first.language.as_deref(), Some("rust"));
+    assert_eq!(first.version.as_deref(), Some("1.0.0"));
+    assert_eq!(page.clients[1].client_id, 42);
+    assert_eq!(page.clients[1].subscriptions, None);
+}
+
+#[test]
+fn connz_closed_page_preserves_close_reason() {
+    let raw: ConnzResponse = serde_json::from_str(
+        r#"{
+            "num_connections": 1,
+            "total": 1,
+            "connections": [
+                {
+                    "cid": 7,
+                    "stop": "2026-05-07T10:05:00Z",
+                    "reason": "Client Closed"
+                }
+            ]
+        }"#,
+    )
+    .unwrap();
+
+    let page = normalize_client_status_page(
+        "http://localhost:8222".to_string(),
+        SystemTime::UNIX_EPOCH,
+        ClientStatusQuery {
+            state: ClientConnectionState::Closed,
+            ..Default::default()
+        },
+        raw,
+    );
+
+    assert_eq!(page.clients[0].state, ClientConnectionState::Closed);
+    assert_eq!(
+        page.clients[0].closed_reason.as_deref(),
+        Some("Client Closed")
+    );
+    assert_eq!(
+        page.clients[0].closed_at.as_deref(),
+        Some("2026-05-07T10:05:00Z")
+    );
+}
+
+#[test]
+fn selected_client_detail_keeps_subscription_subjects() {
+    let raw: ConnzResponse = serde_json::from_str(
+        r#"{
+            "num_connections": 1,
+            "total": 1,
+            "connections": [
+                {
+                    "cid": 9,
+                    "subscriptions": 2,
+                    "subscriptions_list": ["orders.*", "events.>"]
+                }
+            ]
+        }"#,
+    )
+    .unwrap();
+
+    let detail = normalize_client_status_detail(
+        "http://localhost:8222".to_string(),
+        SystemTime::UNIX_EPOCH,
+        ClientStatusQuery::detail(9),
+        raw,
+    )
+    .unwrap();
+
+    assert_eq!(detail.client.client_id, 9);
+    assert_eq!(
+        detail.client.subscription_details,
+        vec![
+            ClientStatusSubscription {
+                subject: "orders.*".to_string()
+            },
+            ClientStatusSubscription {
+                subject: "events.>".to_string()
+            }
+        ]
+    );
+}

--- a/crates/nats-backend/src/worker/mod.rs
+++ b/crates/nats-backend/src/worker/mod.rs
@@ -355,6 +355,34 @@ pub async fn run_worker(
             } => {
                 metrics::handle_fetch_metrics(&state, connection_id, endpoint, &evt_tx).await;
             }
+            BackendCommand::FetchClientStatusPage {
+                connection_id,
+                endpoint,
+                query,
+            } => {
+                metrics::handle_fetch_client_status_page(
+                    &state,
+                    connection_id,
+                    endpoint,
+                    query,
+                    &evt_tx,
+                )
+                .await;
+            }
+            BackendCommand::FetchClientStatusDetail {
+                connection_id,
+                endpoint,
+                query,
+            } => {
+                metrics::handle_fetch_client_status_detail(
+                    &state,
+                    connection_id,
+                    endpoint,
+                    query,
+                    &evt_tx,
+                )
+                .await;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Add client-status fetching from the monitoring endpoint.
- Add a Clients tab with filters, paging, row selection, and detail view.

## Tests
- cargo test -p easy-nats
- cargo test -p nats-backend
- cargo clippy -p easy-nats --all-targets -- -D warnings
- cargo clippy -p nats-backend --all-targets -- -D warnings