### PR TITLE
Fix theme preference persistence

### DIFF
--- a/crates/app/src/theme/mod.rs
+++ b/crates/app/src/theme/mod.rs
@@ -14,11 +14,46 @@ pub fn resolve_theme(saved_theme: Option<ThemeId>, system_prefers_dark: Option<b
 }
 
 pub fn apply_theme(ctx: &egui::Context, theme_id: ThemeId) {
+    let egui_theme = if theme_definition(theme_id).is_dark {
+        egui::Theme::Dark
+    } else {
+        egui::Theme::Light
+    };
+    ctx.set_theme(egui_theme);
+
     match theme_id {
         ThemeId::EguiDark | ThemeId::EguiLight => builtin::apply_theme(ctx, theme_id),
         ThemeId::CatppuccinLatte
         | ThemeId::CatppuccinFrappe
         | ThemeId::CatppuccinMacchiato
         | ThemeId::CatppuccinMocha => catppuccin::apply_theme(ctx, theme_id),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ThemeId, apply_theme};
+    use eframe::egui::{Context, Theme};
+
+    #[test]
+    fn applying_dark_theme_switches_egui_preference_from_light() {
+        let ctx = Context::default();
+        ctx.set_theme(Theme::Light);
+
+        apply_theme(&ctx, ThemeId::CatppuccinMocha);
+
+        assert_eq!(ctx.theme(), Theme::Dark);
+        assert!(ctx.global_style().visuals.dark_mode);
+    }
+
+    #[test]
+    fn applying_light_theme_switches_egui_preference_from_dark() {
+        let ctx = Context::default();
+        ctx.set_theme(Theme::Dark);
+
+        apply_theme(&ctx, ThemeId::CatppuccinLatte);
+
+        assert_eq!(ctx.theme(), Theme::Light);
+        assert!(!ctx.global_style().visuals.dark_mode);
     }
 }

--- a/packaging/flatpak/io.github.mcthesw.easy-nats.metainfo.xml
+++ b/packaging/flatpak/io.github.mcthesw.easy-nats.metainfo.xml
@@ -23,6 +23,11 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="0.1.23" date="2026-05-29">
+      <description>
+        <p>Fixes saved theme selection when opening the app.</p>
+      </description>
+    </release>
     <release version="0.1.22" date="2026-05-27">
       <description>
         <p>Fixes KV value and history panel sizing.</p>


### PR DESCRIPTION
Fix saved dark and custom themes being overwritten by egui's light/system preference when the app opens by syncing egui's theme preference before applying Easy NATS visuals.