### PR TITLE
feat: add scoped request reply workflow

### DIFF
--- a/assets/i18n/publisher.yaml
+++ b/assets/i18n/publisher.yaml
@@ -41,6 +41,21 @@ response_headers:
 waiting:
   en: "Waiting for response..."
   zh: "等待响应中..."
+request_status_waiting:
+  en: "Waiting"
+  zh: "等待中"
+request_status_responded:
+  en: "Responded"
+  zh: "已响应"
+request_status_timed_out:
+  en: "Timed out"
+  zh: "已超时"
+request_status_no_responders:
+  en: "No responders"
+  zh: "无响应者"
+request_status_failed:
+  en: "Failed"
+  zh: "失败"
 format_json:
   en: "Format JSON"
   zh: "格式化 JSON"

--- a/assets/i18n/subscriber.yaml
+++ b/assets/i18n/subscriber.yaml
@@ -56,6 +56,42 @@ detail_headers:
 detail_payload:
   en: "Payload:"
   zh: "载荷:"
+reply:
+  en: "Reply"
+  zh: "回复"
+reply_payload:
+  en: "Reply Payload"
+  zh: "回复载荷"
+reply_headers:
+  en: "Reply Headers"
+  zh: "回复头部"
+header_key:
+  en: "Key"
+  zh: "键"
+header_value:
+  en: "Value"
+  zh: "值"
+add_header:
+  en: "+ Header"
+  zh: "+ 头部"
+send_reply:
+  en: "Send Reply"
+  zh: "发送回复"
+reply_failed_message:
+  en: "Reply failed"
+  zh: "回复失败"
+reply_status_replyable:
+  en: "Replyable"
+  zh: "可回复"
+reply_status_sending:
+  en: "Sending"
+  zh: "发送中"
+reply_status_replied:
+  en: "Replied"
+  zh: "已回复"
+reply_status_failed:
+  en: "Failed"
+  zh: "失败"
 
 search_placeholder:
   en: "Search retained messages"

--- a/crates/app/src/app/events.rs
+++ b/crates/app/src/app/events.rs
@@ -1,7 +1,6 @@
 use eframe::egui;
 use nats_backend::{BackendCommand, BackendEvent, ConnectionStatusKind};
 
-use crate::tabs::{ReceivedMessage, ResponseData, TabKind};
 use crate::toast::ToastLevel;
 
 use super::model::EasyNatsApp;
@@ -69,57 +68,62 @@ impl EasyNatsApp {
                 BackendEvent::RequestResponse {
                     connection_id,
                     backend_id: response_backend_id,
+                    request_id,
                     subject,
                     payload,
                     headers,
                 } => {
-                    for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
-                        if let TabKind::Publisher {
-                            connection_id: cid,
-                            backend_id,
-                            state,
-                            ..
-                        } = tab
-                            && *cid == connection_id
-                            && *backend_id == response_backend_id
-                        {
-                            state.response = Some(ResponseData {
-                                subject: subject.clone(),
-                                payload: payload.clone(),
-                                headers: headers.clone(),
-                            });
-                            state.waiting = false;
-                        }
-                    }
+                    self.apply_publisher_request_response(
+                        connection_id,
+                        response_backend_id,
+                        request_id,
+                        subject,
+                        payload,
+                        headers,
+                    );
+                }
+                BackendEvent::RequestFailed {
+                    connection_id,
+                    backend_id: response_backend_id,
+                    request_id,
+                    message,
+                    kind,
+                } => {
+                    self.apply_publisher_request_failed(
+                        connection_id,
+                        response_backend_id,
+                        request_id,
+                        kind,
+                        message,
+                    );
+                }
+                BackendEvent::Replied {
+                    connection_id,
+                    backend_id: reply_backend_id,
+                    reply_id,
+                    ..
+                } => {
+                    self.apply_subscriber_reply_success(connection_id, reply_backend_id, reply_id);
+                }
+                BackendEvent::ReplyFailed {
+                    connection_id,
+                    backend_id: reply_backend_id,
+                    reply_id,
+                    message,
+                } => {
+                    self.apply_subscriber_reply_failed(
+                        connection_id,
+                        reply_backend_id,
+                        reply_id,
+                        message,
+                    );
                 }
                 BackendEvent::MessageBatch {
                     connection_id,
                     backend_id: msg_backend_id,
                     messages,
                 } => {
-                    for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
-                        if let TabKind::Subscriber {
-                            connection_id: cid,
-                            backend_id,
-                            state,
-                            ..
-                        } = tab
-                            && *cid == connection_id
-                            && *backend_id == msg_backend_id
-                        {
-                            state.push_messages(messages.into_iter().map(|message| {
-                                ReceivedMessage {
-                                    id: 0,
-                                    subject: message.subject,
-                                    reply: message.reply,
-                                    headers: message.headers,
-                                    payload: message.payload,
-                                    timestamp: message.timestamp,
-                                }
-                            }));
-                            break;
-                        }
-                    }
+                    self.apply_subscriber_message_batch(connection_id, msg_backend_id, messages);
                 }
                 BackendEvent::MetricsSnapshot {
                     connection_id,

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -6,6 +6,7 @@ mod metrics_results;
 mod model;
 mod obj_store_results;
 mod operation_results;
+mod pubsub_events;
 mod search_workspace;
 mod server_info_results;
 mod sidebar;

--- a/crates/app/src/app/operation_results.rs
+++ b/crates/app/src/app/operation_results.rs
@@ -27,29 +27,11 @@ impl EasyNatsApp {
     pub(crate) fn handle_error(
         &mut self,
         connection_id: Option<u64>,
-        backend_id: Option<u64>,
+        _backend_id: Option<u64>,
         operation: BackendOperation,
         message: &str,
         context: Option<&BackendErrorContext>,
     ) {
-        if operation == BackendOperation::Request
-            && let Some(cid) = connection_id
-        {
-            for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
-                if let TabKind::Publisher {
-                    connection_id: tab_cid,
-                    backend_id: tab_backend_id,
-                    state,
-                    ..
-                } = tab
-                    && *tab_cid == cid
-                    && backend_id.is_none_or(|backend_id| *tab_backend_id == backend_id)
-                {
-                    state.waiting = false;
-                }
-            }
-        }
-
         if operation == BackendOperation::ListConsumers
             && let Some(cid) = connection_id
         {

--- a/crates/app/src/app/pubsub_events.rs
+++ b/crates/app/src/app/pubsub_events.rs
@@ -1,0 +1,138 @@
+use nats_backend::{MessageData, RequestFailureKind};
+
+use crate::tabs::{ReceivedMessage, ResponseData, TabKind};
+
+use super::model::EasyNatsApp;
+
+impl EasyNatsApp {
+    pub(crate) fn apply_publisher_request_response(
+        &mut self,
+        connection_id: u64,
+        response_backend_id: u64,
+        request_id: u64,
+        subject: Option<String>,
+        payload: Vec<u8>,
+        headers: Vec<(String, String)>,
+    ) {
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::Publisher {
+                connection_id: cid,
+                backend_id,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+                && *backend_id == response_backend_id
+            {
+                state.apply_request_response(
+                    request_id,
+                    ResponseData {
+                        subject,
+                        payload,
+                        headers,
+                    },
+                );
+                break;
+            }
+        }
+    }
+
+    pub(crate) fn apply_publisher_request_failed(
+        &mut self,
+        connection_id: u64,
+        response_backend_id: u64,
+        request_id: u64,
+        kind: RequestFailureKind,
+        message: String,
+    ) {
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::Publisher {
+                connection_id: cid,
+                backend_id,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+                && *backend_id == response_backend_id
+            {
+                state.apply_request_failure(request_id, kind, message);
+                break;
+            }
+        }
+    }
+
+    pub(crate) fn apply_subscriber_reply_success(
+        &mut self,
+        connection_id: u64,
+        reply_backend_id: u64,
+        reply_id: u64,
+    ) {
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::Subscriber {
+                connection_id: cid,
+                backend_id,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+                && *backend_id == reply_backend_id
+            {
+                state.apply_reply_success(reply_id);
+                break;
+            }
+        }
+    }
+
+    pub(crate) fn apply_subscriber_reply_failed(
+        &mut self,
+        connection_id: u64,
+        reply_backend_id: u64,
+        reply_id: u64,
+        message: String,
+    ) {
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::Subscriber {
+                connection_id: cid,
+                backend_id,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+                && *backend_id == reply_backend_id
+            {
+                state.apply_reply_failure(reply_id, message);
+                break;
+            }
+        }
+    }
+
+    pub(crate) fn apply_subscriber_message_batch(
+        &mut self,
+        connection_id: u64,
+        msg_backend_id: u64,
+        messages: Vec<MessageData>,
+    ) {
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::Subscriber {
+                connection_id: cid,
+                backend_id,
+                state,
+                ..
+            } = tab
+                && *cid == connection_id
+                && *backend_id == msg_backend_id
+            {
+                state.push_messages(messages.into_iter().map(|message| {
+                    ReceivedMessage::new(
+                        message.subject,
+                        message.reply,
+                        message.headers,
+                        message.payload,
+                        message.timestamp,
+                    )
+                }));
+                break;
+            }
+        }
+    }
+}

--- a/crates/app/src/tabs/common.rs
+++ b/crates/app/src/tabs/common.rs
@@ -34,6 +34,19 @@ pub(crate) fn format_bytes(bytes: u64) -> String {
     }
 }
 
+pub(crate) fn collect_headers(headers: &[(String, String)]) -> Option<Vec<(String, String)>> {
+    let non_empty: Vec<(String, String)> = headers
+        .iter()
+        .filter(|(key, value)| !key.trim().is_empty() || !value.trim().is_empty())
+        .cloned()
+        .collect();
+    if non_empty.is_empty() {
+        None
+    } else {
+        Some(non_empty)
+    }
+}
+
 pub(crate) const SEARCH_RESULT_LIMIT: usize = 200;
 pub(crate) const KV_VALUE_SEARCH_BATCH: usize = 100;
 

--- a/crates/app/src/tabs/mod.rs
+++ b/crates/app/src/tabs/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod settings;
 mod stream;
 mod stream_consumers;
 mod subscriber;
+mod subscriber_detail;
 mod types;
 mod viewer;
 

--- a/crates/app/src/tabs/publisher.rs
+++ b/crates/app/src/tabs/publisher.rs
@@ -5,8 +5,8 @@ use crate::format;
 use crate::i18n::t;
 use crate::schema::MessageSchemaManager;
 
-use super::common::{payload_input_format_selector, topic_history_text_edit};
-use super::types::{PublisherState, TabAction};
+use super::common::{collect_headers, payload_input_format_selector, topic_history_text_edit};
+use super::types::{CurrentRequest, PublisherState, RequestStatus, TabAction};
 
 #[allow(clippy::too_many_arguments)]
 pub fn publisher_ui(
@@ -134,7 +134,7 @@ pub fn publisher_ui(
 
         if ui
             .add_enabled(
-                can_submit && !state.waiting,
+                can_submit && !state.is_request_waiting(),
                 egui::Button::new(t("publisher.request")),
             )
             .clicked()
@@ -150,16 +150,16 @@ pub fn publisher_ui(
                     topic: subject.clone(),
                 });
                 let timeout_ms = state.timeout_ms.parse::<u64>().unwrap_or(5000);
+                let request_id = state.start_request(subject.clone());
                 backend.send(BackendCommand::Request {
                     connection_id,
                     backend_id,
+                    request_id,
                     subject: subject.clone(),
                     payload: outgoing.payload,
                     headers: collect_headers(&state.headers),
                     timeout_ms,
                 });
-                state.response = None;
-                state.waiting = true;
             }
         }
     });
