### PR TITLE
feat: add MsgPack payload support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,6 +1019,7 @@ dependencies = [
  "prost-types",
  "protox",
  "rfd",
+ "rmpv",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3804,6 +3805,15 @@ checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
 dependencies = [
  "rmp",
  "serde",
+]
+
+[[package]]
+name = "rmpv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a4e1d4b9b938a26d2996af33229f0ca0956c652c1375067f0b45291c1df8417"
+dependencies = [
+ "rmp",
 ]
 
 [[package]]

--- a/assets/i18n/common.yaml
+++ b/assets/i18n/common.yaml
@@ -114,6 +114,18 @@ storage_label:
 replicas:
   en: "Replicas"
   zh: "副本数"
+payload_input_format:
+  en: "Input"
+  zh: "输入"
+payload_preview_format:
+  en: "Preview"
+  zh: "预览"
+payload_input_text:
+  en: "Text"
+  zh: "文本"
+payload_input_messagepack:
+  en: "MsgPack"
+  zh: "MsgPack"
 
 clear:
   en: "Clear"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 [dependencies]
 nats-backend = { path = "../nats-backend" }
 base64 = "0.22"
+rmpv = "1.3.1"
 # Keep native desktop functionality, but avoid eframe's default feature bundle
 # (notably wgpu + web_screen_reader) since this app explicitly uses Glow.
 # Inspection stays inactive unless EGUI_INSPECTION is explicitly set at runtime.

--- a/crates/app/src/app/actions.rs
+++ b/crates/app/src/app/actions.rs
@@ -367,10 +367,11 @@ impl EasyNatsApp {
 
     pub(crate) fn publish_stream_editor(&mut self) {
         let subject = self.stream_publish_editor.subject.trim().to_string();
-        let outgoing = self.schema_manager.prepare_outgoing(
+        let outgoing = self.schema_manager.prepare_outgoing_with_input_format(
             self.stream_publish_editor.connection_id,
             &subject,
             &self.stream_publish_editor.payload,
+            self.stream_publish_editor.payload_input_format,
         );
         if !outgoing.can_send {
             if let Some(status) = outgoing.status {
@@ -466,10 +467,11 @@ impl EasyNatsApp {
             &self.kv_entry_create_editor.bucket_name,
             self.kv_entry_create_editor.key.trim(),
         );
-        let outgoing = self.schema_manager.prepare_outgoing(
+        let outgoing = self.schema_manager.prepare_outgoing_with_input_format(
             self.kv_entry_create_editor.connection_id,
             &subject,
             &self.kv_entry_create_editor.value,
+            self.kv_entry_create_editor.value_input_format,
         );
         if !outgoing.can_send {
             if let Some(status) = outgoing.status {

--- a/crates/app/src/app/editors.rs
+++ b/crates/app/src/app/editors.rs
@@ -3,6 +3,8 @@ use nats_backend::{
     ConsumerAckPolicyKind, ConsumerDeliverPolicyKind, ConsumerInfo, KvBucketInfo, StorageKind,
 };
 
+use crate::schema::PayloadInputFormat;
+
 #[derive(Default)]
 pub(crate) struct ConnectionEditor {
     pub(crate) visible: bool,
@@ -95,6 +97,7 @@ pub(crate) struct StreamPublishEditor {
     pub(crate) stream_name: String,
     pub(crate) subject: String,
     pub(crate) payload: String,
+    pub(crate) payload_input_format: PayloadInputFormat,
     pub(crate) headers: Vec<(String, String)>,
 }
 
@@ -106,6 +109,7 @@ impl StreamPublishEditor {
             stream_name,
             subject,
             payload: String::new(),
+            payload_input_format: PayloadInputFormat::Text,
             headers: Vec::new(),
         }
     }
@@ -359,6 +363,7 @@ pub(crate) struct KvEntryCreateEditor {
     pub(crate) bucket_name: String,
     pub(crate) key: String,
     pub(crate) value: String,
+    pub(crate) value_input_format: PayloadInputFormat,
 }
 
 impl KvEntryCreateEditor {
@@ -369,6 +374,7 @@ impl KvEntryCreateEditor {
             bucket_name,
             key: initial_key,
             value: String::new(),
+            value_input_format: PayloadInputFormat::Text,
         }
     }
 }

--- a/crates/app/src/app/windows/kv.rs
+++ b/crates/app/src/app/windows/kv.rs
@@ -3,6 +3,7 @@ use eframe::egui;
 use crate::format;
 use crate::i18n::t;
 use crate::schema::kv_subject;
+use crate::tabs::payload_input_format_selector;
 
 use super::super::{editors::StorageSelection, model::EasyNatsApp};
 
@@ -203,16 +204,23 @@ fn render_entry_create_editor(app: &mut EasyNatsApp, ui: &mut egui::Ui) {
                     app.kv_entry_create_editor.key.trim(),
                 );
                 let outgoing_preview = if !app.kv_entry_create_editor.key.trim().is_empty() {
-                    Some(app.schema_manager.prepare_outgoing(
+                    Some(app.schema_manager.prepare_outgoing_with_input_format(
                         app.kv_entry_create_editor.connection_id,
                         &entry_subject,
                         &app.kv_entry_create_editor.value,
+                        app.kv_entry_create_editor.value_input_format,
                     ))
                 } else {
                     None
                 };
                 ui.horizontal(|ui| {
                     ui.label(t("kv.value_editor"));
+                    ui.label(t("common.payload_input_format"));
+                    payload_input_format_selector(
+                        ui,
+                        "kv_entry_create_value_input_fmt",
+                        &mut app.kv_entry_create_editor.value_input_format,
+                    );
                     if ui.small_button(t("kv.format_json")).clicked()
                         && let Ok(val) = serde_json::from_str::<serde_json::Value>(
                             &app.kv_entry_create_editor.value,

--- a/crates/app/src/app/windows/stream.rs
+++ b/crates/app/src/app/windows/stream.rs
@@ -2,6 +2,7 @@ use eframe::egui;
 
 use crate::format;
 use crate::i18n::t;
+use crate::tabs::payload_input_format_selector;
 
 use super::super::model::EasyNatsApp;
 
@@ -169,16 +170,23 @@ fn render_publish(app: &mut EasyNatsApp, ui: &mut egui::Ui) {
                 ui.add_space(4.0);
                 let stream_subject = app.stream_publish_editor.subject.trim().to_string();
                 let outgoing_preview = if !stream_subject.is_empty() {
-                    Some(app.schema_manager.prepare_outgoing(
+                    Some(app.schema_manager.prepare_outgoing_with_input_format(
                         app.stream_publish_editor.connection_id,
                         &stream_subject,
                         &app.stream_publish_editor.payload,
+                        app.stream_publish_editor.payload_input_format,
                     ))
                 } else {
                     None
                 };
                 ui.horizontal(|ui| {
                     ui.label(t("publisher.payload"));
+                    ui.label(t("common.payload_input_format"));
+                    payload_input_format_selector(
+                        ui,
+                        "stream_publish_payload_input_fmt",
+                        &mut app.stream_publish_editor.payload_input_format,
+                    );
                     if ui.small_button(t("publisher.format_json")).clicked()
                         && let Ok(val) = serde_json::from_str::<serde_json::Value>(
                             &app.stream_publish_editor.payload,

--- a/crates/app/src/format/json.rs
+++ b/crates/app/src/format/json.rs
@@ -1,0 +1,119 @@
+use eframe::egui;
+use egui::text::LayoutJob;
+
+use super::format_text;
+
+/// Pretty-print JSON. Returns the formatted string.
+pub fn format_json(data: &[u8]) -> String {
+    match serde_json::from_slice::<serde_json::Value>(data) {
+        Ok(val) => serde_json::to_string_pretty(&val).unwrap_or_else(|_| format_text(data)),
+        Err(_) => format_text(data),
+    }
+}
+
+/// Build a `LayoutJob` with basic JSON syntax highlighting.
+pub fn json_syntax_highlight(json: &str, style: &egui::Style) -> LayoutJob {
+    let mut job = LayoutJob::default();
+    let mono = egui::FontId::monospace(13.0);
+    let base_color = style.visuals.text_color();
+
+    let string_color = if style.visuals.dark_mode {
+        egui::Color32::from_rgb(152, 195, 121)
+    } else {
+        egui::Color32::from_rgb(80, 161, 79)
+    };
+    let number_color = if style.visuals.dark_mode {
+        egui::Color32::from_rgb(209, 154, 102)
+    } else {
+        egui::Color32::from_rgb(152, 104, 1)
+    };
+    let keyword_color = if style.visuals.dark_mode {
+        egui::Color32::from_rgb(86, 182, 194)
+    } else {
+        egui::Color32::from_rgb(1, 132, 188)
+    };
+    let key_color = if style.visuals.dark_mode {
+        egui::Color32::from_rgb(224, 108, 117)
+    } else {
+        egui::Color32::from_rgb(228, 86, 73)
+    };
+
+    let chars: Vec<char> = json.chars().collect();
+    let mut i = 0;
+    let mut after_colon = false;
+
+    while i < chars.len() {
+        let ch = chars[i];
+        match ch {
+            '"' => {
+                let start = i;
+                i += 1;
+                while i < chars.len() {
+                    if chars[i] == '\\' {
+                        i += 2;
+                        continue;
+                    }
+                    if chars[i] == '"' {
+                        i += 1;
+                        break;
+                    }
+                    i += 1;
+                }
+                let s: String = chars[start..i].iter().collect();
+                let color = if after_colon { string_color } else { key_color };
+                job.append(&s, 0.0, egui::TextFormat::simple(mono.clone(), color));
+                after_colon = false;
+            }
+            ':' => {
+                job.append(":", 0.0, egui::TextFormat::simple(mono.clone(), base_color));
+                after_colon = true;
+                i += 1;
+            }
+            ',' | '{' | '}' | '[' | ']' => {
+                let s = String::from(ch);
+                job.append(&s, 0.0, egui::TextFormat::simple(mono.clone(), base_color));
+                after_colon = false;
+                i += 1;
+            }
+            't' | 'f' | 'n' => {
+                let start = i;
+                while i < chars.len() && chars[i].is_alphabetic() {
+                    i += 1;
+                }
+                let word: String = chars[start..i].iter().collect();
+                job.append(
+                    &word,
+                    0.0,
+                    egui::TextFormat::simple(mono.clone(), keyword_color),
+                );
+                after_colon = false;
+            }
+            c if c == '-' || c.is_ascii_digit() => {
+                let start = i;
+                while i < chars.len()
+                    && (chars[i].is_ascii_digit()
+                        || chars[i] == '.'
+                        || chars[i] == '-'
+                        || chars[i] == '+'
+                        || chars[i] == 'e'
+                        || chars[i] == 'E')
+                {
+                    i += 1;
+                }
+                let num: String = chars[start..i].iter().collect();
+                job.append(
+                    &num,
+                    0.0,
+                    egui::TextFormat::simple(mono.clone(), number_color),
+                );
+                after_colon = false;
+            }
+            _ => {
+                let s = String::from(ch);
+                job.append(&s, 0.0, egui::TextFormat::simple(mono.clone(), base_color));
+                i += 1;
+            }
+        }
+    }
+    job
+}

--- a/crates/app/src/format/mod.rs
+++ b/crates/app/src/format/mod.rs
@@ -1,10 +1,18 @@
 use base64::Engine;
 use eframe::egui;
-use egui::text::LayoutJob;
-use std::ops::Range;
 
 use crate::proto::{AutoDetectResult, ProtoViewState};
 use crate::schema::{MessageSchemaManager, PayloadSchemaStatus, SchemaStatusLevel};
+
+mod json;
+pub mod msgpack;
+mod preview;
+
+pub use json::{format_json, json_syntax_highlight};
+pub use msgpack::format_msgpack;
+pub use preview::{
+    READ_ONLY_PREVIEW_FORMATS, format_read_only_preview, read_only_preview_layout_job,
+};
 
 /// Display format for message payloads.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -13,6 +21,7 @@ pub enum PayloadFormat {
     Auto,
     Text,
     Json,
+    MessagePack,
     Hex,
     Base64,
     Protobuf,
@@ -23,6 +32,7 @@ impl PayloadFormat {
         PayloadFormat::Auto,
         PayloadFormat::Text,
         PayloadFormat::Json,
+        PayloadFormat::MessagePack,
         PayloadFormat::Hex,
         PayloadFormat::Base64,
         PayloadFormat::Protobuf,
@@ -33,6 +43,7 @@ impl PayloadFormat {
             PayloadFormat::Auto => "Auto",
             PayloadFormat::Text => "Text",
             PayloadFormat::Json => "JSON",
+            PayloadFormat::MessagePack => "MsgPack",
             PayloadFormat::Hex => "Hex",
             PayloadFormat::Base64 => "Base64",
             PayloadFormat::Protobuf => "Protobuf",
@@ -41,7 +52,7 @@ impl PayloadFormat {
 }
 
 /// Detects the best display format for `data`.
-/// Order: valid JSON → valid UTF-8 text → hex dump.
+/// Order: valid JSON -> valid UTF-8 text -> confident MessagePack -> hex dump.
 pub fn detect_format(data: &[u8]) -> PayloadFormat {
     if data.is_empty() {
         return PayloadFormat::Text;
@@ -53,6 +64,9 @@ pub fn detect_format(data: &[u8]) -> PayloadFormat {
     // Try UTF-8 text
     if std::str::from_utf8(data).is_ok() {
         return PayloadFormat::Text;
+    }
+    if msgpack::is_confident_auto(data) {
+        return PayloadFormat::MessagePack;
     }
     PayloadFormat::Hex
 }
@@ -71,124 +85,6 @@ pub fn resolve_format(format: PayloadFormat, data: &[u8]) -> PayloadFormat {
 /// Render payload as plain UTF-8 text (lossy).
 pub fn format_text(data: &[u8]) -> String {
     String::from_utf8_lossy(data).into_owned()
-}
-
-/// Pretty-print JSON. Returns the formatted string.
-pub fn format_json(data: &[u8]) -> String {
-    match serde_json::from_slice::<serde_json::Value>(data) {
-        Ok(val) => serde_json::to_string_pretty(&val).unwrap_or_else(|_| format_text(data)),
-        Err(_) => format_text(data),
-    }
-}
-
-/// Build a `LayoutJob` with basic JSON syntax highlighting.
-pub fn json_syntax_highlight(json: &str, style: &egui::Style) -> LayoutJob {
-    let mut job = LayoutJob::default();
-    let mono = egui::FontId::monospace(13.0);
-    let base_color = style.visuals.text_color();
-
-    let string_color = if style.visuals.dark_mode {
-        egui::Color32::from_rgb(152, 195, 121) // green
-    } else {
-        egui::Color32::from_rgb(80, 161, 79)
-    };
-    let number_color = if style.visuals.dark_mode {
-        egui::Color32::from_rgb(209, 154, 102) // orange
-    } else {
-        egui::Color32::from_rgb(152, 104, 1)
-    };
-    let keyword_color = if style.visuals.dark_mode {
-        egui::Color32::from_rgb(86, 182, 194) // cyan
-    } else {
-        egui::Color32::from_rgb(1, 132, 188)
-    };
-    let key_color = if style.visuals.dark_mode {
-        egui::Color32::from_rgb(224, 108, 117) // red
-    } else {
-        egui::Color32::from_rgb(228, 86, 73)
-    };
-
-    let chars: Vec<char> = json.chars().collect();
-    let mut i = 0;
-    let mut after_colon = false;
-
-    while i < chars.len() {
-        let ch = chars[i];
-        match ch {
-            '"' => {
-                // Scan string
-                let start = i;
-                i += 1;
-                while i < chars.len() {
-                    if chars[i] == '\\' {
-                        i += 2;
-                        continue;
-                    }
-                    if chars[i] == '"' {
-                        i += 1;
-                        break;
-                    }
-                    i += 1;
-                }
-                let s: String = chars[start..i].iter().collect();
-                let color = if after_colon { string_color } else { key_color };
-                job.append(&s, 0.0, egui::TextFormat::simple(mono.clone(), color));
-                after_colon = false;
-            }
-            ':' => {
-                job.append(":", 0.0, egui::TextFormat::simple(mono.clone(), base_color));
-                after_colon = true;
-                i += 1;
-            }
-            ',' | '{' | '}' | '[' | ']' => {
-                let s = String::from(ch);
-                job.append(&s, 0.0, egui::TextFormat::simple(mono.clone(), base_color));
-                after_colon = false;
-                i += 1;
-            }
-            't' | 'f' | 'n' => {
-                // true, false, null
-                let start = i;
-                while i < chars.len() && chars[i].is_alphabetic() {
-                    i += 1;
-                }
-                let word: String = chars[start..i].iter().collect();
-                job.append(
-                    &word,
-                    0.0,
-                    egui::TextFormat::simple(mono.clone(), keyword_color),
-                );
-                after_colon = false;
-            }
-            c if c == '-' || c.is_ascii_digit() => {
-                let start = i;
-                while i < chars.len()
-                    && (chars[i].is_ascii_digit()
-                        || chars[i] == '.'
-                        || chars[i] == '-'
-                        || chars[i] == '+'
-                        || chars[i] == 'e'
-                        || chars[i] == 'E')
-                {
-                    i += 1;
-                }
-                let num: String = chars[start..i].iter().collect();
-                job.append(
-                    &num,
-                    0.0,
-                    egui::TextFormat::simple(mono.clone(), number_color),
-                );
-                after_colon = false;
-            }
-            _ => {
-                // Whitespace or other
-                let s = String::from(ch);
-                job.append(&s, 0.0, egui::TextFormat::simple(mono.clone(), base_color));
-                i += 1;
-            }
-        }
-    }
-    job
 }
 
 /// Format as hex dump with offset | hex | ASCII columns.
@@ -236,152 +132,6 @@ pub fn format_base64(data: &[u8]) -> String {
     base64::engine::general_purpose::STANDARD.encode(data)
 }
 
-pub const READ_ONLY_PREVIEW_FORMATS: &[PayloadFormat] = &[
-    PayloadFormat::Auto,
-    PayloadFormat::Text,
-    PayloadFormat::Json,
-    PayloadFormat::Hex,
-    PayloadFormat::Base64,
-];
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ReadOnlyPreview {
-    pub resolved_format: PayloadFormat,
-    pub text: String,
-}
-
-pub fn format_read_only_preview(data: &[u8], format: PayloadFormat) -> ReadOnlyPreview {
-    let requested = if READ_ONLY_PREVIEW_FORMATS.contains(&format) {
-        format
-    } else {
-        PayloadFormat::Auto
-    };
-    let resolved = resolve_format(requested, data);
-    let text = match resolved {
-        PayloadFormat::Json => format_json(data),
-        PayloadFormat::Hex => format_hex(data),
-        PayloadFormat::Base64 => format_base64(data),
-        PayloadFormat::Text | PayloadFormat::Auto => format_text(data),
-        PayloadFormat::Protobuf => format_text(data),
-    };
-    ReadOnlyPreview {
-        resolved_format: resolved,
-        text,
-    }
-}
-
-pub fn preview_match_ranges(text: &str, query: &str) -> Vec<Range<usize>> {
-    let query = query.trim();
-    if text.is_empty() || query.is_empty() {
-        return Vec::new();
-    }
-
-    if text.is_ascii() && query.is_ascii() {
-        return ascii_match_ranges(text, query);
-    }
-
-    unicode_match_ranges(text, query)
-}
-
-pub fn read_only_preview_layout_job(
-    preview: &ReadOnlyPreview,
-    style: &egui::Style,
-    query: &str,
-) -> LayoutJob {
-    let ranges = preview_match_ranges(&preview.text, query);
-    highlighted_monospace_job(&preview.text, style, &ranges)
-}
-
-fn ascii_match_ranges(text: &str, query: &str) -> Vec<Range<usize>> {
-    let text_bytes = text.as_bytes();
-    let query_bytes = query.as_bytes();
-    if query_bytes.len() > text_bytes.len() {
-        return Vec::new();
-    }
-
-    let mut ranges = Vec::new();
-    let mut index = 0;
-    while index + query_bytes.len() <= text_bytes.len() {
-        let window = &text_bytes[index..index + query_bytes.len()];
-        let matches = window
-            .iter()
-            .zip(query_bytes.iter())
-            .all(|(value, query)| value.eq_ignore_ascii_case(query));
-        if matches {
-            ranges.push(index..index + query_bytes.len());
-            index += query_bytes.len();
-        } else {
-            index += 1;
-        }
-    }
-    ranges
-}
-
-fn unicode_match_ranges(text: &str, query: &str) -> Vec<Range<usize>> {
-    let query_chars = query.chars().count();
-    if query_chars == 0 {
-        return Vec::new();
-    }
-    let query_lower = query.to_lowercase();
-    let starts = text.char_indices().map(|(idx, _)| idx).collect::<Vec<_>>();
-    let mut ranges = Vec::new();
-    let mut cursor = 0;
-
-    while cursor < starts.len() {
-        let start = starts[cursor];
-        let Some(end) = byte_index_after_chars(text, start, query_chars) else {
-            break;
-        };
-        if text[start..end].to_lowercase() == query_lower {
-            ranges.push(start..end);
-            cursor += query_chars;
-        } else {
-            cursor += 1;
-        }
-    }
-    ranges
-}
-
-fn byte_index_after_chars(text: &str, start: usize, char_count: usize) -> Option<usize> {
-    let mut iter = text[start..].char_indices();
-    for _ in 0..char_count {
-        iter.next()?;
-    }
-    iter.next().map(|(idx, _)| start + idx).or(Some(text.len()))
-}
-
-fn highlighted_monospace_job(
-    text: &str,
-    style: &egui::Style,
-    ranges: &[Range<usize>],
-) -> LayoutJob {
-    let mut job = LayoutJob::default();
-    let mono = egui::FontId::monospace(13.0);
-    let text_color = style.visuals.text_color();
-    let highlight_bg = style.visuals.selection.bg_fill;
-    let highlight_fg = style.visuals.selection.stroke.color;
-    let normal = egui::TextFormat::simple(mono.clone(), text_color);
-    let highlighted = egui::TextFormat {
-        font_id: mono,
-        color: highlight_fg,
-        background: highlight_bg,
-        ..Default::default()
-    };
-
-    let mut cursor = 0;
-    for range in ranges {
-        if range.start > cursor {
-            job.append(&text[cursor..range.start], 0.0, normal.clone());
-        }
-        job.append(&text[range.clone()], 0.0, highlighted.clone());
-        cursor = range.end;
-    }
-    if cursor < text.len() {
-        job.append(&text[cursor..], 0.0, normal);
-    }
-    job
-}
-
 /// Show a format selector combo box. Returns true if the format changed.
 pub fn format_selector(ui: &mut egui::Ui, id_salt: &str, format: &mut PayloadFormat) -> bool {
     let before = *format;
@@ -411,6 +161,10 @@ pub fn render_payload(ui: &mut egui::Ui, data: &[u8], format: PayloadFormat) {
         PayloadFormat::Base64 => {
             let b64 = format_base64(data);
             ui.label(egui::RichText::new(b64).monospace());
+        }
+        PayloadFormat::MessagePack => {
+            let msgpack = format_msgpack(data);
+            ui.label(egui::RichText::new(msgpack).monospace());
         }
         PayloadFormat::Protobuf => {
             // Wire-format fallback when called without proto state
@@ -619,6 +373,13 @@ fn render_proto_decoded(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rmpv::{Value, encode::write_value};
+
+    fn encode_msgpack(value: Value) -> Vec<u8> {
+        let mut data = Vec::new();
+        write_value(&mut data, &value).unwrap();
+        data
+    }
 
     #[test]
     fn detect_json() {
@@ -635,6 +396,41 @@ mod tests {
     #[test]
     fn detect_hex_for_binary() {
         assert_eq!(detect_format(&[0xFF, 0xFE, 0x00, 0x01]), PayloadFormat::Hex);
+    }
+
+    #[test]
+    fn detect_messagepack_only_for_confident_structures() {
+        let map = encode_msgpack(Value::Map(vec![(Value::from("kind"), Value::from("path"))]));
+        let array = encode_msgpack(Value::Array(vec![Value::from(1), Value::from(2)]));
+        let binary = encode_msgpack(Value::Binary(vec![0, 1, 255]));
+        let ext = encode_msgpack(Value::Ext(-1, vec![0, 0, 0, 1]));
+
+        assert_eq!(detect_format(&map), PayloadFormat::MessagePack);
+        assert_eq!(detect_format(&array), PayloadFormat::MessagePack);
+        assert_eq!(detect_format(&binary), PayloadFormat::MessagePack);
+        assert_eq!(detect_format(&ext), PayloadFormat::MessagePack);
+
+        let boolean = encode_msgpack(Value::Boolean(true));
+        assert_eq!(detect_format(&boolean), PayloadFormat::Hex);
+    }
+
+    #[test]
+    fn detect_auto_keeps_json_and_utf8_before_messagepack() {
+        assert_eq!(detect_format(br#"{"a":1}"#), PayloadFormat::Json);
+
+        let msgpack_positive_integer = encode_msgpack(Value::from(42));
+        assert_eq!(
+            detect_format(&msgpack_positive_integer),
+            PayloadFormat::Text
+        );
+    }
+
+    #[test]
+    fn detect_auto_rejects_messagepack_with_trailing_bytes() {
+        let mut data = encode_msgpack(Value::Map(vec![(Value::from("a"), Value::from(1))]));
+        data.push(0);
+
+        assert_eq!(detect_format(&data), PayloadFormat::Hex);
     }
 
     #[test]
@@ -665,6 +461,46 @@ mod tests {
     #[test]
     fn base64_output() {
         assert_eq!(format_base64(b"Hello"), "SGVsbG8=");
+    }
+
+    #[test]
+    fn messagepack_display_formats_maps_arrays_and_scalars() {
+        let data = encode_msgpack(Value::Map(vec![
+            (Value::from("kind"), Value::from("path")),
+            (
+                Value::from("items"),
+                Value::Array(vec![Value::from(1), Value::Boolean(true)]),
+            ),
+        ]));
+
+        let rendered = format_msgpack(&data);
+
+        assert!(rendered.contains(r#""kind": "path""#));
+        assert!(rendered.contains(r#""items": ["#));
+        assert!(rendered.contains("1,"));
+        assert!(rendered.contains("true"));
+
+        let scalar = encode_msgpack(Value::from(42));
+        assert_eq!(format_msgpack(&scalar), "42");
+    }
+
+    #[test]
+    fn messagepack_display_preserves_binary_ext_and_non_string_keys() {
+        let binary = encode_msgpack(Value::Binary(vec![0, 1, 255]));
+        assert!(format_msgpack(&binary).contains("bin(3): 00 01 FF"));
+
+        let timestamp_ext = encode_msgpack(Value::Ext(-1, vec![0, 0, 0, 1]));
+        assert!(format_msgpack(&timestamp_ext).contains("ext(type: -1, len: 4): 00 00 00 01"));
+
+        let map = encode_msgpack(Value::Map(vec![(Value::from(7), Value::from("lucky"))]));
+        assert!(format_msgpack(&map).contains(r#"[7]: "lucky""#));
+    }
+
+    #[test]
+    fn messagepack_display_reports_local_decode_errors() {
+        let rendered = format_msgpack(&[0x81, 0xa1]);
+
+        assert!(rendered.starts_with("MsgPack decode error:"));
     }
 
     #[test]
@@ -704,6 +540,29 @@ mod tests {
     }
 
     #[test]
+    fn read_only_preview_supports_messagepack_selection() {
+        assert!(READ_ONLY_PREVIEW_FORMATS.contains(&PayloadFormat::MessagePack));
+
+        let data = encode_msgpack(Value::Map(vec![(Value::from("a"), Value::from(1))]));
+        let preview = format_read_only_preview(&data, PayloadFormat::Auto);
+
+        assert_eq!(preview.resolved_format, PayloadFormat::MessagePack);
+        assert!(preview.text.contains(r#""a": 1"#));
+    }
+
+    #[test]
+    fn read_only_preview_keeps_display_errors_isolated() {
+        let invalid = [0x81, 0xa1];
+        let msgpack = format_read_only_preview(&invalid, PayloadFormat::MessagePack);
+        let hex = format_read_only_preview(&invalid, PayloadFormat::Hex);
+        let text = format_read_only_preview(&invalid, PayloadFormat::Text);
+
+        assert!(msgpack.text.starts_with("MsgPack decode error:"));
+        assert!(hex.text.contains("81 A1"));
+        assert!(!text.text.starts_with("MsgPack decode error:"));
+    }
+
+    #[test]
     fn read_only_preview_falls_back_for_unsupported_format() {
         let preview = format_read_only_preview(br#"{"a":1}"#, PayloadFormat::Protobuf);
 
@@ -713,7 +572,7 @@ mod tests {
 
     #[test]
     fn preview_match_ranges_find_ascii_matches_case_insensitively() {
-        let ranges = preview_match_ranges("Balance balance BALANCE", "balance");
+        let ranges = preview::preview_match_ranges("Balance balance BALANCE", "balance");
 
         assert_eq!(ranges, vec![0..7, 8..15, 16..23]);
     }
@@ -722,7 +581,7 @@ mod tests {
     fn preview_match_ranges_find_matches_after_json_formatting() {
         let preview =
             format_read_only_preview(br#"{"event_id":"abc","kind":"path"}"#, PayloadFormat::Json);
-        let ranges = preview_match_ranges(&preview.text, "kind");
+        let ranges = preview::preview_match_ranges(&preview.text, "kind");
 
         assert_eq!(ranges.len(), 1);
         assert_eq!(&preview.text[ranges[0].clone()], "kind");
@@ -732,6 +591,6 @@ mod tests {
     fn preview_match_ranges_omit_absent_transformed_output() {
         let preview = format_read_only_preview(b"balance", PayloadFormat::Base64);
 
-        assert!(preview_match_ranges(&preview.text, "balance").is_empty());
+        assert!(preview::preview_match_ranges(&preview.text, "balance").is_empty());
     }
 }

--- a/crates/app/src/format/msgpack.rs
+++ b/crates/app/src/format/msgpack.rs
@@ -1,0 +1,161 @@
+use std::io::Cursor;
+
+use rmpv::{Value, decode::read_value_with_max_depth};
+
+const MAX_DEPTH: usize = 100;
+
+pub fn decode_value(data: &[u8]) -> Result<Value, String> {
+    if data.is_empty() {
+        return Err("empty payload".to_string());
+    }
+
+    let mut cursor = Cursor::new(data);
+    let value = read_value_with_max_depth(&mut cursor, MAX_DEPTH)
+        .map_err(|error| format!("decode failed: {error}"))?;
+    let consumed = cursor.position() as usize;
+    if consumed != data.len() {
+        return Err(format!("{} trailing byte(s)", data.len() - consumed));
+    }
+    Ok(value)
+}
+
+pub fn is_confident_auto(data: &[u8]) -> bool {
+    matches!(
+        decode_value(data),
+        Ok(Value::Map(_) | Value::Array(_) | Value::Binary(_) | Value::Ext(_, _))
+    )
+}
+
+pub fn format_msgpack(data: &[u8]) -> String {
+    match decode_value(data) {
+        Ok(value) => render_value(&value, 0),
+        Err(error) => format!("MsgPack decode error: {error}"),
+    }
+}
+
+fn render_value(value: &Value, indent: usize) -> String {
+    match value {
+        Value::Nil => "nil".to_string(),
+        Value::Boolean(value) => value.to_string(),
+        Value::Integer(value) => value.to_string(),
+        Value::F32(value) => value.to_string(),
+        Value::F64(value) => value.to_string(),
+        Value::String(value) => render_string(value),
+        Value::Binary(value) => format!("bin({}): {}", value.len(), hex_bytes(value)),
+        Value::Array(values) => render_array(values, indent),
+        Value::Map(values) => render_map(values, indent),
+        Value::Ext(ty, value) => format!(
+            "ext(type: {ty}, len: {}): {}",
+            value.len(),
+            hex_bytes(value)
+        ),
+    }
+}
+
+fn render_array(values: &[Value], indent: usize) -> String {
+    if values.is_empty() {
+        return "[]".to_string();
+    }
+
+    let child_indent = indent + 2;
+    let child_padding = " ".repeat(child_indent);
+    let mut out = String::from("[\n");
+    for (index, value) in values.iter().enumerate() {
+        out.push_str(&child_padding);
+        out.push_str(&indent_multiline(
+            &render_value(value, child_indent),
+            child_indent,
+        ));
+        if index + 1 < values.len() {
+            out.push(',');
+        }
+        out.push('\n');
+    }
+    out.push_str(&" ".repeat(indent));
+    out.push(']');
+    out
+}
+
+fn render_map(values: &[(Value, Value)], indent: usize) -> String {
+    if values.is_empty() {
+        return "{}".to_string();
+    }
+
+    let child_indent = indent + 2;
+    let child_padding = " ".repeat(child_indent);
+    let mut out = String::from("{\n");
+    for (key, value) in values {
+        out.push_str(&child_padding);
+        out.push_str(&render_key(key));
+        out.push_str(": ");
+        out.push_str(&indent_multiline(
+            &render_value(value, child_indent),
+            child_indent,
+        ));
+        out.push('\n');
+    }
+    out.push_str(&" ".repeat(indent));
+    out.push('}');
+    out
+}
+
+fn render_key(value: &Value) -> String {
+    match value {
+        Value::String(value) => render_string(value),
+        other => format!("[{}]", render_compact(other)),
+    }
+}
+
+fn render_compact(value: &Value) -> String {
+    match value {
+        Value::Nil => "nil".to_string(),
+        Value::Boolean(value) => value.to_string(),
+        Value::Integer(value) => value.to_string(),
+        Value::F32(value) => value.to_string(),
+        Value::F64(value) => value.to_string(),
+        Value::String(value) => render_string(value),
+        Value::Binary(value) => format!("bin({}):{}", value.len(), hex_bytes(value)),
+        Value::Ext(ty, value) => format!("ext(type:{ty},len:{}):{}", value.len(), hex_bytes(value)),
+        Value::Array(values) => format!(
+            "[{}]",
+            values
+                .iter()
+                .map(render_compact)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        Value::Map(values) => format!(
+            "{{{}}}",
+            values
+                .iter()
+                .map(|(key, value)| format!("{}: {}", render_key(key), render_compact(value)))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    }
+}
+
+fn render_string(value: &rmpv::Utf8String) -> String {
+    if let Some(value) = value.as_str() {
+        serde_json::to_string(value).unwrap_or_else(|_| format!("{value:?}"))
+    } else {
+        format!(
+            "str(invalid utf-8, len: {}): {}",
+            value.as_bytes().len(),
+            hex_bytes(value.as_bytes())
+        )
+    }
+}
+
+fn indent_multiline(value: &str, indent: usize) -> String {
+    let padding = " ".repeat(indent);
+    value.replace('\n', &format!("\n{padding}"))
+}
+
+fn hex_bytes(value: &[u8]) -> String {
+    value
+        .iter()
+        .map(|byte| format!("{byte:02X}"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}

--- a/crates/app/src/format/preview.rs
+++ b/crates/app/src/format/preview.rs
@@ -1,0 +1,156 @@
+use eframe::egui;
+use egui::text::LayoutJob;
+use std::ops::Range;
+
+use super::{
+    PayloadFormat, format_base64, format_hex, format_json, format_msgpack, format_text,
+    resolve_format,
+};
+
+pub const READ_ONLY_PREVIEW_FORMATS: &[PayloadFormat] = &[
+    PayloadFormat::Auto,
+    PayloadFormat::Text,
+    PayloadFormat::Json,
+    PayloadFormat::MessagePack,
+    PayloadFormat::Hex,
+    PayloadFormat::Base64,
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReadOnlyPreview {
+    pub resolved_format: PayloadFormat,
+    pub text: String,
+}
+
+pub fn format_read_only_preview(data: &[u8], format: PayloadFormat) -> ReadOnlyPreview {
+    let requested = if READ_ONLY_PREVIEW_FORMATS.contains(&format) {
+        format
+    } else {
+        PayloadFormat::Auto
+    };
+    let resolved = resolve_format(requested, data);
+    let text = match resolved {
+        PayloadFormat::Json => format_json(data),
+        PayloadFormat::MessagePack => format_msgpack(data),
+        PayloadFormat::Hex => format_hex(data),
+        PayloadFormat::Base64 => format_base64(data),
+        PayloadFormat::Text | PayloadFormat::Auto => format_text(data),
+        PayloadFormat::Protobuf => format_text(data),
+    };
+    ReadOnlyPreview {
+        resolved_format: resolved,
+        text,
+    }
+}
+
+pub fn preview_match_ranges(text: &str, query: &str) -> Vec<Range<usize>> {
+    let query = query.trim();
+    if text.is_empty() || query.is_empty() {
+        return Vec::new();
+    }
+
+    if text.is_ascii() && query.is_ascii() {
+        return ascii_match_ranges(text, query);
+    }
+
+    unicode_match_ranges(text, query)
+}
+
+pub fn read_only_preview_layout_job(
+    preview: &ReadOnlyPreview,
+    style: &egui::Style,
+    query: &str,
+) -> LayoutJob {
+    let ranges = preview_match_ranges(&preview.text, query);
+    highlighted_monospace_job(&preview.text, style, &ranges)
+}
+
+fn ascii_match_ranges(text: &str, query: &str) -> Vec<Range<usize>> {
+    let text_bytes = text.as_bytes();
+    let query_bytes = query.as_bytes();
+    if query_bytes.len() > text_bytes.len() {
+        return Vec::new();
+    }
+
+    let mut ranges = Vec::new();
+    let mut index = 0;
+    while index + query_bytes.len() <= text_bytes.len() {
+        let window = &text_bytes[index..index + query_bytes.len()];
+        let matches = window
+            .iter()
+            .zip(query_bytes.iter())
+            .all(|(value, query)| value.eq_ignore_ascii_case(query));
+        if matches {
+            ranges.push(index..index + query_bytes.len());
+            index += query_bytes.len();
+        } else {
+            index += 1;
+        }
+    }
+    ranges
+}
+
+fn unicode_match_ranges(text: &str, query: &str) -> Vec<Range<usize>> {
+    let query_chars = query.chars().count();
+    if query_chars == 0 {
+        return Vec::new();
+    }
+    let query_lower = query.to_lowercase();
+    let starts = text.char_indices().map(|(idx, _)| idx).collect::<Vec<_>>();
+    let mut ranges = Vec::new();
+    let mut cursor = 0;
+
+    while cursor < starts.len() {
+        let start = starts[cursor];
+        let Some(end) = byte_index_after_chars(text, start, query_chars) else {
+            break;
+        };
+        if text[start..end].to_lowercase() == query_lower {
+            ranges.push(start..end);
+            cursor += query_chars;
+        } else {
+            cursor += 1;
+        }
+    }
+    ranges
+}
+
+fn byte_index_after_chars(text: &str, start: usize, char_count: usize) -> Option<usize> {
+    let mut iter = text[start..].char_indices();
+    for _ in 0..char_count {
+        iter.next()?;
+    }
+    iter.next().map(|(idx, _)| start + idx).or(Some(text.len()))
+}
+
+fn highlighted_monospace_job(
+    text: &str,
+    style: &egui::Style,
+    ranges: &[Range<usize>],
+) -> LayoutJob {
+    let mut job = LayoutJob::default();
+    let mono = egui::FontId::monospace(13.0);
+    let text_color = style.visuals.text_color();
+    let highlight_bg = style.visuals.selection.bg_fill;
+    let highlight_fg = style.visuals.selection.stroke.color;
+    let normal = egui::TextFormat::simple(mono.clone(), text_color);
+    let highlighted = egui::TextFormat {
+        font_id: mono,
+        color: highlight_fg,
+        background: highlight_bg,
+        ..Default::default()
+    };
+
+    let mut cursor = 0;
+    for range in ranges {
+        if range.start > cursor {
+            job.append(&text[cursor..range.start], 0.0, normal.clone());
+        }
+        job.append(&text[range.clone()], 0.0, highlighted.clone());
+        cursor = range.end;
+    }
+    if cursor < text.len() {
+        job.append(&text[cursor..], 0.0, normal);
+    }
+    job
+}

--- a/crates/app/src/schema.rs
+++ b/crates/app/src/schema.rs
@@ -11,7 +11,7 @@ pub use config::MessageSchemaConfig;
 pub use manager::MessageSchemaManager;
 pub use subject::SubjectPattern;
 pub use types::{
-    BindingResolution, OutgoingPayload, PayloadSchemaStatus, RenderedSchemaPayload, SchemaBinding,
-    SchemaSelector, SchemaSource, SchemaSourceKind, SchemaSourceState, SchemaSourceStatus,
-    SchemaStatusLevel, ValidationPolicy, kv_subject,
+    BindingResolution, OutgoingPayload, PayloadInputFormat, PayloadSchemaStatus,
+    RenderedSchemaPayload, SchemaBinding, SchemaSelector, SchemaSource, SchemaSourceKind,
+    SchemaSourceState, SchemaSourceStatus, SchemaStatusLevel, ValidationPolicy, kv_subject,
 };

--- a/crates/app/src/schema/payload.rs
+++ b/crates/app/src/schema/payload.rs
@@ -1,25 +1,39 @@
 use std::collections::BTreeMap;
 
 use crate::proto::{AutoDetectResult, ProtoSchemaManager};
+use rmpv::{Value, encode::write_value};
 
 use super::{
-    BindingResolution, MessageSchemaManager, OutgoingPayload, PayloadSchemaStatus,
-    RenderedSchemaPayload, SchemaBinding, SchemaSelector, SchemaStatusLevel, ValidationPolicy,
+    BindingResolution, MessageSchemaManager, OutgoingPayload, PayloadInputFormat,
+    PayloadSchemaStatus, RenderedSchemaPayload, SchemaBinding, SchemaSelector, SchemaStatusLevel,
+    ValidationPolicy,
 };
 
 impl MessageSchemaManager {
+    #[allow(dead_code)]
     pub fn prepare_outgoing(
         &self,
         connection_id: u64,
         subject: &str,
         payload_text: &str,
     ) -> OutgoingPayload {
+        self.prepare_outgoing_with_input_format(
+            connection_id,
+            subject,
+            payload_text,
+            PayloadInputFormat::Text,
+        )
+    }
+
+    pub fn prepare_outgoing_with_input_format(
+        &self,
+        connection_id: u64,
+        subject: &str,
+        payload_text: &str,
+        input_format: PayloadInputFormat,
+    ) -> OutgoingPayload {
         match self.resolve_binding(connection_id, subject) {
-            BindingResolution::NoMatch => OutgoingPayload {
-                payload: payload_text.as_bytes().to_vec(),
-                status: None,
-                can_send: true,
-            },
+            BindingResolution::NoMatch => prepare_without_binding(payload_text, input_format),
             BindingResolution::Ambiguous(bindings) => {
                 let status = PayloadSchemaStatus {
                     level: SchemaStatusLevel::Warning,
@@ -349,4 +363,79 @@ impl MessageSchemaManager {
             .unwrap_or("Unknown source");
         format!("{source_name} / {}", binding.selector.entry())
     }
+}
+
+fn prepare_without_binding(
+    payload_text: &str,
+    input_format: PayloadInputFormat,
+) -> OutgoingPayload {
+    match input_format {
+        PayloadInputFormat::Text => OutgoingPayload {
+            payload: payload_text.as_bytes().to_vec(),
+            status: None,
+            can_send: true,
+        },
+        PayloadInputFormat::MessagePack => match encode_messagepack_json(payload_text) {
+            Ok(payload) => OutgoingPayload {
+                payload,
+                status: Some(PayloadSchemaStatus {
+                    level: SchemaStatusLevel::Info,
+                    label: "MsgPack input".to_string(),
+                    message: "JSON will be encoded as MsgPack".to_string(),
+                    can_send: true,
+                }),
+                can_send: true,
+            },
+            Err(error) => OutgoingPayload {
+                payload: Vec::new(),
+                status: Some(PayloadSchemaStatus {
+                    level: SchemaStatusLevel::Error,
+                    label: "MsgPack input".to_string(),
+                    message: error,
+                    can_send: false,
+                }),
+                can_send: false,
+            },
+        },
+    }
+}
+
+fn encode_messagepack_json(input: &str) -> Result<Vec<u8>, String> {
+    let json = serde_json::from_str::<serde_json::Value>(input)
+        .map_err(|error| format!("Invalid JSON for MsgPack input: {error}"))?;
+    let value = json_to_msgpack(json)?;
+    let mut out = Vec::new();
+    write_value(&mut out, &value).map_err(|error| format!("MsgPack encode error: {error}"))?;
+    Ok(out)
+}
+
+fn json_to_msgpack(value: serde_json::Value) -> Result<Value, String> {
+    Ok(match value {
+        serde_json::Value::Null => Value::Nil,
+        serde_json::Value::Bool(value) => Value::Boolean(value),
+        serde_json::Value::Number(value) => {
+            if let Some(value) = value.as_i64() {
+                Value::from(value)
+            } else if let Some(value) = value.as_u64() {
+                Value::from(value)
+            } else if let Some(value) = value.as_f64() {
+                Value::F64(value)
+            } else {
+                return Err("Unsupported JSON number".to_string());
+            }
+        }
+        serde_json::Value::String(value) => Value::String(value.into()),
+        serde_json::Value::Array(values) => Value::Array(
+            values
+                .into_iter()
+                .map(json_to_msgpack)
+                .collect::<Result<Vec<_>, _>>()?,
+        ),
+        serde_json::Value::Object(values) => Value::Map(
+            values
+                .into_iter()
+                .map(|(key, value)| Ok((Value::String(key.into()), json_to_msgpack(value)?)))
+                .collect::<Result<Vec<_>, String>>()?,
+        ),
+    })
 }

--- a/crates/app/src/schema/tests.rs
+++ b/crates/app/src/schema/tests.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::proto::ProtoSchemaManager;
+use rmpv::Value;
 
 use super::json_schema::{JsonSchemaCatalog, json_schema_template, schema_entry_name};
 
@@ -273,6 +274,174 @@ fn blocking_json_schema_binding_prevents_invalid_publish() {
     let valid = manager.prepare_outgoing(1, "orders.created", r#"{"id":"A1"}"#);
     assert!(valid.can_send);
     assert_eq!(valid.payload, br#"{"id":"A1"}"#);
+}
+
+#[test]
+fn messagepack_input_without_binding_encodes_json_payload() {
+    let manager = MessageSchemaManager::default();
+
+    let outgoing = manager.prepare_outgoing_with_input_format(
+        1,
+        "orders.created",
+        r#"{"id":"A1","items":[true,null]}"#,
+        PayloadInputFormat::MessagePack,
+    );
+
+    assert!(outgoing.can_send);
+    assert_ne!(outgoing.payload, br#"{"id":"A1","items":[true,null]}"#);
+
+    let decoded = crate::format::msgpack::decode_value(&outgoing.payload).unwrap();
+    let Value::Map(entries) = decoded else {
+        panic!("expected MessagePack map");
+    };
+    assert!(entries.contains(&(rmpv::Value::from("id"), rmpv::Value::from("A1"))));
+}
+
+#[test]
+fn messagepack_input_without_binding_rejects_invalid_json() {
+    let manager = MessageSchemaManager::default();
+
+    let outgoing = manager.prepare_outgoing_with_input_format(
+        1,
+        "orders.created",
+        r#"{"id":}"#,
+        PayloadInputFormat::MessagePack,
+    );
+
+    assert!(!outgoing.can_send);
+    assert!(outgoing.payload.is_empty());
+    let status = outgoing.status.unwrap();
+    assert_eq!(status.level, SchemaStatusLevel::Error);
+    assert!(
+        status
+            .message
+            .starts_with("Invalid JSON for MsgPack input:")
+    );
+}
+
+#[test]
+fn json_schema_binding_ignores_messagepack_input_format() {
+    let mut config = MessageSchemaConfig::default();
+    let source_id = config.add_source(
+        "schemas".to_string(),
+        SchemaSourceKind::JsonSchema,
+        "unused".to_string(),
+    );
+    config
+        .add_binding(
+            "orders".to_string(),
+            None,
+            "orders.created".to_string(),
+            source_id,
+            SchemaSelector::JsonSchema {
+                entry: "order".to_string(),
+            },
+            ValidationPolicy::Block,
+        )
+        .unwrap();
+    let mut manager = MessageSchemaManager::from_config(config);
+    let schema = serde_json::json!({
+        "type": "object",
+        "required": ["id"],
+        "properties": { "id": { "type": "string" } }
+    });
+    let mut validators = HashMap::new();
+    validators.insert(
+        "order".to_string(),
+        jsonschema::validator_for(&schema).unwrap(),
+    );
+    manager.json_sources.insert(
+        source_id,
+        JsonSchemaCatalog {
+            validators,
+            schemas: HashMap::from([("order".to_string(), schema)]),
+        },
+    );
+    manager.statuses.insert(
+        source_id,
+        SchemaSourceStatus::loaded(vec!["order".to_string()]),
+    );
+
+    let payload = r#"{"id":"A1"}"#;
+    let outgoing = manager.prepare_outgoing_with_input_format(
+        1,
+        "orders.created",
+        payload,
+        PayloadInputFormat::MessagePack,
+    );
+
+    assert!(outgoing.can_send);
+    assert_eq!(outgoing.payload, payload.as_bytes());
+    assert_eq!(
+        outgoing
+            .status
+            .as_ref()
+            .map(|status| status.message.as_str()),
+        Some("Valid JSON Schema payload")
+    );
+}
+
+#[test]
+fn protobuf_binding_ignores_messagepack_input_format() {
+    let dir = unique_temp_dir("easy-nats-proto-input-precedence");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("order.proto"),
+        r#"
+                syntax = "proto3";
+                package demo;
+                message Order {
+                    string id = 1;
+                    int32 count = 2;
+                }
+            "#,
+    )
+    .unwrap();
+
+    let mut config = MessageSchemaConfig::default();
+    let source_id = config.add_source(
+        "schemas".to_string(),
+        SchemaSourceKind::Protobuf,
+        dir.to_string_lossy().to_string(),
+    );
+    config
+        .add_binding(
+            "orders".to_string(),
+            None,
+            "orders.created".to_string(),
+            source_id,
+            SchemaSelector::ProtobufMessage {
+                type_name: "demo.Order".to_string(),
+            },
+            ValidationPolicy::Block,
+        )
+        .unwrap();
+    let mut manager = MessageSchemaManager::from_config(config);
+    let mut proto = ProtoSchemaManager::default();
+    proto.set_schema_dir(dir.clone());
+    manager.proto_sources.insert(source_id, proto);
+    manager.statuses.insert(
+        source_id,
+        SchemaSourceStatus::loaded(vec!["demo.Order".to_string()]),
+    );
+
+    let payload = r#"{"id":"A1","count":2}"#;
+    let outgoing = manager.prepare_outgoing_with_input_format(
+        1,
+        "orders.created",
+        payload,
+        PayloadInputFormat::MessagePack,
+    );
+
+    assert!(outgoing.can_send);
+    assert_ne!(outgoing.payload, payload.as_bytes());
+    let decoded = manager
+        .decode_manual_proto(&outgoing.payload, "demo.Order")
+        .unwrap();
+    assert!(decoded.contains(r#""id": "A1""#));
+    assert!(decoded.contains(r#""count": 2"#));
+
+    let _ = std::fs::remove_dir_all(dir);
 }
 
 #[test]

--- a/crates/app/src/schema/types.rs
+++ b/crates/app/src/schema/types.rs
@@ -28,6 +28,24 @@ impl SchemaSourceKind {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum PayloadInputFormat {
+    #[default]
+    Text,
+    MessagePack,
+}
+
+impl PayloadInputFormat {
+    pub const ALL: [Self; 2] = [Self::Text, Self::MessagePack];
+
+    pub fn label_key(self) -> &'static str {
+        match self {
+            Self::Text => "common.payload_input_text",
+            Self::MessagePack => "common.payload_input_messagepack",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SchemaBinding {
     pub id: u64,

--- a/crates/app/src/tabs/common.rs
+++ b/crates/app/src/tabs/common.rs
@@ -4,6 +4,7 @@ use eframe::egui;
 use eframe::egui::{Popup, PopupCloseBehavior, TextEdit};
 
 use crate::i18n::t;
+use crate::schema::PayloadInputFormat;
 
 use super::types::AutoRefresh;
 
@@ -148,6 +149,22 @@ fn contains_ascii_case_insensitive(value: &[u8], query: &[u8]) -> bool {
 
 pub(crate) fn searchable_payload_text(payload: &[u8]) -> String {
     String::from_utf8_lossy(payload).into_owned()
+}
+
+pub(crate) fn payload_input_format_selector(
+    ui: &mut egui::Ui,
+    id_salt: &str,
+    format: &mut PayloadInputFormat,
+) -> bool {
+    let before = *format;
+    egui::ComboBox::from_id_salt(id_salt)
+        .selected_text(t(format.label_key()))
+        .show_ui(ui, |ui| {
+            for choice in PayloadInputFormat::ALL {
+                ui.selectable_value(format, choice, t(choice.label_key()));
+            }
+        });
+    *format != before
 }
 
 /// Render auto-refresh toggle + interval selector inline.

--- a/crates/app/src/tabs/kv.rs
+++ b/crates/app/src/tabs/kv.rs
@@ -7,7 +7,8 @@ use crate::schema::{MessageSchemaManager, kv_subject};
 use crate::tabs::guard::TabGuard;
 
 use super::common::{
-    KV_VALUE_SEARCH_BATCH, SearchStatus, auto_refresh_ui, format_bytes, render_search_row,
+    KV_VALUE_SEARCH_BATCH, SearchStatus, auto_refresh_ui, format_bytes,
+    payload_input_format_selector, render_search_row,
 };
 use super::types::{KvBucketState, TabAction};
 
@@ -364,7 +365,12 @@ fn render_detail_panel(
     let can_save = !entry_key.is_empty();
     let subject = kv_subject(bucket_name, &entry_key);
     let outgoing_preview = if can_save {
-        Some(schema_manager.prepare_outgoing(connection_id, &subject, &state.entry_value))
+        Some(schema_manager.prepare_outgoing_with_input_format(
+            connection_id,
+            &subject,
+            &state.entry_value,
+            state.editor_input_format,
+        ))
     } else {
         None
     };
@@ -461,6 +467,9 @@ fn render_detail_panel(
     // Value editor
     ui.horizontal(|ui| {
         ui.label(t("kv.value_editor"));
+        ui.label(t("common.payload_input_format"));
+        payload_input_format_selector(ui, "kv_value_input_fmt", &mut state.editor_input_format);
+        ui.label(t("common.payload_preview_format"));
         format::format_selector(ui, "kv_value_fmt", &mut state.editor_format);
         if ui.small_button(t("kv.format_json")).clicked()
             && let Ok(val) = serde_json::from_str::<serde_json::Value>(&state.entry_value)
@@ -488,13 +497,18 @@ fn render_detail_panel(
 
     ui.add_space(4.0);
     ui.label(t("kv.value_preview"));
+    let preview_bytes = outgoing_preview
+        .as_ref()
+        .filter(|outgoing| outgoing.can_send)
+        .map(|outgoing| outgoing.payload.as_slice())
+        .unwrap_or_else(|| state.entry_value.as_bytes());
     egui::ScrollArea::vertical()
         .id_salt(("kv_value_preview", connection_id, bucket_name))
         .auto_shrink([false; 2])
         .show(ui, |ui| {
             format::render_payload_with_proto(
                 ui,
-                state.entry_value.as_bytes(),
+                preview_bytes,
                 state.editor_format,
                 "kv_editor_proto",
                 &mut state.editor_proto_view,

--- a/crates/app/src/tabs/mod.rs
+++ b/crates/app/src/tabs/mod.rs
@@ -16,7 +16,9 @@ mod subscriber;
 mod types;
 mod viewer;
 
-pub(crate) use common::{KV_VALUE_SEARCH_BATCH, NormalizedSearchQuery};
+pub(crate) use common::{
+    KV_VALUE_SEARCH_BATCH, NormalizedSearchQuery, payload_input_format_selector,
+};
 pub use guard::{TabGuard, next_backend_id, next_generation};
 pub use kv::kv_bucket_ui;
 pub use message_schemas::message_schemas_ui;

--- a/crates/app/src/tabs/publisher.rs
+++ b/crates/app/src/tabs/publisher.rs
@@ -5,7 +5,7 @@ use crate::format;
 use crate::i18n::t;
 use crate::schema::MessageSchemaManager;
 
-use super::common::topic_history_text_edit;
+use super::common::{payload_input_format_selector, topic_history_text_edit};
 use super::types::{PublisherState, TabAction};
 
 #[allow(clippy::too_many_arguments)]
@@ -65,6 +65,8 @@ pub fn publisher_ui(
     let payload_template = schema_manager.payload_template(connection_id, &subject);
     ui.horizontal(|ui| {
         ui.label(t("publisher.payload"));
+        ui.label(t("common.payload_input_format"));
+        payload_input_format_selector(ui, "pub_payload_input_fmt", &mut state.payload_input_format);
         if ui.small_button(t("publisher.format_json")).clicked()
             && let Ok(val) = serde_json::from_str::<serde_json::Value>(&state.payload)
             && let Ok(pretty) = serde_json::to_string_pretty(&val)
@@ -88,7 +90,12 @@ pub fn publisher_ui(
     ui.add_space(4.0);
     let can_send = !subject.is_empty();
     let outgoing_preview = if can_send {
-        schema_manager.prepare_outgoing(connection_id, &subject, &state.payload)
+        schema_manager.prepare_outgoing_with_input_format(
+            connection_id,
+            &subject,
+            &state.payload,
+            state.payload_input_format,
+        )
     } else {
         crate::schema::OutgoingPayload {
             payload: Vec::new(),
@@ -96,12 +103,18 @@ pub fn publisher_ui(
             can_send: false,
         }
     };
+    let can_submit = can_send && outgoing_preview.can_send;
     ui.horizontal(|ui| {
         if ui
-            .add_enabled(can_send, egui::Button::new(t("publisher.publish")))
+            .add_enabled(can_submit, egui::Button::new(t("publisher.publish")))
             .clicked()
         {
-            let outgoing = schema_manager.prepare_outgoing(connection_id, &subject, &state.payload);
+            let outgoing = schema_manager.prepare_outgoing_with_input_format(
+                connection_id,
+                &subject,
+                &state.payload,
+                state.payload_input_format,
+            );
             if outgoing.can_send {
                 actions.push(TabAction::RecordTopic {
                     topic: subject.clone(),
@@ -121,12 +134,17 @@ pub fn publisher_ui(
 
         if ui
             .add_enabled(
-                can_send && !state.waiting,
+                can_submit && !state.waiting,
                 egui::Button::new(t("publisher.request")),
             )
             .clicked()
         {
-            let outgoing = schema_manager.prepare_outgoing(connection_id, &subject, &state.payload);
+            let outgoing = schema_manager.prepare_outgoing_with_input_format(
+                connection_id,
+                &subject,
+                &state.payload,
+                state.payload_input_format,
+            );
             if outgoing.can_send {
                 actions.push(TabAction::RecordTopic {
                     topic: subject.clone(),

--- a/crates/app/src/tabs/types.rs
+++ b/crates/app/src/tabs/types.rs
@@ -17,7 +17,7 @@ use nats_backend::{
 
 use crate::format::PayloadFormat;
 use crate::proto::ProtoViewState;
-use crate::schema::{SchemaSelector, SchemaSourceKind, ValidationPolicy};
+use crate::schema::{PayloadInputFormat, SchemaSelector, SchemaSourceKind, ValidationPolicy};
 use crate::theme::ThemeId;
 
 /// Auto-refresh configuration for periodic data reloading.
@@ -147,6 +147,7 @@ pub struct PublisherState {
     pub timeout_ms: String,
     pub response: Option<ResponseData>,
     pub waiting: bool,
+    pub payload_input_format: PayloadInputFormat,
     pub response_format: PayloadFormat,
     pub proto_view: ProtoViewState,
 }
@@ -161,6 +162,7 @@ impl Default for PublisherState {
             timeout_ms: "5000".to_string(),
             response: None,
             waiting: false,
+            payload_input_format: PayloadInputFormat::Text,
             response_format: PayloadFormat::Auto,
             proto_view: ProtoViewState::default(),
         }
@@ -583,6 +585,7 @@ pub struct KvBucketState {
     pub entry_revision: Option<u64>,
     pub entry_operation: Option<String>,
     pub entry_created: Option<String>,
+    pub editor_input_format: PayloadInputFormat,
     pub editor_format: PayloadFormat,
     pub history: Vec<KvHistoryItem>,
     pub history_format: PayloadFormat,
@@ -617,6 +620,7 @@ impl Default for KvBucketState {
             entry_revision: None,
             entry_operation: None,
             entry_created: None,
+            editor_input_format: PayloadInputFormat::Text,
             editor_format: PayloadFormat::Auto,
             history: Vec::new(),
             history_format: PayloadFormat::Auto,


### PR DESCRIPTION
## Summary
- add MsgPack display and conservative Auto preview support
- add MsgPack input mode for publish/request, stream publish, and KV create/edit when no schema binding matches
- split payload formatting into JSON, MsgPack, and read-only preview helpers

Notes:
- JSON Schema and Protobuf bindings still take precedence over Payload Input Format.
- Checked with Docker NATS + egui MCP, `cargo fmt --all -- --check`, `cargo test -p easy-nats`, and `cargo check -p easy-nats`.