### PR TITLE
fix(kv): expand history panel height

### DIFF
--- a/crates/app/src/tabs/kv.rs
+++ b/crates/app/src/tabs/kv.rs
@@ -488,6 +488,7 @@ fn render_detail_panel(
     ui.label(t("kv.value_preview"));
     egui::ScrollArea::vertical()
         .id_salt(("kv_value_preview", connection_id, bucket_name))
+        .auto_shrink([false; 2])
         .show(ui, |ui| {
             format::render_payload_with_proto(
                 ui,
@@ -526,7 +527,8 @@ fn render_history(
     } else {
         egui::ScrollArea::vertical()
             .id_salt(("kv_history", connection_id, bucket_name))
-            .max_height(220.0)
+            .max_height(history_scroll_height(ui.available_height()))
+            .auto_shrink([false; 2])
             .show(ui, |ui| {
                 for item in &state.history {
                     let revision = item.revision;
@@ -553,6 +555,10 @@ fn render_history(
                 }
             });
     }
+}
+
+fn history_scroll_height(available_height: f32) -> f32 {
+    available_height.max(80.0)
 }
 
 fn render_generate_json_button(
@@ -672,5 +678,11 @@ mod tests {
     fn normalized_entry_key_trims_schema_and_write_target() {
         assert_eq!(normalized_entry_key("  orders.1  "), "orders.1");
         assert_eq!(normalized_entry_key("\tusers.alice\n"), "users.alice");
+    }
+
+    #[test]
+    fn history_scroll_height_uses_available_panel_space() {
+        assert_eq!(history_scroll_height(640.0), 640.0);
+        assert_eq!(history_scroll_height(12.0), 80.0);
     }
 }

--- a/packaging/flatpak/io.github.mcthesw.easy-nats.metainfo.xml
+++ b/packaging/flatpak/io.github.mcthesw.easy-nats.metainfo.xml
@@ -23,6 +23,11 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="0.1.22" date="2026-05-27">
+      <description>
+        <p>Fixes KV value and history panel sizing.</p>
+      </description>
+    </release>
     <release version="0.1.21" date="2026-05-19">
       <description>
         <p>Fixes KV key list scrolling in narrow panes.</p>


### PR DESCRIPTION
## Summary
- Expand the KV history panel and value preview to use the available detail-pane space.
- Add the Flathub/AppStream 0.1.22 note for the KV sizing fix.