### PR TITLE
chore(deps): use upstream egui_dock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,8 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "egui_dock"
-version = "0.19.1"
-source = "git+https://github.com/mcthesw/egui_dock.git?branch=compat%2Fegui-0-35#9f4b8dbad767c8d46b7ff37404c4226d8acb036f"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff42beee431ab63b0c1a2044685c4c04ceb0e5e4c1d14dda3dad07aee1ff1525"
 dependencies = [
  "duplicate",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,3 @@ codegen-units = 1
 strip = "symbols"
 panic = "unwind"
 
-[patch.crates-io]
-egui_dock = { git = "https://github.com/mcthesw/egui_dock.git", branch = "compat/egui-0-35" }
-

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -27,7 +27,7 @@ eframe = { version = "0.35", default-features = false, features = [
     "accesskit",
     "inspection",
 ] }
-egui_dock = "0.19.1"
+egui_dock = "0.20.0"
 egui_plot = "0.36.0"
 mimalloc = "0.1"
 protox = "0.9"


### PR DESCRIPTION
Switches tab docking back from the temporary fork patch to upstream `egui_dock` 0.20.0.

Cargo now resolves `egui_dock` from crates.io on the same `egui 0.35` line as the app.

Validated with `cargo fmt --all -- --check`, `cargo check --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`.