### PR TITLE
fix(connection): close bound tabs on disconnect

### DIFF
--- a/crates/app/src/app/actions.rs
+++ b/crates/app/src/app/actions.rs
@@ -32,6 +32,14 @@ impl EasyNatsApp {
 
     pub(crate) fn disconnect(&mut self, id: u64) {
         self.user_wants_connected.remove(&id);
+        // Close every tab bound to this connection so their auto-refresh loops and
+        // loading spinners stop driving backend commands against a connection that
+        // is being torn down (which would surface "Not connected" error toasts).
+        // The `Disconnect` command below aborts the connection's subscriptions and
+        // KV tasks wholesale, so `close_tabs_for_connection` does not send per-tab
+        // `Unsubscribe` (that is reserved for closing individual tabs on a live
+        // connection via `remove_tabs_matching`).
+        self.close_tabs_for_connection(id);
         self.backend.send(BackendCommand::Disconnect { id });
     }
 
@@ -507,14 +515,41 @@ impl EasyNatsApp {
                 (tab.tab_id(), unsubs)
             })
             .collect();
-        for (tid, unsubs) in to_remove {
+        for (_tid, unsubs) in &to_remove {
             for (connection_id, backend_id, subject) in unsubs {
                 self.backend.send(BackendCommand::Unsubscribe {
-                    connection_id,
-                    backend_id,
-                    subject,
+                    connection_id: *connection_id,
+                    backend_id: *backend_id,
+                    subject: subject.clone(),
                 });
             }
+        }
+        self.remove_tabs_by_ids(to_remove.into_iter().map(|(tid, _)| tid).collect());
+    }
+
+    /// Close every dock tab bound to a connection.
+    ///
+    /// Used during connection teardown (user disconnect / delete). The backend
+    /// `Disconnect` command already aborts that connection's subscriptions and KV
+    /// tasks wholesale, so — unlike closing an individual tab on a live connection
+    /// (`remove_tabs_matching`) — we do *not* send per-tab `Unsubscribe` here; doing
+    /// so would race the teardown and surface spurious "not subscribed" errors.
+    /// Dropping the tabs still fires each `TabGuard::drop` for token cancellation
+    /// and display-ID recycling.
+    pub(crate) fn close_tabs_for_connection(&mut self, connection_id: u64) {
+        let ids: Vec<egui::Id> = self
+            .dock_state
+            .iter_all_tabs()
+            .filter(|(_, tab)| tab.connection_id() == Some(connection_id))
+            .map(|(_, tab)| tab.tab_id())
+            .collect();
+        self.remove_tabs_by_ids(ids);
+    }
+
+    /// Remove tabs from the dock by structural id. Dropping each removed tab
+    /// fires its `TabGuard::drop` (token cancellation + display-ID recycling).
+    fn remove_tabs_by_ids(&mut self, ids: Vec<egui::Id>) {
+        for tid in ids {
             if let Some(pos) = self.dock_state.find_tab_from(|t| t.tab_id() == tid) {
                 self.dock_state.remove_tab(pos);
             }

--- a/crates/app/src/app/actions/tests.rs
+++ b/crates/app/src/app/actions/tests.rs
@@ -134,3 +134,51 @@ fn clients_tab_focuses_existing_tab_for_same_connection() {
 
     assert_eq!(count_clients_tabs(&app, 7), 1);
 }
+
+fn count_tabs_for_connection(app: &EasyNatsApp, connection_id: u64) -> usize {
+    app.dock_state
+        .iter_all_tabs()
+        .filter(|(_, tab)| tab.connection_id() == Some(connection_id))
+        .count()
+}
+
+#[test]
+fn disconnect_closes_all_tabs_bound_to_the_connection() {
+    let mut app = test_app(PubSubTabMode::NewTab);
+    push_metrics_connection(&mut app, 7);
+    push_metrics_connection(&mut app, 9);
+
+    app.open_or_focus_publisher_tab(7);
+    app.open_or_focus_subscriber_tab(7);
+    app.open_or_focus_metrics_tab(7);
+    app.open_or_focus_clients_tab(7);
+    app.open_or_focus_publisher_tab(9);
+
+    assert!(count_tabs_for_connection(&app, 7) >= 4);
+    assert_eq!(count_tabs_for_connection(&app, 9), 1);
+
+    app.disconnect(7);
+
+    assert_eq!(count_tabs_for_connection(&app, 7), 0);
+    // Tabs for an unrelated connection are untouched.
+    assert_eq!(count_tabs_for_connection(&app, 9), 1);
+}
+
+#[test]
+fn close_tabs_for_connection_preserves_singleton_tabs() {
+    let mut app = test_app(PubSubTabMode::NewTab);
+    push_metrics_connection(&mut app, 7);
+
+    app.open_or_focus_tab_kind(TabKind::Settings);
+    app.open_or_focus_metrics_tab(7);
+
+    app.close_tabs_for_connection(7);
+
+    // Settings has no backing connection and must survive connection teardown.
+    assert!(
+        app.dock_state
+            .iter_all_tabs()
+            .any(|(_, tab)| matches!(tab, TabKind::Settings))
+    );
+    assert_eq!(count_metrics_tabs(&app, 7), 0);
+}

--- a/crates/app/src/tabs/types/tab_kind.rs
+++ b/crates/app/src/tabs/types/tab_kind.rs
@@ -189,6 +189,29 @@ impl TabKind {
             TabKind::LogViewer => egui::Id::new("tab:log-viewer"),
         }
     }
+
+    /// The connection this tab is bound to, if any.
+    ///
+    /// Tabs without a backing connection (Welcome, SearchWorkspace, MessageSchemas,
+    /// Settings, LogViewer) return `None`. Used for connection-scoped teardown such
+    /// as closing every tab belonging to a disconnected connection.
+    pub fn connection_id(&self) -> Option<u64> {
+        match self {
+            TabKind::Welcome
+            | TabKind::SearchWorkspace { .. }
+            | TabKind::MessageSchemas { .. }
+            | TabKind::Settings
+            | TabKind::LogViewer => None,
+            TabKind::Publisher { connection_id, .. }
+            | TabKind::Subscriber { connection_id, .. }
+            | TabKind::Stream { connection_id, .. }
+            | TabKind::KvBucket { connection_id, .. }
+            | TabKind::ObjectStoreBucket { connection_id, .. }
+            | TabKind::ServerInfo { connection_id, .. }
+            | TabKind::Metrics { connection_id, .. }
+            | TabKind::Clients { connection_id, .. } => Some(*connection_id),
+        }
+    }
 }
 
 pub struct AppTabViewer<'a> {


### PR DESCRIPTION
## Problem

After disconnecting (⏏) a server, the tabs bound to that connection (Stream / KV / ObjectStore / ServerInfo / Metrics / Clients / Publisher / Subscriber) stayed open. Their auto-refresh loops and loading spinners kept issuing backend commands against the torn-down connection, surfacing `Not connected` error toasts, and the tabs themselves never closed.

## Fix

- Add `TabKind::connection_id() -> Option<u64>` to express tab→connection ownership in one place.
- Close every bound tab in `disconnect()` via a new `close_tabs_for_connection` helper.
- Connection teardown relies on the backend `Disconnect` command for wholesale subscription/KV-task cleanup, so no per-tab `Unsubscribe` is sent (avoids spurious `not subscribed` errors); `TabGuard::drop` still cancels tab-scoped tokens.
- Extract `remove_tabs_by_ids` to share the dock-removal logic with `remove_tabs_matching`.

## Scope

- Explicit user disconnect (⏏) and delete both close the connection's tabs.
- Transient server-side disconnect (user still wants connected) is unchanged — tabs stay for reconnect.

## Tests

- `disconnect_closes_all_tabs_bound_to_the_connection`
- `close_tabs_for_connection_preserves_singleton_tabs`
