### PR TITLE
Add formatted search result previews

### DIFF
--- a/assets/i18n/search_workspace.yaml
+++ b/assets/i18n/search_workspace.yaml
@@ -66,8 +66,11 @@ stale_result:
   en: "Source changed; showing saved preview."
   zh: "来源已变化；显示保存的预览。"
 open_source:
-  en: "Open source"
-  zh: "打开来源"
+  en: "Go to source"
+  zh: "转到来源"
+preview_format:
+  en: "Display"
+  zh: "显示"
 field_key:
   en: "Key"
   zh: "键"

--- a/crates/app/src/app/actions.rs
+++ b/crates/app/src/app/actions.rs
@@ -225,6 +225,7 @@ impl EasyNatsApp {
             state.load_generation = new_gen;
             state.keys.clear();
             state.fetched_values.clear();
+            state.fetched_value_bytes.clear();
             state.invalidate_filtered_key_cache();
             state.value_search_cursor = 0;
             state.value_search_scanning = 0;

--- a/crates/app/src/app/kv_results.rs
+++ b/crates/app/src/app/kv_results.rs
@@ -117,6 +117,9 @@ impl EasyNatsApp {
                 state
                     .fetched_values
                     .insert(entry_key.to_string(), entry_value.clone());
+                state
+                    .fetched_value_bytes
+                    .insert(entry_key.to_string(), entry.value.clone());
                 state.invalidate_filtered_key_cache();
                 state.search_generation = state.search_generation.wrapping_add(1);
                 if state.value_search_pending.remove(entry_key) {
@@ -188,6 +191,7 @@ impl EasyNatsApp {
                 state.load_generation = new_gen;
                 state.keys.clear();
                 state.fetched_values.clear();
+                state.fetched_value_bytes.clear();
                 state.invalidate_filtered_key_cache();
                 state.value_search_cursor = 0;
                 state.value_search_scanning = 0;
@@ -317,7 +321,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use egui_dock::DockState;
-    use nats_backend::{BackendErrorContext, BackendOperation};
+    use nats_backend::{BackendErrorContext, BackendOperation, KvEntryInfo};
     use tokio_util::sync::CancellationToken;
 
     use super::EasyNatsApp;
@@ -344,6 +348,40 @@ mod tests {
             state,
         }]);
         app
+    }
+
+    #[test]
+    fn apply_kv_entry_keeps_raw_value_bytes() {
+        let mut app = test_app_with_kv_tab(7, "ORDERS", KvBucketState::default());
+        app.apply_kv_entry(
+            7,
+            KvEntryInfo {
+                bucket: "ORDERS".to_string(),
+                key: "orders/1".to_string(),
+                value: b"abc\xff".to_vec(),
+                revision: Some(1),
+                delta: None,
+                created: None,
+                operation: None,
+            },
+        );
+
+        let (_, tab) = app
+            .dock_state
+            .iter_all_tabs()
+            .next()
+            .expect("KV tab exists");
+        let TabKind::KvBucket { state, .. } = tab else {
+            panic!("expected KV bucket tab");
+        };
+        assert_eq!(
+            state.fetched_values.get("orders/1").map(String::as_str),
+            Some("abc\u{fffd}")
+        );
+        assert_eq!(
+            state.fetched_value_bytes.get("orders/1").map(Vec::as_slice),
+            Some(b"abc\xff".as_slice())
+        );
     }
 
     #[test]

--- a/crates/app/src/format.rs
+++ b/crates/app/src/format.rs
@@ -1,6 +1,7 @@
 use base64::Engine;
 use eframe::egui;
 use egui::text::LayoutJob;
+use std::ops::Range;
 
 use crate::proto::{AutoDetectResult, ProtoViewState};
 use crate::schema::{MessageSchemaManager, PayloadSchemaStatus, SchemaStatusLevel};
@@ -233,6 +234,152 @@ pub fn format_hex(data: &[u8]) -> String {
 /// Format as Base64 encoded string.
 pub fn format_base64(data: &[u8]) -> String {
     base64::engine::general_purpose::STANDARD.encode(data)
+}
+
+pub const READ_ONLY_PREVIEW_FORMATS: &[PayloadFormat] = &[
+    PayloadFormat::Auto,
+    PayloadFormat::Text,
+    PayloadFormat::Json,
+    PayloadFormat::Hex,
+    PayloadFormat::Base64,
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReadOnlyPreview {
+    pub resolved_format: PayloadFormat,
+    pub text: String,
+}
+
+pub fn format_read_only_preview(data: &[u8], format: PayloadFormat) -> ReadOnlyPreview {
+    let requested = if READ_ONLY_PREVIEW_FORMATS.contains(&format) {
+        format
+    } else {
+        PayloadFormat::Auto
+    };
+    let resolved = resolve_format(requested, data);
+    let text = match resolved {
+        PayloadFormat::Json => format_json(data),
+        PayloadFormat::Hex => format_hex(data),
+        PayloadFormat::Base64 => format_base64(data),
+        PayloadFormat::Text | PayloadFormat::Auto => format_text(data),
+        PayloadFormat::Protobuf => format_text(data),
+    };
+    ReadOnlyPreview {
+        resolved_format: resolved,
+        text,
+    }
+}
+
+pub fn preview_match_ranges(text: &str, query: &str) -> Vec<Range<usize>> {
+    let query = query.trim();
+    if text.is_empty() || query.is_empty() {
+        return Vec::new();
+    }
+
+    if text.is_ascii() && query.is_ascii() {
+        return ascii_match_ranges(text, query);
+    }
+
+    unicode_match_ranges(text, query)
+}
+
+pub fn read_only_preview_layout_job(
+    preview: &ReadOnlyPreview,
+    style: &egui::Style,
+    query: &str,
+) -> LayoutJob {
+    let ranges = preview_match_ranges(&preview.text, query);
+    highlighted_monospace_job(&preview.text, style, &ranges)
+}
+
+fn ascii_match_ranges(text: &str, query: &str) -> Vec<Range<usize>> {
+    let text_bytes = text.as_bytes();
+    let query_bytes = query.as_bytes();
+    if query_bytes.len() > text_bytes.len() {
+        return Vec::new();
+    }
+
+    let mut ranges = Vec::new();
+    let mut index = 0;
+    while index + query_bytes.len() <= text_bytes.len() {
+        let window = &text_bytes[index..index + query_bytes.len()];
+        let matches = window
+            .iter()
+            .zip(query_bytes.iter())
+            .all(|(value, query)| value.eq_ignore_ascii_case(query));
+        if matches {
+            ranges.push(index..index + query_bytes.len());
+            index += query_bytes.len();
+        } else {
+            index += 1;
+        }
+    }
+    ranges
+}
+
+fn unicode_match_ranges(text: &str, query: &str) -> Vec<Range<usize>> {
+    let query_chars = query.chars().count();
+    if query_chars == 0 {
+        return Vec::new();
+    }
+    let query_lower = query.to_lowercase();
+    let starts = text.char_indices().map(|(idx, _)| idx).collect::<Vec<_>>();
+    let mut ranges = Vec::new();
+    let mut cursor = 0;
+
+    while cursor < starts.len() {
+        let start = starts[cursor];
+        let Some(end) = byte_index_after_chars(text, start, query_chars) else {
+            break;
+        };
+        if text[start..end].to_lowercase() == query_lower {
+            ranges.push(start..end);
+            cursor += query_chars;
+        } else {
+            cursor += 1;
+        }
+    }
+    ranges
+}
+
+fn byte_index_after_chars(text: &str, start: usize, char_count: usize) -> Option<usize> {
+    let mut iter = text[start..].char_indices();
+    for _ in 0..char_count {
+        iter.next()?;
+    }
+    iter.next().map(|(idx, _)| start + idx).or(Some(text.len()))
+}
+
+fn highlighted_monospace_job(
+    text: &str,
+    style: &egui::Style,
+    ranges: &[Range<usize>],
+) -> LayoutJob {
+    let mut job = LayoutJob::default();
+    let mono = egui::FontId::monospace(13.0);
+    let text_color = style.visuals.text_color();
+    let highlight_bg = style.visuals.selection.bg_fill;
+    let highlight_fg = style.visuals.selection.stroke.color;
+    let normal = egui::TextFormat::simple(mono.clone(), text_color);
+    let highlighted = egui::TextFormat {
+        font_id: mono,
+        color: highlight_fg,
+        background: highlight_bg,
+        ..Default::default()
+    };
+
+    let mut cursor = 0;
+    for range in ranges {
+        if range.start > cursor {
+            job.append(&text[cursor..range.start], 0.0, normal.clone());
+        }
+        job.append(&text[range.clone()], 0.0, highlighted.clone());
+        cursor = range.end;
+    }
+    if cursor < text.len() {
+        job.append(&text[cursor..], 0.0, normal);
+    }
+    job
 }
 
 /// Show a format selector combo box. Returns true if the format changed.
@@ -534,5 +681,57 @@ mod tests {
             resolve_format(PayloadFormat::Hex, b"hello"),
             PayloadFormat::Hex
         );
+    }
+
+    #[test]
+    fn read_only_preview_pretty_prints_json() {
+        let preview = format_read_only_preview(br#"{"a":1,"b":"hello"}"#, PayloadFormat::Auto);
+
+        assert_eq!(preview.resolved_format, PayloadFormat::Json);
+        assert!(preview.text.contains("  \"a\": 1"));
+        assert!(preview.text.contains("  \"b\": \"hello\""));
+    }
+
+    #[test]
+    fn read_only_preview_formats_text_and_binary_auto_fallback() {
+        let text = format_read_only_preview(b"hello", PayloadFormat::Auto);
+        assert_eq!(text.resolved_format, PayloadFormat::Text);
+        assert_eq!(text.text, "hello");
+
+        let binary = format_read_only_preview(&[0xFF, 0xFE, 0x00], PayloadFormat::Auto);
+        assert_eq!(binary.resolved_format, PayloadFormat::Hex);
+        assert!(binary.text.contains("FF FE 00"));
+    }
+
+    #[test]
+    fn read_only_preview_falls_back_for_unsupported_format() {
+        let preview = format_read_only_preview(br#"{"a":1}"#, PayloadFormat::Protobuf);
+
+        assert_eq!(preview.resolved_format, PayloadFormat::Json);
+        assert!(preview.text.contains("\"a\": 1"));
+    }
+
+    #[test]
+    fn preview_match_ranges_find_ascii_matches_case_insensitively() {
+        let ranges = preview_match_ranges("Balance balance BALANCE", "balance");
+
+        assert_eq!(ranges, vec![0..7, 8..15, 16..23]);
+    }
+
+    #[test]
+    fn preview_match_ranges_find_matches_after_json_formatting() {
+        let preview =
+            format_read_only_preview(br#"{"event_id":"abc","kind":"path"}"#, PayloadFormat::Json);
+        let ranges = preview_match_ranges(&preview.text, "kind");
+
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(&preview.text[ranges[0].clone()], "kind");
+    }
+
+    #[test]
+    fn preview_match_ranges_omit_absent_transformed_output() {
+        let preview = format_read_only_preview(b"balance", PayloadFormat::Base64);
+
+        assert!(preview_match_ranges(&preview.text, "balance").is_empty());
     }
 }

--- a/crates/app/src/tabs/kv.rs
+++ b/crates/app/src/tabs/kv.rs
@@ -51,6 +51,7 @@ pub fn kv_bucket_ui(
         state.load_generation = new_gen;
         state.keys.clear();
         state.fetched_values.clear();
+        state.fetched_value_bytes.clear();
         key_filter::invalidate(state);
         state.value_search_cursor = 0;
         state.value_search_scanning = 0;
@@ -319,6 +320,7 @@ fn refresh_kv_keys(
     state.load_generation = new_gen;
     state.keys.clear();
     state.fetched_values.clear();
+    state.fetched_value_bytes.clear();
     key_filter::invalidate(state);
     state.value_search_cursor = 0;
     state.value_search_scanning = 0;

--- a/crates/app/src/tabs/search_workspace.rs
+++ b/crates/app/src/tabs/search_workspace.rs
@@ -1,5 +1,6 @@
 use eframe::egui;
 
+use crate::format::{self, PayloadFormat};
 use crate::i18n::t;
 
 use super::common::SEARCH_RESULT_LIMIT;
@@ -405,38 +406,71 @@ fn render_preview(
         return;
     };
 
-    let current = results
-        .iter()
-        .find(|result| result.identity == preview.identity);
-    let active_preview = current.unwrap_or(preview);
+    let (active_preview, is_stale) = active_preview_result(preview, results);
 
     ui.heading(&active_preview.item_label);
     ui.horizontal_wrapped(|ui| {
         ui.label(&active_preview.source_label);
         ui.weak(field_label(active_preview.field));
-        if current.is_none() {
+        if is_stale {
             ui.weak(t("search_workspace.stale_result"));
         }
     });
     ui.add_space(4.0);
-    if let Some(current) = current {
-        if ui.button(t("search_workspace.open_source")).clicked() {
-            actions.push(TabAction::NavigateSearchResult {
-                locator: current.locator.clone(),
-            });
+    ui.horizontal_wrapped(|ui| {
+        render_preview_format_selector(ui, &mut state.preview_format);
+        if !is_stale {
+            if ui.button(t("search_workspace.open_source")).clicked() {
+                actions.push(TabAction::NavigateSearchResult {
+                    locator: active_preview.locator.clone(),
+                });
+            }
+        } else {
+            ui.add_enabled(false, egui::Button::new(t("search_workspace.open_source")));
         }
-    } else {
-        ui.add_enabled(false, egui::Button::new(t("search_workspace.open_source")));
-    }
+    });
     ui.separator();
-    let mut preview_text = active_preview.preview.clone();
-    ui.add(
-        egui::TextEdit::multiline(&mut preview_text)
-            .desired_width(f32::INFINITY)
-            .desired_rows(14)
-            .code_editor()
-            .interactive(false),
-    );
+    render_formatted_preview(ui, active_preview, state.preview_format, &state.query);
+}
+
+fn render_preview_format_selector(ui: &mut egui::Ui, format: &mut PayloadFormat) {
+    if !format::READ_ONLY_PREVIEW_FORMATS.contains(format) {
+        *format = PayloadFormat::Auto;
+    }
+    ui.label(t("search_workspace.preview_format"));
+    egui::ComboBox::from_id_salt("search_workspace_preview_format")
+        .selected_text(format.label())
+        .show_ui(ui, |ui| {
+            for &choice in format::READ_ONLY_PREVIEW_FORMATS {
+                ui.selectable_value(format, choice, choice.label());
+            }
+        });
+}
+
+fn render_formatted_preview(
+    ui: &mut egui::Ui,
+    result: &SearchWorkspaceResult,
+    selected_format: PayloadFormat,
+    query: &str,
+) {
+    let preview = format::format_read_only_preview(&result.preview_bytes, selected_format);
+    let job = format::read_only_preview_layout_job(&preview, ui.style(), query);
+    egui::ScrollArea::both()
+        .id_salt("search_workspace_preview")
+        .auto_shrink([false, false])
+        .show(ui, |ui| {
+            ui.add(egui::Label::new(job).selectable(true));
+        });
+}
+
+fn active_preview_result<'a>(
+    preview: &'a SearchWorkspaceResult,
+    results: &'a [SearchWorkspaceResult],
+) -> (&'a SearchWorkspaceResult, bool) {
+    results
+        .iter()
+        .find(|result| result.identity == preview.identity)
+        .map_or((preview, true), |current| (current, false))
 }
 
 fn field_label(field: SearchField) -> &'static str {

--- a/crates/app/src/tabs/search_workspace/results.rs
+++ b/crates/app/src/tabs/search_workspace/results.rs
@@ -107,6 +107,7 @@ fn append_kv_results(
                     key,
                     key,
                     key,
+                    key.as_bytes(),
                     SearchResultLocator::KvKey {
                         connection_id,
                         bucket_name: bucket_name.to_string(),
@@ -127,12 +128,18 @@ fn append_kv_results(
             ctx.stats.records_scanned += 1;
             ctx.stats.payload_value_bytes += value.len();
             if ctx.query.matches(value) {
+                let preview_bytes = state
+                    .fetched_value_bytes
+                    .get(key.as_str())
+                    .map(Vec::as_slice)
+                    .unwrap_or_else(|| value.as_bytes());
                 push_result(
                     &mut ctx,
                     SearchField::Value,
                     key,
                     key,
                     value,
+                    preview_bytes,
                     SearchResultLocator::KvKey {
                         connection_id,
                         bucket_name: bucket_name.to_string(),
@@ -167,6 +174,7 @@ fn append_stream_results(
                     &sequence.to_string(),
                     &item_label,
                     subject,
+                    subject.as_bytes(),
                     SearchResultLocator::StreamMessage {
                         connection_id,
                         stream_name: stream_name.to_string(),
@@ -191,6 +199,7 @@ fn append_stream_results(
                     &sequence.to_string(),
                     &item_label,
                     &payload,
+                    &msg.payload,
                     SearchResultLocator::StreamMessage {
                         connection_id,
                         stream_name: stream_name.to_string(),
@@ -222,6 +231,7 @@ fn append_subscriber_results(
                     &msg.id.to_string(),
                     &item_label,
                     &msg.subject,
+                    msg.subject.as_bytes(),
                     SearchResultLocator::SubscriberMessage {
                         connection_id,
                         backend_id,
@@ -246,6 +256,7 @@ fn append_subscriber_results(
                     &msg.id.to_string(),
                     &item_label,
                     &payload,
+                    &msg.payload,
                     SearchResultLocator::SubscriberMessage {
                         connection_id,
                         backend_id,
@@ -275,6 +286,7 @@ fn push_result(
     item_id: &str,
     item_label: &str,
     text: &str,
+    preview_bytes: &[u8],
     locator: SearchResultLocator,
 ) {
     ctx.results.push(SearchWorkspaceResult {
@@ -288,7 +300,7 @@ fn push_result(
         field,
         item_label: item_label.to_string(),
         snippet: compact_text(text, 160),
-        preview: text.to_string(),
+        preview_bytes: preview_bytes.to_vec(),
         locator,
     });
 }

--- a/crates/app/src/tabs/search_workspace/tests.rs
+++ b/crates/app/src/tabs/search_workspace/tests.rs
@@ -1,13 +1,27 @@
 use nats_backend::StreamMessageInfo;
 use tokio_util::sync::CancellationToken;
 
+use super::super::types::{SearchResultIdentity, SearchResultLocator};
 use super::*;
-use crate::tabs::{NormalizedSearchQuery, StreamState, TabGuard};
+use crate::format::{self, PayloadFormat};
+use crate::tabs::{KvBucketState, NormalizedSearchQuery, StreamState, TabGuard};
 
 fn stream_source_and_tab(
     stream_name: &str,
     generation: u64,
     messages: Vec<(&str, &str)>,
+) -> (SearchSourceSummary, TabKind) {
+    let messages = messages
+        .into_iter()
+        .map(|(subject, payload)| (subject, payload.as_bytes().to_vec()))
+        .collect();
+    stream_source_and_tab_bytes(stream_name, generation, messages)
+}
+
+fn stream_source_and_tab_bytes(
+    stream_name: &str,
+    generation: u64,
+    messages: Vec<(&str, Vec<u8>)>,
 ) -> (SearchSourceSummary, TabKind) {
     let tab = TabKind::Stream {
         connection_id: 1,
@@ -21,7 +35,7 @@ fn stream_source_and_tab(
                 .map(|(idx, (subject, payload))| StreamMessageInfo {
                     sequence: idx as u64 + 1,
                     subject: subject.to_string(),
-                    payload: payload.as_bytes().to_vec(),
+                    payload,
                     headers: Vec::new(),
                     time: String::new(),
                 })
@@ -31,6 +45,31 @@ fn stream_source_and_tab(
         },
     };
     let source = source_summary_from_tab(&tab).expect("stream tab is searchable");
+    (source, tab)
+}
+
+fn kv_source_and_tab(
+    bucket_name: &str,
+    generation: u64,
+    values: Vec<(&str, String, Vec<u8>)>,
+) -> (SearchSourceSummary, TabKind) {
+    let mut state = KvBucketState {
+        keys: values.iter().map(|(key, _, _)| key.to_string()).collect(),
+        search_generation: generation,
+        ..Default::default()
+    };
+    for (key, decoded_value, raw_value) in values {
+        state.fetched_values.insert(key.to_string(), decoded_value);
+        state.fetched_value_bytes.insert(key.to_string(), raw_value);
+    }
+    let tab = TabKind::KvBucket {
+        connection_id: 1,
+        connection_name: "local".to_string(),
+        bucket_name: bucket_name.to_string(),
+        guard: TabGuard::new_without_id(CancellationToken::new()),
+        state,
+    };
+    let source = source_summary_from_tab(&tab).expect("KV tab is searchable");
     (source, tab)
 }
 
@@ -149,4 +188,102 @@ fn workspace_results_ignore_missing_selected_sources() {
 fn compact_text_collapses_and_truncates() {
     assert_eq!(compact_text("a\n b  c", 8), "a b c");
     assert_eq!(compact_text("abcdef", 3), "abc...");
+}
+
+#[test]
+fn workspace_payload_preview_keeps_original_bytes_for_formatting() {
+    let (source, tab) =
+        stream_source_and_tab_bytes("orders", 1, vec![("orders.created", b"abc\xff".to_vec())]);
+    let state = SearchWorkspaceState {
+        query: "abc".to_string(),
+        selected_sources: vec![source.id.clone()],
+        ..Default::default()
+    };
+
+    let results = workspace_results(&state, &[(source, tab)]);
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].snippet, "abc\u{fffd}");
+    assert_eq!(results[0].preview_bytes, b"abc\xff");
+    let hex = format::format_read_only_preview(&results[0].preview_bytes, PayloadFormat::Hex);
+    assert!(hex.text.contains("61 62 63 FF"));
+    assert!(!hex.text.contains("EF BF BD"));
+}
+
+#[test]
+fn workspace_kv_value_preview_keeps_original_bytes_for_formatting() {
+    let (source, tab) = kv_source_and_tab(
+        "orders",
+        1,
+        vec![("orders.1", "abc\u{fffd}".to_string(), b"abc\xff".to_vec())],
+    );
+    let state = SearchWorkspaceState {
+        query: "abc".to_string(),
+        selected_sources: vec![source.id.clone()],
+        primary: false,
+        secondary: true,
+        ..Default::default()
+    };
+
+    let results = workspace_results(&state, &[(source, tab)]);
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].snippet, "abc\u{fffd}");
+    assert_eq!(results[0].preview_bytes, b"abc\xff");
+    let hex = format::format_read_only_preview(&results[0].preview_bytes, PayloadFormat::Hex);
+    assert!(hex.text.contains("61 62 63 FF"));
+    assert!(!hex.text.contains("EF BF BD"));
+}
+
+#[test]
+fn workspace_preview_format_defaults_to_auto_and_persists() {
+    let mut state = SearchWorkspaceState::default();
+    assert_eq!(state.preview_format, PayloadFormat::Auto);
+
+    state.preview_format = PayloadFormat::Json;
+    state.selected_preview = Some(SearchWorkspaceResult {
+        identity: SearchResultIdentity {
+            source_id: SearchSourceId::Stream {
+                connection_id: 1,
+                stream_name: "orders".to_string(),
+            },
+            generation: 1,
+            field: SearchField::Payload,
+            item_id: "1".to_string(),
+        },
+        source_label: "orders (local)".to_string(),
+        field: SearchField::Payload,
+        item_label: "#1 orders.created".to_string(),
+        snippet: "{\"balance\":42}".to_string(),
+        preview_bytes: br#"{"balance":42}"#.to_vec(),
+        locator: SearchResultLocator::StreamMessage {
+            connection_id: 1,
+            stream_name: "orders".to_string(),
+            sequence: 1,
+        },
+    });
+
+    state.selected_result = None;
+
+    assert_eq!(state.preview_format, PayloadFormat::Json);
+}
+
+#[test]
+fn active_preview_result_prefers_current_result_and_marks_stale_snapshot() {
+    let (source, tab) = stream_source_and_tab("orders", 1, vec![("orders.created", "balance: 42")]);
+    let state = SearchWorkspaceState {
+        query: "balance".to_string(),
+        selected_sources: vec![source.id.clone()],
+        ..Default::default()
+    };
+    let results = workspace_results(&state, &[(source, tab)]);
+    let snapshot = results[0].clone();
+
+    let (active, stale) = active_preview_result(&snapshot, &results);
+    assert!(!stale);
+    assert_eq!(active.snippet, "balance: 42");
+
+    let (active, stale) = active_preview_result(&snapshot, &[]);
+    assert!(stale);
+    assert_eq!(active.snippet, "balance: 42");
 }

--- a/crates/app/src/tabs/types.rs
+++ b/crates/app/src/tabs/types.rs
@@ -355,7 +355,7 @@ pub struct SearchWorkspaceResult {
     pub field: SearchField,
     pub item_label: String,
     pub snippet: String,
-    pub preview: String,
+    pub preview_bytes: Vec<u8>,
     pub locator: SearchResultLocator,
 }
 
@@ -377,6 +377,7 @@ pub struct SearchWorkspaceState {
     pub selected_sources: Vec<SearchSourceId>,
     pub selected_result: Option<SearchResultIdentity>,
     pub selected_preview: Option<SearchWorkspaceResult>,
+    pub preview_format: PayloadFormat,
     pub cached_results: Option<CachedSearchWorkspaceResults>,
 }
 
@@ -420,6 +421,7 @@ impl Default for SearchWorkspaceState {
             selected_sources: Vec::new(),
             selected_result: None,
             selected_preview: None,
+            preview_format: PayloadFormat::Auto,
             cached_results: None,
         }
     }
@@ -577,6 +579,7 @@ pub struct KvBucketState {
     pub entry_key: String,
     pub entry_value: String,
     pub fetched_values: HashMap<String, String>,
+    pub fetched_value_bytes: HashMap<String, Vec<u8>>,
     pub entry_revision: Option<u64>,
     pub entry_operation: Option<String>,
     pub entry_created: Option<String>,
@@ -610,6 +613,7 @@ impl Default for KvBucketState {
             entry_key: String::new(),
             entry_value: String::new(),
             fetched_values: HashMap::new(),
+            fetched_value_bytes: HashMap::new(),
             entry_revision: None,
             entry_operation: None,
             entry_created: None,

--- a/packaging/flatpak/io.github.mcthesw.easy-nats.metainfo.xml
+++ b/packaging/flatpak/io.github.mcthesw.easy-nats.metainfo.xml
@@ -23,6 +23,11 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="0.1.24" date="2026-06-16">
+      <description>
+        <p>Adds formatted Search Workspace result previews.</p>
+      </description>
+    </release>
     <release version="0.1.23" date="2026-05-29">
       <description>
         <p>Fixes saved theme selection when opening the app.</p>


### PR DESCRIPTION
## Summary

Adds formatted, read-only Search Workspace result previews with a compact display selector and visible query highlighting. The source navigation button now reads `Go to source` to avoid the `Open source` ambiguity.

Also updates the Flatpak metainfo release notes for the user-visible preview improvement.

## Review Follow-up

Preserves original payload and KV value bytes for Search Workspace previews so Hex/Base64 formatting does not encode lossy UTF-8 replacement text for binary stream, subscriber, or KV value matches.

## Checks

- `cargo test -p easy-nats format --no-fail-fast`
- `cargo test -p easy-nats search_workspace --no-fail-fast`
- `cargo test -p easy-nats apply_kv_entry_keeps_raw_value_bytes --no-fail-fast`
- `cargo clippy --workspace --all-targets`
- Parsed `packaging/flatpak/io.github.mcthesw.easy-nats.metainfo.xml` as XML and confirmed the top release is `0.1.24`.
- `git diff --check` reported no whitespace errors beyond Windows line-ending warnings.