@@ -173,7 +173,7 @@ pub fn publisher_ui(
         ui.label(t("publisher.response"));
         format::format_selector(ui, "pub_resp_fmt", &mut state.response_format);
     });
-    render_response(ui, connection_id, state, schema_manager);
+    render_current_response(ui, connection_id, state, schema_manager);
 }
 
 fn render_generate_json_button(
@@ -205,19 +205,59 @@ fn render_generate_json_button(
     }
 }
 
-fn render_response(
+fn render_current_response(
     ui: &mut egui::Ui,
     connection_id: u64,
     state: &mut PublisherState,
     schema_manager: &MessageSchemaManager,
 ) {
-    if state.waiting {
-        ui.spinner();
-        ui.label(t("publisher.waiting"));
+    let PublisherState {
+        current_request,
+        response_format,
+        proto_view,
+        ..
+    } = state;
+    let Some(request) = current_request.as_ref() else {
+        ui.label(t("publisher.no_response"));
         return;
+    };
+    render_request_detail(
+        ui,
+        connection_id,
+        request,
+        *response_format,
+        proto_view,
+        schema_manager,
+    );
+}
+
+fn render_request_detail(
+    ui: &mut egui::Ui,
+    connection_id: u64,
+    request: &CurrentRequest,
+    response_format: format::PayloadFormat,
+    proto_view: &mut crate::proto::ProtoViewState,
+    schema_manager: &MessageSchemaManager,
+) {
+    match request.status {
+        RequestStatus::Waiting => {
+            ui.horizontal(|ui| {
+                ui.spinner();
+                ui.label(t("publisher.waiting"));
+            });
+        }
+        RequestStatus::TimedOut | RequestStatus::NoResponders | RequestStatus::Failed => {
+            if let Some(message) = &request.error_message {
+                ui.colored_label(
+                    ui.visuals().error_fg_color,
+                    format!("{}: {message}", t(request.status.label_key())),
+                );
+            }
+        }
+        RequestStatus::Responded => {}
     }
 
-    if let Some(resp) = &state.response {
+    if let Some(resp) = &request.response {
         if !resp.headers.is_empty() {
             ui.label(t("publisher.response_headers"));
             egui::Grid::new("resp_headers")
@@ -238,44 +278,19 @@ fn render_response(
             .id_salt("resp_payload")
             .max_height(200.0)
             .show(ui, |ui| {
-                if let Some(subject) = resp.subject.as_deref() {
-                    format::render_payload_with_schema(
-                        ui,
-                        &resp.payload,
-                        state.response_format,
-                        "pub_proto",
-                        &mut state.proto_view,
-                        format::SchemaRenderContext {
-                            manager: schema_manager,
-                            connection_id,
-                            subject,
-                        },
-                    );
-                } else {
-                    format::render_payload_with_proto(
-                        ui,
-                        &resp.payload,
-                        state.response_format,
-                        "pub_proto",
-                        &mut state.proto_view,
-                        schema_manager,
-                    );
-                }
+                let subject = resp.subject.as_deref().unwrap_or(&request.subject);
+                format::render_payload_with_schema(
+                    ui,
+                    &resp.payload,
+                    response_format,
+                    "pub_proto",
+                    proto_view,
+                    format::SchemaRenderContext {
+                        manager: schema_manager,
+                        connection_id,
+                        subject,
+                    },
+                );
             });
-    } else {
-        ui.label(t("publisher.no_response"));
-    }
-}
-
-fn collect_headers(headers: &[(String, String)]) -> Option<Vec<(String, String)>> {
-    let non_empty: Vec<(String, String)> = headers
-        .iter()
-        .filter(|(k, v)| !k.trim().is_empty() || !v.trim().is_empty())
-        .cloned()
-        .collect();
-    if non_empty.is_empty() {
-        None
-    } else {
-        Some(non_empty)
     }
 }

--- a/crates/app/src/tabs/subscriber.rs
+++ b/crates/app/src/tabs/subscriber.rs
@@ -1,7 +1,6 @@
 use eframe::egui;
 use nats_backend::{BackendCommand, BackendHandle};
 
-use crate::format::{self, PayloadFormat};
 use crate::i18n::t;
 use crate::schema::MessageSchemaManager;
 
@@ -10,8 +9,10 @@ use super::common::{
     searchable_payload_text, topic_history_text_edit,
 };
 use super::guard::TabGuard;
+use super::subscriber_detail::message_detail_ui;
 use super::types::{
-    ReceivedMessage, SearchCacheKey, SubjectSubscription, SubscriberState, TabAction,
+    ReceivedMessage, ReplyListStatus, SearchCacheKey, SubjectSubscription, SubscriberState,
+    TabAction,
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -49,14 +50,14 @@ pub fn subscriber_ui(
         });
 
     egui::CentralPanel::default().show(ui, |ui| {
-        let selected_msg = state.selected_idx.and_then(|idx| state.messages.get(idx));
-        if let Some(msg) = selected_msg {
+        if let Some(selected_idx) = state.selected_idx.filter(|idx| *idx < state.messages.len()) {
             message_detail_ui(
                 ui,
                 connection_id,
-                msg,
-                &mut state.payload_format,
-                &mut state.proto_view,
+                backend_id,
+                selected_idx,
+                state,
+                backend,
                 schema_manager,
             );
         } else {
@@ -239,7 +240,7 @@ fn render_message_list(ui: &mut egui::Ui, state: &mut SubscriberState) {
         .stick_to_bottom(true)
         .auto_shrink(false)
         .show_rows(ui, 36.0, filtered.len(), |ui, row_range| {
-            for (idx, time, subject) in &filtered[row_range] {
+            for (idx, time, subject, reply_status) in &filtered[row_range] {
                 let selected = next_selected_idx == Some(*idx);
                 let visuals = ui.visuals();
                 let time_color = visuals.weak_text_color();
@@ -258,6 +259,21 @@ fn render_message_list(ui: &mut egui::Ui, state: &mut SubscriberState) {
                         ..Default::default()
                     },
                 );
+                if let Some(reply_status) = reply_status {
+                    let reply_color = match reply_status {
+                        ReplyListStatus::Failed => visuals.error_fg_color,
+                        _ => time_color,
+                    };
+                    job.append(
+                        &format!("  {}", t(reply_status.label_key())),
+                        0.0,
+                        egui::TextFormat {
+                            font_id: egui::FontId::proportional(11.0),
+                            color: reply_color,
+                            ..Default::default()
+                        },
+                    );
+                }
                 job.append(
                     &format!("\n{subject}"),
                     0.0,
@@ -286,7 +302,9 @@ fn subscriber_search_status(state: &mut SubscriberState) -> SearchStatus {
     }
 }
 
-fn filtered_rows(state: &mut SubscriberState) -> &[(usize, String, String)] {
+fn filtered_rows(
+    state: &mut SubscriberState,
+) -> &[(usize, String, String, Option<ReplyListStatus>)] {
     let search_key = SearchCacheKey::from_state(&state.search);
     let needs_refresh = match &state.cached_filtered {
         Some((generation, filter, cached_search, _)) => {
@@ -322,6 +340,7 @@ fn filtered_rows(state: &mut SubscriberState) -> &[(usize, String, String)] {
                     idx,
                     format_timestamp(message.timestamp),
                     message.subject.clone(),
+                    message.reply_list_status(),
                 )
             })
             .collect();
@@ -348,96 +367,35 @@ fn subscriber_message_matches(
     )
 }
 
-fn message_detail_ui(
-    ui: &mut egui::Ui,
-    connection_id: u64,
-    msg: &ReceivedMessage,
-    payload_format: &mut PayloadFormat,
-    proto_view: &mut crate::proto::ProtoViewState,
-    schema_manager: &MessageSchemaManager,
-) {
-    ui.horizontal(|ui| {
-        ui.label(t("subscriber.detail"));
-        format::format_selector(ui, "sub_detail_fmt", payload_format);
-    });
-
-    egui::Grid::new("msg_detail_grid")
-        .num_columns(2)
-        .spacing([8.0, 4.0])
-        .show(ui, |ui| {
-            ui.label(t("subscriber.detail_subject"));
-            ui.label(&msg.subject);
-            ui.end_row();
-
-            if let Some(reply) = &msg.reply {
-                ui.label(t("subscriber.detail_reply"));
-                ui.label(reply);
-                ui.end_row();
-            }
-
-            ui.label(t("subscriber.detail_timestamp"));
-            ui.label(format_timestamp(msg.timestamp));
-            ui.end_row();
-
-            ui.label(t("subscriber.detail_size"));
-            ui.label(format!("{} bytes", msg.payload.len()));
-            ui.end_row();
-        });
-
-    if !msg.headers.is_empty() {
-        ui.add_space(4.0);
-        ui.label(t("subscriber.detail_headers"));
-        egui::Grid::new("msg_detail_headers")
-            .num_columns(2)
-            .striped(true)
-            .show(ui, |ui| {
-                for (k, v) in &msg.headers {
-                    ui.label(k);
-                    ui.label(v);
-                    ui.end_row();
-                }
-            });
-    }
-
-    ui.add_space(4.0);
-    ui.label(t("subscriber.detail_payload"));
-    egui::ScrollArea::vertical()
-        .id_salt("msg_detail_payload")
-        .show(ui, |ui| {
-            format::render_payload_with_schema(
-                ui,
-                &msg.payload,
-                *payload_format,
-                "sub_proto",
-                proto_view,
-                format::SchemaRenderContext {
-                    manager: schema_manager,
-                    connection_id,
-                    subject: &msg.subject,
-                },
-            );
-        });
-}
-
 #[cfg(test)]
 mod tests {
     use std::time::SystemTime;
 
     use super::*;
+    use crate::tabs::types::ReplyState;
 
     fn make_msg(subject: &str) -> ReceivedMessage {
         make_msg_with_payload(subject, b"")
     }
 
     fn make_msg_with_payload(subject: &str, payload: &[u8]) -> ReceivedMessage {
-        ReceivedMessage {
-            id: 0,
-            subject: subject.to_string(),
-            reply: None,
-            headers: Vec::new(),
-            payload: payload.to_vec(),
-            timestamp: SystemTime::now(),
-        }
+        ReceivedMessage::new(
+            subject.to_string(),
+            None,
+            Vec::new(),
+            payload.to_vec(),
+            SystemTime::now(),
+        )
+    }
+
+    fn make_replyable_msg(subject: &str, reply_to: &str) -> ReceivedMessage {
+        ReceivedMessage::new(
+            subject.to_string(),
+            Some(reply_to.to_string()),
+            Vec::new(),
+            Vec::new(),
+            SystemTime::now(),
+        )
     }
 
     #[test]
@@ -512,6 +470,7 @@ mod tests {
         state.clear_messages();
 
         assert!(state.messages.is_empty());
+        assert!(state.in_flight_replies.is_empty());
         assert_eq!(state.selected_idx, None);
         assert!(state.cached_filtered.is_none());
         assert_eq!(state.cache_generation, 2);
@@ -565,5 +524,72 @@ mod tests {
         assert_eq!(subjects, vec!["gamma", "delta", "epsilon"]);
         assert_eq!(state.selected_idx, Some(0));
         assert_eq!(state.cache_generation, 2);
+    }
+
+    #[test]
+    fn replyable_messages_start_with_reply_state_and_draft() {
+        let msg = make_replyable_msg("orders.created", "_INBOX.1");
+
+        assert_eq!(msg.reply_state, Some(ReplyState::Replyable));
+        assert!(msg.reply_draft.is_some());
+        assert_eq!(msg.reply_list_status(), Some(ReplyListStatus::Replyable));
+    }
+
+    #[test]
+    fn reply_success_updates_original_message() {
+        let mut state = SubscriberState::default();
+        state.push_messages([make_replyable_msg("orders.created", "_INBOX.1")]);
+        let message_id = state.messages[0].id;
+
+        let reply_id = state.begin_reply(message_id).expect("message is replyable");
+
+        assert_eq!(
+            state.messages[0].reply_state,
+            Some(ReplyState::Sending { reply_id })
+        );
+        assert_eq!(state.in_flight_replies.get(&reply_id), Some(&message_id));
+
+        state.apply_reply_success(reply_id);
+
+        assert_eq!(state.messages[0].reply_state, Some(ReplyState::Replied));
+        assert!(state.in_flight_replies.is_empty());
+    }
+
+    #[test]
+    fn replied_messages_cannot_start_second_reply_but_failed_replies_can_retry() {
+        let mut state = SubscriberState::default();
+        state.push_messages([make_replyable_msg("orders.created", "_INBOX.1")]);
+        let message_id = state.messages[0].id;
+
+        let reply_id = state.begin_reply(message_id).expect("message is replyable");
+        state.apply_reply_success(reply_id);
+
+        assert!(state.begin_reply(message_id).is_none());
+
+        state.push_messages([make_replyable_msg("orders.updated", "_INBOX.2")]);
+        let retry_message_id = state.messages[1].id;
+        let failed_reply_id = state
+            .begin_reply(retry_message_id)
+            .expect("message is replyable");
+        state.apply_reply_failure(failed_reply_id, "publish failed".to_string());
+
+        assert!(state.begin_reply(retry_message_id).is_some());
+    }
+
+    #[test]
+    fn evicting_message_forgets_in_flight_reply() {
+        let mut state = SubscriberState {
+            max_messages: 1,
+            ..Default::default()
+        };
+        state.push_messages([make_replyable_msg("orders.created", "_INBOX.1")]);
+        let message_id = state.messages[0].id;
+        let reply_id = state.begin_reply(message_id).expect("message is replyable");
+
+        state.push_messages([make_msg("orders.updated")]);
+
+        assert_eq!(state.messages.len(), 1);
+        assert_eq!(state.messages[0].subject, "orders.updated");
+        assert!(!state.in_flight_replies.contains_key(&reply_id));
     }
 }

--- a/crates/app/src/tabs/subscriber_detail.rs
+++ b/crates/app/src/tabs/subscriber_detail.rs
@@ -1,0 +1,251 @@
+use eframe::egui;
+use nats_backend::{BackendCommand, BackendHandle};
+
+use crate::format;
+use crate::i18n::t;
+use crate::schema::{MessageSchemaManager, PayloadInputFormat};
+
+use super::common::{collect_headers, format_timestamp, payload_input_format_selector};
+use super::types::{ReceivedMessage, ReplyDraft, ReplyState, SubscriberState};
+
+struct PendingReply {
+    message_id: u64,
+    reply_to: String,
+    subject: String,
+    payload_text: String,
+    payload_input_format: PayloadInputFormat,
+    headers: Option<Vec<(String, String)>>,
+}
+
+pub(super) fn message_detail_ui(
+    ui: &mut egui::Ui,
+    connection_id: u64,
+    backend_id: u64,
+    selected_idx: usize,
+    state: &mut SubscriberState,
+    backend: &BackendHandle,
+    schema_manager: &MessageSchemaManager,
+) {
+    let mut pending_reply = None;
+    {
+        let messages = &mut state.messages;
+        let payload_format = &mut state.payload_format;
+        let proto_view = &mut state.proto_view;
+        let Some(msg) = messages.get_mut(selected_idx) else {
+            return;
+        };
+
+        ui.horizontal(|ui| {
+            ui.label(t("subscriber.detail"));
+            format::format_selector(ui, "sub_detail_fmt", payload_format);
+        });
+
+        egui::Grid::new("msg_detail_grid")
+            .num_columns(2)
+            .spacing([8.0, 4.0])
+            .show(ui, |ui| {
+                ui.label(t("subscriber.detail_subject"));
+                ui.label(&msg.subject);
+                ui.end_row();
+
+                if let Some(reply) = &msg.reply {
+                    ui.label(t("subscriber.detail_reply"));
+                    ui.label(reply);
+                    ui.end_row();
+                }
+
+                ui.label(t("subscriber.detail_timestamp"));
+                ui.label(format_timestamp(msg.timestamp));
+                ui.end_row();
+
+                ui.label(t("subscriber.detail_size"));
+                ui.label(format!("{} bytes", msg.payload.len()));
+                ui.end_row();
+            });
+
+        if !msg.headers.is_empty() {
+            ui.add_space(4.0);
+            ui.label(t("subscriber.detail_headers"));
+            egui::Grid::new("msg_detail_headers")
+                .num_columns(2)
+                .striped(true)
+                .show(ui, |ui| {
+                    for (k, v) in &msg.headers {
+                        ui.label(k);
+                        ui.label(v);
+                        ui.end_row();
+                    }
+                });
+        }
+
+        ui.add_space(4.0);
+        ui.label(t("subscriber.detail_payload"));
+        egui::ScrollArea::vertical()
+            .id_salt("msg_detail_payload")
+            .max_height(220.0)
+            .show(ui, |ui| {
+                format::render_payload_with_schema(
+                    ui,
+                    &msg.payload,
+                    *payload_format,
+                    "sub_proto",
+                    proto_view,
+                    format::SchemaRenderContext {
+                        manager: schema_manager,
+                        connection_id,
+                        subject: &msg.subject,
+                    },
+                );
+            });
+
+        render_reply_composer(ui, connection_id, msg, schema_manager, &mut pending_reply);
+    }
+
+    if let Some(reply) = pending_reply {
+        let outgoing = schema_manager.prepare_outgoing_with_input_format(
+            connection_id,
+            &reply.subject,
+            &reply.payload_text,
+            reply.payload_input_format,
+        );
+        if outgoing.can_send
+            && let Some(reply_id) = state.begin_reply(reply.message_id)
+        {
+            backend.send(BackendCommand::Reply {
+                connection_id,
+                backend_id,
+                reply_id,
+                reply_to: reply.reply_to,
+                payload: outgoing.payload,
+                headers: reply.headers,
+            });
+        }
+    }
+}
+
+fn render_reply_composer(
+    ui: &mut egui::Ui,
+    connection_id: u64,
+    msg: &mut ReceivedMessage,
+    schema_manager: &MessageSchemaManager,
+    pending_reply: &mut Option<PendingReply>,
+) {
+    let Some(reply_to) = msg.reply.clone() else {
+        return;
+    };
+    if msg.reply_draft.is_none() {
+        msg.reply_draft = Some(ReplyDraft::default());
+    }
+
+    let reply_state = msg.reply_state.clone().unwrap_or(ReplyState::Replyable);
+    let reply_blocked = matches!(
+        reply_state,
+        ReplyState::Sending { .. } | ReplyState::Replied
+    );
+
+    ui.add_space(8.0);
+    ui.separator();
+    ui.horizontal(|ui| {
+        ui.label(t("subscriber.reply"));
+        ui.weak(t(reply_status_label_key(&reply_state)));
+    });
+
+    if let ReplyState::Failed(message) = &reply_state {
+        ui.colored_label(
+            ui.visuals().error_fg_color,
+            format!("{}: {message}", t("subscriber.reply_failed_message")),
+        );
+    }
+
+    let draft = msg
+        .reply_draft
+        .as_mut()
+        .expect("replyable messages have drafts");
+    let outgoing_preview = schema_manager.prepare_outgoing_with_input_format(
+        connection_id,
+        &msg.subject,
+        &draft.payload,
+        draft.payload_input_format,
+    );
+
+    ui.horizontal(|ui| {
+        ui.label(t("subscriber.reply_payload"));
+        ui.label(t("common.payload_input_format"));
+        payload_input_format_selector(
+            ui,
+            &format!("subscriber_reply_payload_fmt_{}", msg.id),
+            &mut draft.payload_input_format,
+        );
+    });
+    egui::ScrollArea::vertical()
+        .id_salt(("subscriber_reply_payload", msg.id))
+        .max_height(140.0)
+        .show(ui, |ui| {
+            ui.add(
+                egui::TextEdit::multiline(&mut draft.payload)
+                    .desired_width(f32::INFINITY)
+                    .desired_rows(4)
+                    .code_editor(),
+            );
+        });
+    if let Some(status) = &outgoing_preview.status {
+        format::render_schema_status(ui, status);
+    }
+
+    render_reply_headers(ui, msg.id, &mut draft.headers);
+
+    let can_send = outgoing_preview.can_send && !reply_blocked;
+    if ui
+        .add_enabled(can_send, egui::Button::new(t("subscriber.send_reply")))
+        .clicked()
+    {
+        *pending_reply = Some(PendingReply {
+            message_id: msg.id,
+            reply_to,
+            subject: msg.subject.clone(),
+            payload_text: draft.payload.clone(),
+            payload_input_format: draft.payload_input_format,
+            headers: collect_headers(&draft.headers),
+        });
+    }
+}
+
+fn reply_status_label_key(state: &ReplyState) -> &'static str {
+    match state {
+        ReplyState::Replyable => "subscriber.reply_status_replyable",
+        ReplyState::Sending { .. } => "subscriber.reply_status_sending",
+        ReplyState::Replied => "subscriber.reply_status_replied",
+        ReplyState::Failed(_) => "subscriber.reply_status_failed",
+    }
+}
+
+fn render_reply_headers(ui: &mut egui::Ui, message_id: u64, headers: &mut Vec<(String, String)>) {
+    egui::CollapsingHeader::new(t("subscriber.reply_headers"))
+        .id_salt(("subscriber_reply_headers", message_id))
+        .show(ui, |ui| {
+            let mut remove_idx = None;
+            for (idx, (key, value)) in headers.iter_mut().enumerate() {
+                ui.horizontal(|ui| {
+                    ui.add(
+                        egui::TextEdit::singleline(key)
+                            .hint_text(t("subscriber.header_key"))
+                            .desired_width(120.0),
+                    );
+                    ui.add(
+                        egui::TextEdit::singleline(value)
+                            .hint_text(t("subscriber.header_value"))
+                            .desired_width(200.0),
+                    );
+                    if ui.small_button("x").clicked() {
+                        remove_idx = Some(idx);
+                    }
+                });
+            }
+            if let Some(idx) = remove_idx {
+                headers.remove(idx);
+            }
+            if ui.small_button(t("subscriber.add_header")).clicked() {
+                headers.push((String::new(), String::new()));
+            }
+        });
+}

--- a/crates/app/src/tabs/types.rs
+++ b/crates/app/src/tabs/types.rs
@@ -1,13 +1,19 @@
 mod client_status_state;
 mod metrics_state;
+mod publisher_state;
+mod subscriber_state;
 mod tab_kind;
 
 pub use client_status_state::ClientStatusState;
 pub use metrics_state::MetricsState;
+pub use publisher_state::{CurrentRequest, PublisherState, RequestStatus, ResponseData};
+pub use subscriber_state::{
+    ReceivedMessage, ReplyDraft, ReplyListStatus, ReplyState, SubjectSubscription, SubscriberState,
+};
 pub use tab_kind::{AppTabViewer, TabKind};
 
-use std::collections::{HashMap, HashSet, VecDeque};
-use std::time::{Instant, SystemTime};
+use std::collections::{HashMap, HashSet};
+use std::time::Instant;
 
 use eframe::egui;
 use nats_backend::{
@@ -138,56 +144,6 @@ pub enum TabAction {
     },
 }
 
-#[derive(Debug)]
-pub struct PublisherState {
-    pub subject: String,
-    pub subject_suggestion_idx: Option<usize>,
-    pub payload: String,
-    pub headers: Vec<(String, String)>,
-    pub timeout_ms: String,
-    pub response: Option<ResponseData>,
-    pub waiting: bool,
-    pub payload_input_format: PayloadInputFormat,
-    pub response_format: PayloadFormat,
-    pub proto_view: ProtoViewState,
-}
-
-impl Default for PublisherState {
-    fn default() -> Self {
-        Self {
-            subject: String::new(),
-            subject_suggestion_idx: None,
-            payload: String::new(),
-            headers: Vec::new(),
-            timeout_ms: "5000".to_string(),
-            response: None,
-            waiting: false,
-            payload_input_format: PayloadInputFormat::Text,
-            response_format: PayloadFormat::Auto,
-            proto_view: ProtoViewState::default(),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct ResponseData {
-    pub subject: Option<String>,
-    pub payload: Vec<u8>,
-    pub headers: Vec<(String, String)>,
-}
-
-#[derive(Debug, Clone)]
-pub struct ReceivedMessage {
-    pub id: u64,
-    pub subject: String,
-    pub reply: Option<String>,
-    pub headers: Vec<(String, String)>,
-    pub payload: Vec<u8>,
-    pub timestamp: SystemTime,
-}
-
-pub type SubscriberListRow = (usize, String, String);
-pub type CachedSubscriberRows = (u64, Option<String>, SearchCacheKey, Vec<SubscriberListRow>);
 pub type StreamListRow = (usize, String);
 pub type CachedStreamRows = (u64, SearchCacheKey, Vec<StreamListRow>);
 
@@ -426,89 +382,6 @@ impl Default for SearchWorkspaceState {
             preview_format: PayloadFormat::Auto,
             cached_results: None,
         }
-    }
-}
-
-#[derive(Debug)]
-pub struct SubjectSubscription {
-    pub subject: String,
-    pub active: bool,
-}
-
-#[derive(Debug)]
-pub struct SubscriberState {
-    pub subject_input: String,
-    pub subject_suggestion_idx: Option<usize>,
-    pub subscriptions: Vec<SubjectSubscription>,
-    pub messages: VecDeque<ReceivedMessage>,
-    pub next_message_id: u64,
-    pub max_messages: usize,
-    pub selected_idx: Option<usize>,
-    pub payload_format: PayloadFormat,
-    /// When set, only display messages matching this subject.
-    pub subject_filter: Option<String>,
-    pub cache_generation: u64,
-    pub cached_filtered: Option<CachedSubscriberRows>,
-    pub search: ScopedSearchState,
-    pub proto_view: ProtoViewState,
-}
-
-impl Default for SubscriberState {
-    fn default() -> Self {
-        Self {
-            subject_input: String::new(),
-            subject_suggestion_idx: None,
-            subscriptions: Vec::new(),
-            messages: VecDeque::new(),
-            next_message_id: 1,
-            max_messages: 1000,
-            selected_idx: None,
-            payload_format: PayloadFormat::Auto,
-            subject_filter: None,
-            cache_generation: 0,
-            cached_filtered: None,
-            search: ScopedSearchState::default(),
-            proto_view: ProtoViewState::default(),
-        }
-    }
-}
-
-impl SubscriberState {
-    pub fn push_messages<I>(&mut self, messages: I)
-    where
-        I: IntoIterator<Item = ReceivedMessage>,
-    {
-        let mut pushed = false;
-        for msg in messages {
-            self.push_message_without_invalidation(msg);
-            pushed = true;
-        }
-        if pushed {
-            self.invalidate_filtered_cache();
-        }
-    }
-
-    fn push_message_without_invalidation(&mut self, mut msg: ReceivedMessage) {
-        if self.messages.len() >= self.max_messages {
-            self.messages.pop_front();
-            if let Some(idx) = self.selected_idx {
-                self.selected_idx = idx.checked_sub(1);
-            }
-        }
-        msg.id = self.next_message_id;
-        self.next_message_id = self.next_message_id.wrapping_add(1).max(1);
-        self.messages.push_back(msg);
-    }
-
-    pub fn clear_messages(&mut self) {
-        self.messages.clear();
-        self.selected_idx = None;
-        self.invalidate_filtered_cache();
-    }
-
-    pub fn invalidate_filtered_cache(&mut self) {
-        self.cache_generation = self.cache_generation.wrapping_add(1);
-        self.cached_filtered = None;
     }
 }
 

--- a/crates/app/src/tabs/types/publisher_state.rs
+++ b/crates/app/src/tabs/types/publisher_state.rs
@@ -1,0 +1,173 @@
+use nats_backend::RequestFailureKind;
+
+use crate::format::PayloadFormat;
+use crate::proto::ProtoViewState;
+use crate::schema::PayloadInputFormat;
+
+#[derive(Debug)]
+pub struct PublisherState {
+    pub subject: String,
+    pub subject_suggestion_idx: Option<usize>,
+    pub payload: String,
+    pub headers: Vec<(String, String)>,
+    pub timeout_ms: String,
+    pub current_request: Option<CurrentRequest>,
+    pub next_request_id: u64,
+    pub payload_input_format: PayloadInputFormat,
+    pub response_format: PayloadFormat,
+    pub proto_view: ProtoViewState,
+}
+
+impl Default for PublisherState {
+    fn default() -> Self {
+        Self {
+            subject: String::new(),
+            subject_suggestion_idx: None,
+            payload: String::new(),
+            headers: Vec::new(),
+            timeout_ms: "5000".to_string(),
+            current_request: None,
+            next_request_id: 1,
+            payload_input_format: PayloadInputFormat::Text,
+            response_format: PayloadFormat::Auto,
+            proto_view: ProtoViewState::default(),
+        }
+    }
+}
+
+impl PublisherState {
+    pub fn start_request(&mut self, subject: String) -> u64 {
+        let request_id = self.next_request_id;
+        self.next_request_id = self.next_request_id.wrapping_add(1).max(1);
+        self.current_request = Some(CurrentRequest {
+            request_id,
+            subject,
+            status: RequestStatus::Waiting,
+            response: None,
+            error_message: None,
+        });
+        request_id
+    }
+
+    pub fn apply_request_response(&mut self, request_id: u64, response: ResponseData) {
+        let Some(current) = self.current_request.as_mut() else {
+            return;
+        };
+        if current.request_id != request_id {
+            return;
+        }
+        current.status = RequestStatus::Responded;
+        current.response = Some(response);
+        current.error_message = None;
+    }
+
+    pub fn apply_request_failure(
+        &mut self,
+        request_id: u64,
+        kind: RequestFailureKind,
+        message: String,
+    ) {
+        let Some(current) = self.current_request.as_mut() else {
+            return;
+        };
+        if current.request_id != request_id {
+            return;
+        }
+        current.status = RequestStatus::from_failure_kind(kind);
+        current.response = None;
+        current.error_message = Some(message);
+    }
+
+    pub fn is_request_waiting(&self) -> bool {
+        self.current_request
+            .as_ref()
+            .is_some_and(|request| request.status == RequestStatus::Waiting)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CurrentRequest {
+    pub request_id: u64,
+    pub subject: String,
+    pub status: RequestStatus,
+    pub response: Option<ResponseData>,
+    pub error_message: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResponseData {
+    pub subject: Option<String>,
+    pub payload: Vec<u8>,
+    pub headers: Vec<(String, String)>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestStatus {
+    Waiting,
+    Responded,
+    TimedOut,
+    NoResponders,
+    Failed,
+}
+
+impl RequestStatus {
+    pub fn label_key(self) -> &'static str {
+        match self {
+            Self::Waiting => "publisher.request_status_waiting",
+            Self::Responded => "publisher.request_status_responded",
+            Self::TimedOut => "publisher.request_status_timed_out",
+            Self::NoResponders => "publisher.request_status_no_responders",
+            Self::Failed => "publisher.request_status_failed",
+        }
+    }
+
+    fn from_failure_kind(kind: RequestFailureKind) -> Self {
+        match kind {
+            RequestFailureKind::TimedOut => Self::TimedOut,
+            RequestFailureKind::NoResponders => Self::NoResponders,
+            RequestFailureKind::Other => Self::Failed,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_slot_ignores_stale_results() {
+        let mut state = PublisherState::default();
+        let first = state.start_request("orders.created".to_string());
+        let second = state.start_request("orders.updated".to_string());
+
+        state.apply_request_response(
+            first,
+            ResponseData {
+                subject: Some("orders.created".to_string()),
+                payload: b"stale".to_vec(),
+                headers: Vec::new(),
+            },
+        );
+
+        let current = state.current_request.as_ref().expect("current request");
+        assert_eq!(current.request_id, second);
+        assert_eq!(current.status, RequestStatus::Waiting);
+        assert!(current.response.is_none());
+    }
+
+    #[test]
+    fn request_failure_maps_kind_for_current_request() {
+        let mut state = PublisherState::default();
+        let request_id = state.start_request("orders.created".to_string());
+
+        state.apply_request_failure(
+            request_id,
+            RequestFailureKind::NoResponders,
+            "no responders".to_string(),
+        );
+
+        let current = state.current_request.as_ref().expect("current request");
+        assert_eq!(current.status, RequestStatus::NoResponders);
+        assert_eq!(current.error_message.as_deref(), Some("no responders"));
+    }
+}

--- a/crates/app/src/tabs/types/subscriber_state.rs
+++ b/crates/app/src/tabs/types/subscriber_state.rs
@@ -1,0 +1,240 @@
+use std::collections::{HashMap, VecDeque};
+use std::time::SystemTime;
+
+use crate::format::PayloadFormat;
+use crate::proto::ProtoViewState;
+use crate::schema::PayloadInputFormat;
+
+use super::{ScopedSearchState, SearchCacheKey};
+
+#[derive(Debug, Clone)]
+pub struct ReceivedMessage {
+    pub id: u64,
+    pub subject: String,
+    pub reply: Option<String>,
+    pub headers: Vec<(String, String)>,
+    pub payload: Vec<u8>,
+    pub timestamp: SystemTime,
+    pub reply_state: Option<ReplyState>,
+    pub reply_draft: Option<ReplyDraft>,
+}
+
+impl ReceivedMessage {
+    pub fn new(
+        subject: String,
+        reply: Option<String>,
+        headers: Vec<(String, String)>,
+        payload: Vec<u8>,
+        timestamp: SystemTime,
+    ) -> Self {
+        let is_replyable = reply.is_some();
+        Self {
+            id: 0,
+            subject,
+            reply,
+            headers,
+            payload,
+            timestamp,
+            reply_state: is_replyable.then_some(ReplyState::Replyable),
+            reply_draft: is_replyable.then(ReplyDraft::default),
+        }
+    }
+
+    pub fn reply_list_status(&self) -> Option<ReplyListStatus> {
+        match self.reply_state.as_ref()? {
+            ReplyState::Replyable => Some(ReplyListStatus::Replyable),
+            ReplyState::Sending { .. } => Some(ReplyListStatus::Sending),
+            ReplyState::Replied => Some(ReplyListStatus::Replied),
+            ReplyState::Failed(_) => Some(ReplyListStatus::Failed),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ReplyDraft {
+    pub payload: String,
+    pub headers: Vec<(String, String)>,
+    pub payload_input_format: PayloadInputFormat,
+}
+
+impl Default for ReplyDraft {
+    fn default() -> Self {
+        Self {
+            payload: String::new(),
+            headers: Vec::new(),
+            payload_input_format: PayloadInputFormat::Text,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReplyState {
+    Replyable,
+    Sending { reply_id: u64 },
+    Replied,
+    Failed(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplyListStatus {
+    Replyable,
+    Sending,
+    Replied,
+    Failed,
+}
+
+impl ReplyListStatus {
+    pub fn label_key(self) -> &'static str {
+        match self {
+            Self::Replyable => "subscriber.reply_status_replyable",
+            Self::Sending => "subscriber.reply_status_sending",
+            Self::Replied => "subscriber.reply_status_replied",
+            Self::Failed => "subscriber.reply_status_failed",
+        }
+    }
+}
+
+pub type SubscriberListRow = (usize, String, String, Option<ReplyListStatus>);
+pub type CachedSubscriberRows = (u64, Option<String>, SearchCacheKey, Vec<SubscriberListRow>);
+
+#[derive(Debug)]
+pub struct SubjectSubscription {
+    pub subject: String,
+    pub active: bool,
+}
+
+#[derive(Debug)]
+pub struct SubscriberState {
+    pub subject_input: String,
+    pub subject_suggestion_idx: Option<usize>,
+    pub subscriptions: Vec<SubjectSubscription>,
+    pub messages: VecDeque<ReceivedMessage>,
+    pub next_message_id: u64,
+    pub next_reply_id: u64,
+    pub in_flight_replies: HashMap<u64, u64>,
+    pub max_messages: usize,
+    pub selected_idx: Option<usize>,
+    pub payload_format: PayloadFormat,
+    /// When set, only display messages matching this subject.
+    pub subject_filter: Option<String>,
+    pub cache_generation: u64,
+    pub cached_filtered: Option<CachedSubscriberRows>,
+    pub search: ScopedSearchState,
+    pub proto_view: ProtoViewState,
+}
+
+impl Default for SubscriberState {
+    fn default() -> Self {
+        Self {
+            subject_input: String::new(),
+            subject_suggestion_idx: None,
+            subscriptions: Vec::new(),
+            messages: VecDeque::new(),
+            next_message_id: 1,
+            next_reply_id: 1,
+            in_flight_replies: HashMap::new(),
+            max_messages: 1000,
+            selected_idx: None,
+            payload_format: PayloadFormat::Auto,
+            subject_filter: None,
+            cache_generation: 0,
+            cached_filtered: None,
+            search: ScopedSearchState::default(),
+            proto_view: ProtoViewState::default(),
+        }
+    }
+}
+
+impl SubscriberState {
+    pub fn push_messages<I>(&mut self, messages: I)
+    where
+        I: IntoIterator<Item = ReceivedMessage>,
+    {
+        let mut pushed = false;
+        for msg in messages {
+            self.push_message_without_invalidation(msg);
+            pushed = true;
+        }
+        if pushed {
+            self.invalidate_filtered_cache();
+        }
+    }
+
+    fn push_message_without_invalidation(&mut self, mut msg: ReceivedMessage) {
+        if self.messages.len() >= self.max_messages {
+            if let Some(removed) = self.messages.pop_front() {
+                self.forget_in_flight_reply_for_message(&removed);
+            }
+            if let Some(idx) = self.selected_idx {
+                self.selected_idx = idx.checked_sub(1);
+            }
+        }
+        msg.id = self.next_message_id;
+        self.next_message_id = self.next_message_id.wrapping_add(1).max(1);
+        self.messages.push_back(msg);
+    }
+
+    pub fn clear_messages(&mut self) {
+        self.messages.clear();
+        self.in_flight_replies.clear();
+        self.selected_idx = None;
+        self.invalidate_filtered_cache();
+    }
+
+    pub fn begin_reply(&mut self, message_id: u64) -> Option<u64> {
+        let message = self
+            .messages
+            .iter_mut()
+            .find(|message| message.id == message_id)?;
+        message.reply.as_ref()?;
+        if matches!(
+            message.reply_state,
+            Some(ReplyState::Sending { .. }) | Some(ReplyState::Replied)
+        ) {
+            return None;
+        }
+        let reply_id = self.next_reply_id;
+        self.next_reply_id = self.next_reply_id.wrapping_add(1).max(1);
+        message.reply_state = Some(ReplyState::Sending { reply_id });
+        self.in_flight_replies.insert(reply_id, message_id);
+        self.invalidate_filtered_cache();
+        Some(reply_id)
+    }
+
+    pub fn apply_reply_success(&mut self, reply_id: u64) {
+        let Some(message_id) = self.in_flight_replies.remove(&reply_id) else {
+            return;
+        };
+        if let Some(message) = self.message_mut(message_id) {
+            message.reply_state = Some(ReplyState::Replied);
+        }
+        self.invalidate_filtered_cache();
+    }
+
+    pub fn apply_reply_failure(&mut self, reply_id: u64, message: String) {
+        let Some(message_id) = self.in_flight_replies.remove(&reply_id) else {
+            return;
+        };
+        if let Some(message_ref) = self.message_mut(message_id) {
+            message_ref.reply_state = Some(ReplyState::Failed(message));
+        }
+        self.invalidate_filtered_cache();
+    }
+
+    pub fn message_mut(&mut self, message_id: u64) -> Option<&mut ReceivedMessage> {
+        self.messages
+            .iter_mut()
+            .find(|message| message.id == message_id)
+    }
+
+    pub fn invalidate_filtered_cache(&mut self) {
+        self.cache_generation = self.cache_generation.wrapping_add(1);
+        self.cached_filtered = None;
+    }
+
+    fn forget_in_flight_reply_for_message(&mut self, message: &ReceivedMessage) {
+        if let Some(ReplyState::Sending { reply_id }) = &message.reply_state {
+            self.in_flight_replies.remove(reply_id);
+        }
+    }
+}

--- a/crates/nats-backend/src/command.rs
+++ b/crates/nats-backend/src/command.rs
@@ -36,10 +36,19 @@ pub enum BackendCommand {
     Request {
         connection_id: u64,
         backend_id: u64,
+        request_id: u64,
         subject: String,
         payload: Vec<u8>,
         headers: Option<Vec<(String, String)>>,
         timeout_ms: u64,
+    },
+    Reply {
+        connection_id: u64,
+        backend_id: u64,
+        reply_id: u64,
+        reply_to: String,
+        payload: Vec<u8>,
+        headers: Option<Vec<(String, String)>>,
     },
     // JetStream
     ListStreams {

--- a/crates/nats-backend/src/event.rs
+++ b/crates/nats-backend/src/event.rs
@@ -22,6 +22,7 @@ pub enum BackendOperation {
     Subscribe,
     Unsubscribe,
     Request,
+    Reply,
     ListStreams,
     CreateStream,
     UpdateStream,
@@ -64,6 +65,7 @@ impl BackendOperation {
             Self::Subscribe => "subscribe",
             Self::Unsubscribe => "unsubscribe",
             Self::Request => "request",
+            Self::Reply => "reply",
             Self::ListStreams => "list_streams",
             Self::CreateStream => "create_stream",
             Self::UpdateStream => "update_stream",
@@ -124,9 +126,29 @@ pub enum BackendEvent {
     RequestResponse {
         connection_id: u64,
         backend_id: u64,
+        request_id: u64,
         subject: Option<String>,
         payload: Vec<u8>,
         headers: Vec<(String, String)>,
+    },
+    RequestFailed {
+        connection_id: u64,
+        backend_id: u64,
+        request_id: u64,
+        message: String,
+        kind: RequestFailureKind,
+    },
+    Replied {
+        connection_id: u64,
+        backend_id: u64,
+        reply_id: u64,
+        subject: String,
+    },
+    ReplyFailed {
+        connection_id: u64,
+        backend_id: u64,
+        reply_id: u64,
+        message: String,
     },
     MetricsSnapshot {
         connection_id: u64,
@@ -296,4 +318,11 @@ pub enum ConnectionStatusKind {
     Disconnected,
     Connecting,
     Error(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestFailureKind {
+    TimedOut,
+    NoResponders,
+    Other,
 }

--- a/crates/nats-backend/src/lib.rs
+++ b/crates/nats-backend/src/lib.rs
@@ -14,7 +14,9 @@ pub use cancellation::TaskCancellation;
 pub use command::BackendCommand;
 pub use config::AppConfig;
 pub use connection::{AuthMethod, ConnectionConfig, ConnectionStatus, MonitoringConfig};
-pub use event::{BackendEvent, BackendOperation, ConnectionStatusKind, MessageData};
+pub use event::{
+    BackendEvent, BackendOperation, ConnectionStatusKind, MessageData, RequestFailureKind,
+};
 pub use models::{
     BackendErrorContext, ConsumerAckPolicyKind, ConsumerConfigInput, ConsumerDeliverPolicyKind,
     KvBucketConfigInput, KvBucketInfo, KvEntryInfo, KvHistoryItem, KvKeyBatch,

--- a/crates/nats-backend/src/worker/helpers.rs
+++ b/crates/nats-backend/src/worker/helpers.rs
@@ -1,9 +1,15 @@
-pub fn build_header_map(headers: &[(String, String)]) -> async_nats::HeaderMap {
+pub fn build_header_map(headers: &[(String, String)]) -> Result<async_nats::HeaderMap, String> {
     let mut map = async_nats::HeaderMap::new();
-    for (k, v) in headers {
-        map.insert(k.as_str(), v.as_str());
+    for (name, value) in headers {
+        let header_name = name
+            .parse::<async_nats::HeaderName>()
+            .map_err(|e| format!("Invalid header name {name:?}: {e}"))?;
+        let header_value = value
+            .parse::<async_nats::HeaderValue>()
+            .map_err(|e| format!("Invalid header value for {name:?}: {e}"))?;
+        map.insert(header_name, header_value);
     }
-    map
+    Ok(map)
 }
 
 pub fn extract_headers(headers: &Option<async_nats::HeaderMap>) -> Vec<(String, String)> {
@@ -26,8 +32,24 @@ mod tests {
     #[test]
     fn test_build_header_map_single() {
         let headers = vec![("X-Key".to_string(), "Value1".to_string())];
-        let map = build_header_map(&headers);
+        let map = build_header_map(&headers).unwrap();
         assert_eq!(map.get("X-Key").unwrap().to_string(), "Value1");
+    }
+
+    #[test]
+    fn test_build_header_map_rejects_invalid_name() {
+        let headers = vec![("Bad Header".to_string(), "value".to_string())];
+        let error = build_header_map(&headers).unwrap_err();
+
+        assert!(error.contains("Invalid header name"));
+    }
+
+    #[test]
+    fn test_build_header_map_rejects_invalid_value() {
+        let headers = vec![("X-Key".to_string(), "bad\rvalue".to_string())];
+        let error = build_header_map(&headers).unwrap_err();
+
+        assert!(error.contains("Invalid header value"));
     }
 
     #[test]
@@ -36,7 +58,7 @@ mod tests {
             ("X-Foo".to_string(), "bar".to_string()),
             ("X-Baz".to_string(), "qux".to_string()),
         ];
-        let map = build_header_map(&original);
+        let map = build_header_map(&original).unwrap();
         let extracted = extract_headers(&Some(map));
         assert!(extracted.iter().any(|(k, v)| k == "X-Foo" && v == "bar"));
         assert!(extracted.iter().any(|(k, v)| k == "X-Baz" && v == "qux"));

--- a/crates/nats-backend/src/worker/mod.rs
+++ b/crates/nats-backend/src/worker/mod.rs
@@ -69,6 +69,7 @@ pub async fn run_worker(
             BackendCommand::Request {
                 connection_id,
                 backend_id,
+                request_id,
                 subject,
                 payload,
                 headers,
@@ -79,10 +80,33 @@ pub async fn run_worker(
                     pubsub::RequestParams {
                         connection_id,
                         backend_id,
+                        request_id,
                         subject,
                         payload,
                         headers,
                         timeout_ms,
+                    },
+                    &evt_tx,
+                )
+                .await;
+            }
+            BackendCommand::Reply {
+                connection_id,
+                backend_id,
+                reply_id,
+                reply_to,
+                payload,
+                headers,
+            } => {
+                pubsub::handle_reply(
+                    &state,
+                    pubsub::ReplyParams {
+                        connection_id,
+                        backend_id,
+                        reply_id,
+                        reply_to,
+                        payload,
+                        headers,
                     },
                     &evt_tx,
                 )

--- a/crates/nats-backend/src/worker/pubsub.rs
+++ b/crates/nats-backend/src/worker/pubsub.rs
@@ -5,7 +5,7 @@ use bytes::Bytes;
 use futures_util::StreamExt;
 use tokio::sync::mpsc;
 
-use crate::event::{BackendEvent, BackendOperation, MessageData};
+use crate::event::{BackendEvent, BackendOperation, MessageData, RequestFailureKind};
 
 use super::helpers::{build_header_map, extract_headers};
 use super::state::WorkerState;
@@ -15,10 +15,20 @@ const MAX_BATCH_SIZE: usize = 256;
 pub(crate) struct RequestParams {
     pub connection_id: u64,
     pub backend_id: u64,
+    pub request_id: u64,
     pub subject: String,
     pub payload: Vec<u8>,
     pub headers: Option<Vec<(String, String)>>,
     pub timeout_ms: u64,
+}
+
+pub(crate) struct ReplyParams {
+    pub connection_id: u64,
+    pub backend_id: u64,
+    pub reply_id: u64,
+    pub reply_to: String,
+    pub payload: Vec<u8>,
+    pub headers: Option<Vec<(String, String)>>,
 }
 
 pub(crate) async fn handle_publish(
@@ -31,10 +41,22 @@ pub(crate) async fn handle_publish(
 ) {
     if let Some(client) = state.clients.get(&connection_id) {
         let payload = Bytes::from(payload);
+        let headers = match build_optional_header_map(headers) {
+            Ok(headers) => headers,
+            Err(message) => {
+                send_err(
+                    evt_tx,
+                    connection_id,
+                    None,
+                    BackendOperation::Publish,
+                    message,
+                )
+                .await;
+                return;
+            }
+        };
         let result = if let Some(hdrs) = headers {
-            client
-                .publish_with_headers(subject, build_header_map(&hdrs), payload)
-                .await
+            client.publish_with_headers(subject, hdrs, payload).await
         } else {
             client.publish(subject, payload).await
         };
@@ -189,64 +211,151 @@ pub(crate) async fn handle_request(
     let RequestParams {
         connection_id,
         backend_id,
+        request_id,
         subject,
         payload,
         headers,
         timeout_ms,
     } = params;
     if let Some(client) = state.clients.get(&connection_id) {
-        let request_subject = subject.clone();
-        let payload = Bytes::from(payload);
-        let timeout = std::time::Duration::from_millis(timeout_ms);
-        let result = tokio::time::timeout(timeout, async {
-            if let Some(hdrs) = headers {
-                client
-                    .request_with_headers(subject, build_header_map(&hdrs), payload)
-                    .await
-            } else {
-                client.request(subject, payload).await
+        let headers = match build_optional_header_map(headers) {
+            Ok(headers) => headers,
+            Err(message) => {
+                send_request_failed(
+                    evt_tx,
+                    connection_id,
+                    backend_id,
+                    request_id,
+                    message,
+                    RequestFailureKind::Other,
+                )
+                .await;
+                return;
             }
-        })
-        .await;
-        match result {
-            Ok(Ok(msg)) => {
-                let _ = evt_tx
-                    .send(BackendEvent::RequestResponse {
+        };
+        let client = client.clone();
+        let evt_tx = evt_tx.clone();
+        let request_subject = subject.clone();
+        tokio::spawn(async move {
+            let payload = Bytes::from(payload);
+            let timeout = std::time::Duration::from_millis(timeout_ms);
+            let result = tokio::time::timeout(timeout, async {
+                if let Some(hdrs) = headers {
+                    client.request_with_headers(subject, hdrs, payload).await
+                } else {
+                    client.request(subject, payload).await
+                }
+            })
+            .await;
+            match result {
+                Ok(Ok(msg)) => {
+                    let _ = evt_tx
+                        .send(BackendEvent::RequestResponse {
+                            connection_id,
+                            backend_id,
+                            request_id,
+                            subject: Some(request_subject),
+                            payload: msg.payload.to_vec(),
+                            headers: extract_headers(&msg.headers),
+                        })
+                        .await;
+                }
+                Ok(Err(e)) => {
+                    let kind = request_failure_kind(e.kind());
+                    send_request_failed(
+                        &evt_tx,
                         connection_id,
                         backend_id,
-                        subject: Some(request_subject),
-                        payload: msg.payload.to_vec(),
-                        headers: extract_headers(&msg.headers),
-                    })
+                        request_id,
+                        e.to_string(),
+                        kind,
+                    )
                     .await;
+                }
+                Err(_) => {
+                    send_request_failed(
+                        &evt_tx,
+                        connection_id,
+                        backend_id,
+                        request_id,
+                        "Request timed out".to_string(),
+                        RequestFailureKind::TimedOut,
+                    )
+                    .await;
+                }
             }
-            Ok(Err(e)) => {
-                send_err(
-                    evt_tx,
-                    connection_id,
-                    Some(backend_id),
-                    BackendOperation::Request,
-                    e.to_string(),
-                )
-                .await
-            }
-            Err(_) => {
-                send_err(
-                    evt_tx,
-                    connection_id,
-                    Some(backend_id),
-                    BackendOperation::Request,
-                    "Request timed out".to_string(),
-                )
-                .await
-            }
-        }
+        });
     } else {
-        send_not_connected(
+        send_request_failed(
             evt_tx,
             connection_id,
-            Some(backend_id),
-            BackendOperation::Request,
+            backend_id,
+            request_id,
+            "Not connected".to_string(),
+            RequestFailureKind::Other,
+        )
+        .await;
+    }
+}
+
+pub(crate) async fn handle_reply(
+    state: &WorkerState,
+    params: ReplyParams,
+    evt_tx: &mpsc::Sender<BackendEvent>,
+) {
+    let ReplyParams {
+        connection_id,
+        backend_id,
+        reply_id,
+        reply_to,
+        payload,
+        headers,
+    } = params;
+
+    if let Some(client) = state.clients.get(&connection_id) {
+        let headers = match build_optional_header_map(headers) {
+            Ok(headers) => headers,
+            Err(message) => {
+                send_reply_failed(evt_tx, connection_id, backend_id, reply_id, message).await;
+                return;
+            }
+        };
+        let client = client.clone();
+        let evt_tx = evt_tx.clone();
+        tokio::spawn(async move {
+            let payload = Bytes::from(payload);
+            let result = if let Some(hdrs) = headers {
+                client
+                    .publish_with_headers(reply_to.clone(), hdrs, payload)
+                    .await
+            } else {
+                client.publish(reply_to.clone(), payload).await
+            };
+
+            match result {
+                Ok(()) => {
+                    let _ = evt_tx
+                        .send(BackendEvent::Replied {
+                            connection_id,
+                            backend_id,
+                            reply_id,
+                            subject: reply_to,
+                        })
+                        .await;
+                }
+                Err(e) => {
+                    send_reply_failed(&evt_tx, connection_id, backend_id, reply_id, e.to_string())
+                        .await;
+                }
+            }
+        });
+    } else {
+        send_reply_failed(
+            evt_tx,
+            connection_id,
+            backend_id,
+            reply_id,
+            "Not connected".to_string(),
         )
         .await;
     }
@@ -260,6 +369,22 @@ fn to_message_data(msg: async_nats::Message) -> MessageData {
         payload: msg.payload.to_vec(),
         timestamp: SystemTime::now(),
     }
+}
+
+fn request_failure_kind(kind: async_nats::RequestErrorKind) -> RequestFailureKind {
+    match kind {
+        async_nats::RequestErrorKind::TimedOut => RequestFailureKind::TimedOut,
+        async_nats::RequestErrorKind::NoResponders => RequestFailureKind::NoResponders,
+        async_nats::RequestErrorKind::InvalidSubject | async_nats::RequestErrorKind::Other => {
+            RequestFailureKind::Other
+        }
+    }
+}
+
+fn build_optional_header_map(
+    headers: Option<Vec<(String, String)>>,
+) -> Result<Option<async_nats::HeaderMap>, String> {
+    headers.as_deref().map(build_header_map).transpose()
 }
 
 async fn send_ok(
@@ -307,4 +432,65 @@ async fn send_not_connected(
         "Not connected".to_string(),
     )
     .await;
+}
+
+async fn send_request_failed(
+    evt_tx: &mpsc::Sender<BackendEvent>,
+    connection_id: u64,
+    backend_id: u64,
+    request_id: u64,
+    message: String,
+    kind: RequestFailureKind,
+) {
+    let _ = evt_tx
+        .send(BackendEvent::RequestFailed {
+            connection_id,
+            backend_id,
+            request_id,
+            message,
+            kind,
+        })
+        .await;
+}
+
+async fn send_reply_failed(
+    evt_tx: &mpsc::Sender<BackendEvent>,
+    connection_id: u64,
+    backend_id: u64,
+    reply_id: u64,
+    message: String,
+) {
+    let _ = evt_tx
+        .send(BackendEvent::ReplyFailed {
+            connection_id,
+            backend_id,
+            reply_id,
+            message,
+        })
+        .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_failure_kind_preserves_user_visible_categories() {
+        assert_eq!(
+            request_failure_kind(async_nats::RequestErrorKind::TimedOut),
+            RequestFailureKind::TimedOut
+        );
+        assert_eq!(
+            request_failure_kind(async_nats::RequestErrorKind::NoResponders),
+            RequestFailureKind::NoResponders
+        );
+        assert_eq!(
+            request_failure_kind(async_nats::RequestErrorKind::InvalidSubject),
+            RequestFailureKind::Other
+        );
+        assert_eq!(
+            request_failure_kind(async_nats::RequestErrorKind::Other),
+            RequestFailureKind::Other
+        );
+    }
 }

--- a/packaging/flatpak/io.github.mcthesw.easy-nats.metainfo.xml
+++ b/packaging/flatpak/io.github.mcthesw.easy-nats.metainfo.xml
@@ -23,6 +23,21 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="0.1.27" date="2026-06-28">
+      <description>
+        <p>Adds scoped request/reply debugging with subscriber replies.</p>
+      </description>
+    </release>
+    <release version="0.1.26" date="2026-06-27">
+      <description>
+        <p>Adds MessagePack payload input and display.</p>
+      </description>
+    </release>
+    <release version="0.1.25" date="2026-06-19">
+      <description>
+        <p>Closes connection-bound tabs on disconnect.</p>
+      </description>
+    </release>
     <release version="0.1.24" date="2026-06-16">
       <description>
         <p>Adds formatted Search Workspace result previews.</p>


### PR DESCRIPTION
## Summary
- Add correlated Publisher request response/failure handling for the current request.
- Add Subscriber reply composer/status backed by an explicit backend Reply command.
- Split request/reply tab state and pub/sub event reducers, and update Flatpak release metadata.

## Notes
- Publisher request history is intentionally left for a future dedicated request/response workbench.