### PR TITLE
feat(search): show value/payload in preview for Key/Subject matches

### DIFF
--- a/assets/i18n/search_workspace.yaml
+++ b/assets/i18n/search_workspace.yaml
@@ -71,6 +71,18 @@ open_source:
 preview_format:
   en: "Display"
   zh: "显示"
+loading_value:
+  en: "Loading value..."
+  zh: "正在加载值…"
+fetch_error:
+  en: "Failed to load value"
+  zh: "加载值失败"
+retry:
+  en: "Retry"
+  zh: "重试"
+value_not_found:
+  en: "Value not found"
+  zh: "未找到值"
 field_key:
   en: "Key"
   zh: "键"

--- a/crates/app/src/app/kv_results.rs
+++ b/crates/app/src/app/kv_results.rs
@@ -114,6 +114,38 @@ impl EasyNatsApp {
                 && *cid == connection_id
                 && *bucket_name == entry.bucket
             {
+                // Missing entry guard: the key was deleted between listing and
+                // fetching. Do NOT store an empty payload — clean up stale
+                // references and bump generation so search results rebuild.
+                if entry.revision.is_none() {
+                    state.fetched_values.remove(entry_key);
+                    state.fetched_value_bytes.remove(entry_key);
+                    if let Some(idx) = state.keys.iter().position(|k| k == entry_key) {
+                        state.keys.remove(idx);
+                        if idx < state.value_search_cursor {
+                            state.value_search_cursor = state.value_search_cursor.saturating_sub(1);
+                        }
+                    }
+                    state.invalidate_filtered_key_cache();
+                    state.search_generation = state.search_generation.wrapping_add(1);
+                    if state.value_search_pending.remove(entry_key) {
+                        state.value_search_scanning = state.value_search_pending.len();
+                    }
+                    if state.selected_key.as_deref() == Some(entry_key) {
+                        state.selected_key = None;
+                        state.loading_entry = false;
+                        state.loading_history = false;
+                        state.show_history = false;
+                        state.entry_key.clear();
+                        state.entry_value.clear();
+                        state.entry_revision = None;
+                        state.entry_operation = None;
+                        state.entry_created = None;
+                        state.history.clear();
+                    }
+                    continue;
+                }
+
                 state
                     .fetched_values
                     .insert(entry_key.to_string(), entry_value.clone());
@@ -321,7 +353,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use egui_dock::DockState;
-    use nats_backend::{BackendErrorContext, BackendOperation, KvEntryInfo};
+    use nats_backend::{BackendErrorContext, BackendOperation, KvEntryInfo, KvHistoryItem};
     use tokio_util::sync::CancellationToken;
 
     use super::EasyNatsApp;
@@ -439,5 +471,248 @@ mod tests {
         assert!(state.loading_entry);
         assert_eq!(state.value_search_scanning, 0);
         assert!(state.value_search_pending.is_empty());
+    }
+
+    #[test]
+    fn apply_kv_entry_missing_entry_removes_key_and_does_not_store_value() {
+        let state = KvBucketState {
+            keys: vec!["orders/1".to_string()],
+            ..Default::default()
+        };
+        let initial_generation = state.search_generation;
+        let mut app = test_app_with_kv_tab(7, "ORDERS", state);
+        app.apply_kv_entry(
+            7,
+            KvEntryInfo {
+                bucket: "ORDERS".to_string(),
+                key: "orders/1".to_string(),
+                value: Vec::new(),
+                revision: None,
+                delta: None,
+                created: None,
+                operation: None,
+            },
+        );
+
+        let (_, tab) = app
+            .dock_state
+            .iter_all_tabs()
+            .next()
+            .expect("KV tab exists");
+        let TabKind::KvBucket { state, .. } = tab else {
+            panic!("expected KV bucket tab");
+        };
+        assert!(!state.keys.contains(&"orders/1".to_string()));
+        assert!(!state.fetched_values.contains_key("orders/1"));
+        assert!(!state.fetched_value_bytes.contains_key("orders/1"));
+        assert_ne!(state.search_generation, initial_generation);
+    }
+
+    #[test]
+    fn apply_kv_entry_missing_entry_removes_previously_cached_value() {
+        let mut state = KvBucketState::default();
+        state
+            .fetched_values
+            .insert("orders/1".to_string(), "old".to_string());
+        state
+            .fetched_value_bytes
+            .insert("orders/1".to_string(), b"old".to_vec());
+        let mut app = test_app_with_kv_tab(7, "ORDERS", state);
+        app.apply_kv_entry(
+            7,
+            KvEntryInfo {
+                bucket: "ORDERS".to_string(),
+                key: "orders/1".to_string(),
+                value: Vec::new(),
+                revision: None,
+                delta: None,
+                created: None,
+                operation: None,
+            },
+        );
+
+        let (_, tab) = app
+            .dock_state
+            .iter_all_tabs()
+            .next()
+            .expect("KV tab exists");
+        let TabKind::KvBucket { state, .. } = tab else {
+            panic!("expected KV bucket tab");
+        };
+        assert!(!state.fetched_values.contains_key("orders/1"));
+        assert!(!state.fetched_value_bytes.contains_key("orders/1"));
+    }
+
+    #[test]
+    fn apply_kv_entry_missing_entry_cleans_value_search_pending() {
+        let mut state = KvBucketState {
+            value_search_scanning: 2,
+            ..Default::default()
+        };
+        state.value_search_pending.insert("orders/1".to_string());
+        state.value_search_pending.insert("orders/2".to_string());
+        let mut app = test_app_with_kv_tab(7, "ORDERS", state);
+        app.apply_kv_entry(
+            7,
+            KvEntryInfo {
+                bucket: "ORDERS".to_string(),
+                key: "orders/1".to_string(),
+                value: Vec::new(),
+                revision: None,
+                delta: None,
+                created: None,
+                operation: None,
+            },
+        );
+
+        let (_, tab) = app
+            .dock_state
+            .iter_all_tabs()
+            .next()
+            .expect("KV tab exists");
+        let TabKind::KvBucket { state, .. } = tab else {
+            panic!("expected KV bucket tab");
+        };
+        assert_eq!(state.value_search_scanning, 1);
+        assert!(state.value_search_pending.contains("orders/2"));
+        assert!(!state.value_search_pending.contains("orders/1"));
+    }
+
+    #[test]
+    fn apply_kv_entry_missing_entry_rewinds_value_search_cursor() {
+        let state = KvBucketState {
+            keys: vec![
+                "orders/1".to_string(),
+                "orders/2".to_string(),
+                "orders/3".to_string(),
+            ],
+            value_search_cursor: 2,
+            ..Default::default()
+        };
+        let mut app = test_app_with_kv_tab(7, "ORDERS", state);
+        app.apply_kv_entry(
+            7,
+            KvEntryInfo {
+                bucket: "ORDERS".to_string(),
+                key: "orders/1".to_string(),
+                value: Vec::new(),
+                revision: None,
+                delta: None,
+                created: None,
+                operation: None,
+            },
+        );
+
+        let (_, tab) = app
+            .dock_state
+            .iter_all_tabs()
+            .next()
+            .expect("KV tab exists");
+        let TabKind::KvBucket { state, .. } = tab else {
+            panic!("expected KV bucket tab");
+        };
+        assert_eq!(
+            state.keys,
+            vec!["orders/2".to_string(), "orders/3".to_string()]
+        );
+        assert_eq!(state.value_search_cursor, 1);
+    }
+
+    #[test]
+    fn apply_kv_entry_missing_entry_clears_selected_entry_state() {
+        let state = KvBucketState {
+            loading_entry: true,
+            loading_history: true,
+            show_history: true,
+            selected_key: Some("orders/1".to_string()),
+            entry_key: "orders/1".to_string(),
+            entry_value: "stale".to_string(),
+            entry_revision: Some(3),
+            entry_operation: Some("PUT".to_string()),
+            entry_created: Some("2025-01-01T00:00:00Z".to_string()),
+            history: vec![KvHistoryItem {
+                key: "orders/1".to_string(),
+                value: b"stale".to_vec(),
+                revision: 3,
+                delta: 0,
+                created: "2025-01-01T00:00:00Z".to_string(),
+                operation: "PUT".to_string(),
+            }],
+            ..Default::default()
+        };
+        let mut app = test_app_with_kv_tab(7, "ORDERS", state);
+        app.apply_kv_entry(
+            7,
+            KvEntryInfo {
+                bucket: "ORDERS".to_string(),
+                key: "orders/1".to_string(),
+                value: Vec::new(),
+                revision: None,
+                delta: None,
+                created: None,
+                operation: None,
+            },
+        );
+
+        let (_, tab) = app
+            .dock_state
+            .iter_all_tabs()
+            .next()
+            .expect("KV tab exists");
+        let TabKind::KvBucket { state, .. } = tab else {
+            panic!("expected KV bucket tab");
+        };
+        assert_eq!(state.selected_key, None);
+        assert!(!state.loading_entry);
+        assert!(!state.loading_history);
+        assert!(!state.show_history);
+        assert!(state.entry_key.is_empty());
+        assert!(state.entry_value.is_empty());
+        assert_eq!(state.entry_revision, None);
+        assert_eq!(state.entry_operation, None);
+        assert_eq!(state.entry_created, None);
+        assert!(state.history.is_empty());
+    }
+
+    #[test]
+    fn apply_kv_entry_missing_entry_does_not_clear_unrelated_selected_entry() {
+        let state = KvBucketState {
+            loading_entry: true,
+            selected_key: Some("orders/2".to_string()),
+            entry_revision: Some(3),
+            entry_operation: Some("PUT".to_string()),
+            entry_created: Some("2025-01-01T00:00:00Z".to_string()),
+            keys: vec!["orders/1".to_string(), "orders/2".to_string()],
+            ..Default::default()
+        };
+        let mut app = test_app_with_kv_tab(7, "ORDERS", state);
+        app.apply_kv_entry(
+            7,
+            KvEntryInfo {
+                bucket: "ORDERS".to_string(),
+                key: "orders/1".to_string(),
+                value: Vec::new(),
+                revision: None,
+                delta: None,
+                created: None,
+                operation: None,
+            },
+        );
+
+        let (_, tab) = app
+            .dock_state
+            .iter_all_tabs()
+            .next()
+            .expect("KV tab exists");
+        let TabKind::KvBucket { state, .. } = tab else {
+            panic!("expected KV bucket tab");
+        };
+        // The unrelated selected entry's loading/detail state must be untouched.
+        assert!(state.loading_entry);
+        assert_eq!(state.entry_revision, Some(3));
+        assert_eq!(state.entry_operation.as_deref(), Some("PUT"));
+        // The missing key should still be removed from keys.
+        assert!(!state.keys.contains(&"orders/1".to_string()));
+        assert!(state.keys.contains(&"orders/2".to_string()));
     }
 }

--- a/crates/app/src/app/operation_results.rs
+++ b/crates/app/src/app/operation_results.rs
@@ -1,7 +1,7 @@
 use nats_backend::{BackendErrorContext, BackendOperation};
 
 use crate::i18n::t;
-use crate::tabs::TabKind;
+use crate::tabs::{PreviewFetchState, SearchSourceId, TabKind};
 use crate::toast::ToastLevel;
 
 use super::model::EasyNatsApp;
@@ -70,10 +70,64 @@ impl EasyNatsApp {
             self.clear_server_info_loading_on_error(cid, operation);
         }
 
+        if operation == BackendOperation::GetKvEntry {
+            self.mark_search_workspace_fetch_failed(connection_id, context, message);
+        }
+
         self.toasts.push(
             ToastLevel::Error,
             operation_error_message(operation, message, context),
         );
+    }
+
+    fn mark_search_workspace_fetch_failed(
+        &mut self,
+        connection_id: Option<u64>,
+        context: Option<&BackendErrorContext>,
+        message: &str,
+    ) {
+        let (failed_bucket, failed_key) = match context {
+            Some(BackendErrorContext::KvEntry { bucket, key }) => {
+                (Some(bucket.as_str()), Some(key.as_str()))
+            }
+            _ => (None, None),
+        };
+
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::SearchWorkspace { state } = tab {
+                let fetch_state = state.preview_fetch.clone();
+                if let PreviewFetchState::Loading(key) = &fetch_state {
+                    let matches = match (&key.source_id, failed_bucket, failed_key) {
+                        (
+                            SearchSourceId::Kv {
+                                connection_id: cid,
+                                bucket_name,
+                            },
+                            Some(bucket),
+                            Some(k),
+                        ) => {
+                            *cid == connection_id.unwrap_or(0)
+                                && bucket_name == bucket
+                                && key.item_id == k
+                        }
+                        (
+                            SearchSourceId::Kv {
+                                connection_id: cid, ..
+                            },
+                            None,
+                            _,
+                        ) => Some(*cid) == connection_id,
+                        _ => false,
+                    };
+                    if matches {
+                        state.preview_fetch = PreviewFetchState::Failed {
+                            key: key.clone(),
+                            message: message.to_string(),
+                        };
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -100,9 +154,43 @@ fn operation_error_message(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use egui_dock::DockState;
     use nats_backend::{BackendErrorContext, BackendOperation};
 
     use super::*;
+    use crate::log_layer::LogBuffer;
+    use crate::settings::AppSettings;
+    use crate::tabs::types::{SearchField, SearchResultKey};
+    use crate::tabs::{SearchSourceId, SearchWorkspaceState};
+    use crate::theme::ThemeId;
+
+    fn test_app_with_search_workspace(preview_fetch: PreviewFetchState) -> EasyNatsApp {
+        let mut app = EasyNatsApp::new(
+            AppSettings::default(),
+            ThemeId::EguiDark,
+            Arc::new(Mutex::new(LogBuffer::default())),
+        );
+        app.dock_state = DockState::new(vec![TabKind::SearchWorkspace {
+            state: SearchWorkspaceState {
+                preview_fetch,
+                ..Default::default()
+            },
+        }]);
+        app
+    }
+
+    fn kv_loading_key(connection_id: u64, bucket: &str, key: &str) -> SearchResultKey {
+        SearchResultKey {
+            source_id: SearchSourceId::Kv {
+                connection_id,
+                bucket_name: bucket.to_string(),
+            },
+            field: SearchField::Key,
+            item_id: key.to_string(),
+        }
+    }
 
     #[test]
     fn workqueue_fetch_limitation_hides_raw_server_error() {
@@ -121,5 +209,121 @@ mod tests {
         assert!(!message.contains("filtered consumer not unique"));
         assert!(!message.contains("Failed to create inspector consumer"));
         assert!(message.contains("fetch_consumer_messages"));
+    }
+
+    #[test]
+    fn get_kv_entry_error_marks_matching_search_workspace_fetch_failed() {
+        let key = kv_loading_key(7, "ORDERS", "orders/1");
+        let mut app = test_app_with_search_workspace(PreviewFetchState::Loading(key.clone()));
+        let context = BackendErrorContext::KvEntry {
+            bucket: "ORDERS".to_string(),
+            key: "orders/1".to_string(),
+        };
+
+        app.handle_error(
+            Some(7),
+            None,
+            BackendOperation::GetKvEntry,
+            "connection refused",
+            Some(&context),
+        );
+
+        for (_, tab) in app.dock_state.iter_all_tabs() {
+            if let TabKind::SearchWorkspace { state } = tab {
+                match &state.preview_fetch {
+                    PreviewFetchState::Failed { key: k, message } => {
+                        assert_eq!(k, &key);
+                        assert_eq!(message, "connection refused");
+                    }
+                    _ => panic!("expected Failed state, got {:?}", state.preview_fetch),
+                }
+                return;
+            }
+        }
+        panic!("no SearchWorkspace tab found");
+    }
+
+    #[test]
+    fn get_kv_entry_error_without_context_marks_connection_loading_failed() {
+        let key = kv_loading_key(7, "ORDERS", "orders/1");
+        let mut app = test_app_with_search_workspace(PreviewFetchState::Loading(key.clone()));
+
+        app.handle_error(
+            Some(7),
+            None,
+            BackendOperation::GetKvEntry,
+            "not connected",
+            None,
+        );
+
+        for (_, tab) in app.dock_state.iter_all_tabs() {
+            if let TabKind::SearchWorkspace { state } = tab {
+                match &state.preview_fetch {
+                    PreviewFetchState::Failed { key: k, message } => {
+                        assert_eq!(k, &key);
+                        assert_eq!(message, "not connected");
+                    }
+                    _ => panic!("expected Failed state, got {:?}", state.preview_fetch),
+                }
+                return;
+            }
+        }
+        panic!("no SearchWorkspace tab found");
+    }
+
+    #[test]
+    fn get_kv_entry_error_does_not_mark_unrelated_search_workspace_fetch() {
+        // Loading a different key — should not be marked as failed.
+        let other_key = kv_loading_key(7, "ORDERS", "orders/2");
+        let mut app = test_app_with_search_workspace(PreviewFetchState::Loading(other_key));
+        let context = BackendErrorContext::KvEntry {
+            bucket: "ORDERS".to_string(),
+            key: "orders/1".to_string(),
+        };
+
+        app.handle_error(
+            Some(7),
+            None,
+            BackendOperation::GetKvEntry,
+            "connection refused",
+            Some(&context),
+        );
+
+        for (_, tab) in app.dock_state.iter_all_tabs() {
+            if let TabKind::SearchWorkspace { state } = tab {
+                // Should still be Loading (not Failed) since the key doesn't match
+                assert!(matches!(
+                    &state.preview_fetch,
+                    PreviewFetchState::Loading(_)
+                ));
+                return;
+            }
+        }
+        panic!("no SearchWorkspace tab found");
+    }
+
+    #[test]
+    fn get_kv_entry_error_does_not_mark_idle_search_workspace() {
+        let mut app = test_app_with_search_workspace(PreviewFetchState::Idle);
+        let context = BackendErrorContext::KvEntry {
+            bucket: "ORDERS".to_string(),
+            key: "orders/1".to_string(),
+        };
+
+        app.handle_error(
+            Some(7),
+            None,
+            BackendOperation::GetKvEntry,
+            "connection refused",
+            Some(&context),
+        );
+
+        for (_, tab) in app.dock_state.iter_all_tabs() {
+            if let TabKind::SearchWorkspace { state } = tab {
+                assert!(matches!(state.preview_fetch, PreviewFetchState::Idle));
+                return;
+            }
+        }
+        panic!("no SearchWorkspace tab found");
     }
 }

--- a/crates/app/src/app/search_workspace.rs
+++ b/crates/app/src/app/search_workspace.rs
@@ -186,6 +186,52 @@ impl EasyNatsApp {
         }
     }
 
+    pub(crate) fn fetch_search_workspace_kv_value(
+        &mut self,
+        source_id: &SearchSourceId,
+        key: &str,
+    ) {
+        let SearchSourceId::Kv {
+            connection_id,
+            bucket_name,
+        } = source_id
+        else {
+            return;
+        };
+
+        let mut send_request = None;
+        for (_surface, tab) in self.dock_state.iter_all_tabs_mut() {
+            if let TabKind::KvBucket {
+                connection_id: cid,
+                bucket_name: current_bucket,
+                state,
+                ..
+            } = tab
+                && *cid == *connection_id
+                && current_bucket == bucket_name
+            {
+                // Double-check before sending: value not already cached,
+                // not already being fetched by batch scan, and key still exists.
+                if state.fetched_value_bytes.contains_key(key)
+                    || state.value_search_pending.contains(key)
+                    || !state.keys.iter().any(|k| k == key)
+                {
+                    break;
+                }
+                send_request = Some((*connection_id, bucket_name.clone(), key.to_string()));
+                break;
+            }
+        }
+
+        if let Some((cid, bucket, key)) = send_request {
+            self.backend.send(BackendCommand::GetKvEntry {
+                connection_id: cid,
+                bucket,
+                key,
+            });
+        }
+    }
+
     pub(crate) fn navigate_search_result(&mut self, locator: SearchResultLocator) {
         let resolved = match locator {
             SearchResultLocator::KvKey {
@@ -459,11 +505,18 @@ fn tab_matches_search_source(tab: &TabKind, source_id: &SearchSourceId) -> bool 
 
 #[cfg(test)]
 mod tests {
-    use nats_backend::StreamMessageInfo;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use egui_dock::DockState;
+    use nats_backend::{BackendEvent, BackendOperation, StreamMessageInfo};
     use tokio_util::sync::CancellationToken;
 
     use super::*;
-    use crate::tabs::{StreamState, TabGuard};
+    use crate::log_layer::LogBuffer;
+    use crate::settings::AppSettings;
+    use crate::tabs::{KvBucketState, StreamState, TabGuard};
+    use crate::theme::ThemeId;
 
     fn stream_source(stream_name: &str, generation: u64) -> SearchSourceSummary {
         let tab = TabKind::Stream {
@@ -565,5 +618,169 @@ mod tests {
         let (_, query_changed) =
             search_workspace_refresh_decision(&state, std::slice::from_ref(&source));
         assert_eq!(query_changed, Some("query"));
+    }
+
+    fn test_app_with_kv_tab(
+        connection_id: u64,
+        bucket_name: &str,
+        state: KvBucketState,
+    ) -> EasyNatsApp {
+        let mut app = EasyNatsApp::new(
+            AppSettings::default(),
+            ThemeId::EguiDark,
+            Arc::new(Mutex::new(LogBuffer::default())),
+        );
+        app.dock_state = DockState::new(vec![TabKind::KvBucket {
+            connection_id,
+            connection_name: "local".to_string(),
+            bucket_name: bucket_name.to_string(),
+            guard: TabGuard::new_without_id(CancellationToken::new()),
+            state,
+        }]);
+        app
+    }
+
+    /// Polls the backend event channel for a short period and returns true if
+    /// a `GetKvEntry` error event is received.
+    fn backend_emitted_get_kv_entry_error(app: &mut EasyNatsApp) -> bool {
+        let deadline = std::time::Instant::now() + Duration::from_millis(500);
+        while std::time::Instant::now() < deadline {
+            if let Some(event) = app.backend.try_recv()
+                && let BackendEvent::Error { operation, .. } = event
+                && operation == BackendOperation::GetKvEntry
+            {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        false
+    }
+
+    #[test]
+    fn fetch_kv_value_sends_get_kv_entry_when_guards_pass() {
+        let state = KvBucketState {
+            keys: vec!["order/1".to_string()],
+            ..Default::default()
+        };
+        let mut app = test_app_with_kv_tab(7, "ORDERS", state);
+        let source_id = SearchSourceId::Kv {
+            connection_id: 7,
+            bucket_name: "ORDERS".to_string(),
+        };
+
+        app.fetch_search_workspace_kv_value(&source_id, "order/1");
+
+        assert!(
+            backend_emitted_get_kv_entry_error(&mut app),
+            "expected a GetKvEntry error event after fetching an uncached key"
+        );
+    }
+
+    #[test]
+    fn fetch_kv_value_skips_when_value_already_cached() {
+        let mut state = KvBucketState {
+            keys: vec!["order/1".to_string()],
+            ..Default::default()
+        };
+        state
+            .fetched_value_bytes
+            .insert("order/1".to_string(), b"value".to_vec());
+        let mut app = test_app_with_kv_tab(7, "ORDERS", state);
+        let source_id = SearchSourceId::Kv {
+            connection_id: 7,
+            bucket_name: "ORDERS".to_string(),
+        };
+
+        app.fetch_search_workspace_kv_value(&source_id, "order/1");
+
+        assert!(
+            !backend_emitted_get_kv_entry_error(&mut app),
+            "should not send GetKvEntry when value is already cached"
+        );
+    }
+
+    #[test]
+    fn fetch_kv_value_skips_when_key_in_value_search_pending() {
+        let mut state = KvBucketState {
+            keys: vec!["order/1".to_string()],
+            value_search_scanning: 1,
+            ..Default::default()
+        };
+        state.value_search_pending.insert("order/1".to_string());
+        let mut app = test_app_with_kv_tab(7, "ORDERS", state);
+        let source_id = SearchSourceId::Kv {
+            connection_id: 7,
+            bucket_name: "ORDERS".to_string(),
+        };
+
+        app.fetch_search_workspace_kv_value(&source_id, "order/1");
+
+        assert!(
+            !backend_emitted_get_kv_entry_error(&mut app),
+            "should not send GetKvEntry when key is in value_search_pending"
+        );
+    }
+
+    #[test]
+    fn fetch_kv_value_skips_when_key_not_in_keys_list() {
+        let state = KvBucketState {
+            keys: vec!["order/2".to_string()],
+            ..Default::default()
+        };
+        let mut app = test_app_with_kv_tab(7, "ORDERS", state);
+        let source_id = SearchSourceId::Kv {
+            connection_id: 7,
+            bucket_name: "ORDERS".to_string(),
+        };
+
+        app.fetch_search_workspace_kv_value(&source_id, "order/1");
+
+        assert!(
+            !backend_emitted_get_kv_entry_error(&mut app),
+            "should not send GetKvEntry when key is not in the keys list"
+        );
+    }
+
+    #[test]
+    fn fetch_kv_value_skips_when_kv_tab_does_not_exist() {
+        let mut app = EasyNatsApp::new(
+            AppSettings::default(),
+            ThemeId::EguiDark,
+            Arc::new(Mutex::new(LogBuffer::default())),
+        );
+        app.dock_state = DockState::new(vec![TabKind::Welcome]);
+        let source_id = SearchSourceId::Kv {
+            connection_id: 7,
+            bucket_name: "ORDERS".to_string(),
+        };
+
+        // Should not panic and should not send anything.
+        app.fetch_search_workspace_kv_value(&source_id, "order/1");
+
+        assert!(
+            !backend_emitted_get_kv_entry_error(&mut app),
+            "should not send GetKvEntry when no matching KV tab exists"
+        );
+    }
+
+    #[test]
+    fn fetch_kv_value_ignores_non_kv_source_id() {
+        let state = KvBucketState {
+            keys: vec!["order/1".to_string()],
+            ..Default::default()
+        };
+        let mut app = test_app_with_kv_tab(7, "ORDERS", state);
+        let source_id = SearchSourceId::Stream {
+            connection_id: 7,
+            stream_name: "ORDERS".to_string(),
+        };
+
+        // Should return early for non-Kv source_id without panicking.
+        app.fetch_search_workspace_kv_value(&source_id, "order/1");
+
+        assert!(
+            !backend_emitted_get_kv_entry_error(&mut app),
+            "should not send GetKvEntry for a non-Kv source_id"
+        );
     }
 }

--- a/crates/app/src/app/ui.rs
+++ b/crates/app/src/app/ui.rs
@@ -213,6 +213,9 @@ impl eframe::App for EasyNatsApp {
                 TabAction::ScanSearchWorkspaceKvValues { source_id } => {
                     self.scan_search_workspace_kv_values(&source_id);
                 }
+                TabAction::FetchSearchWorkspaceKvValue { source_id, key } => {
+                    self.fetch_search_workspace_kv_value(&source_id, &key);
+                }
                 TabAction::NavigateSearchResult { locator } => {
                     self.navigate_search_result(locator);
                 }

--- a/crates/app/src/tabs/mod.rs
+++ b/crates/app/src/tabs/mod.rs
@@ -14,7 +14,7 @@ mod stream;
 mod stream_consumers;
 mod subscriber;
 mod subscriber_detail;
-mod types;
+pub(crate) mod types;
 mod viewer;
 
 pub(crate) use common::{
@@ -36,7 +36,8 @@ pub use stream::stream_ui;
 pub use subscriber::subscriber_ui;
 pub use types::{
     AppTabViewer, ClientStatusState, KvBucketState, MessageSchemasState, MetricsState,
-    ObjectStoreBucketState, PublisherState, ReceivedMessage, ResponseData, SearchResultLocator,
-    SearchSourceId, SearchSourceSummary, SearchWorkspaceCacheKey, SearchWorkspaceResult,
-    SearchWorkspaceState, ServerInfoState, StreamState, SubscriberState, TabAction, TabKind,
+    ObjectStoreBucketState, PreviewFetchState, PublisherState, ReceivedMessage, ResponseData,
+    SearchResultLocator, SearchSourceId, SearchSourceSummary, SearchWorkspaceCacheKey,
+    SearchWorkspaceResult, SearchWorkspaceState, ServerInfoState, StreamState, SubscriberState,
+    TabAction, TabKind,
 };

--- a/crates/app/src/tabs/search_workspace.rs
+++ b/crates/app/src/tabs/search_workspace.rs
@@ -5,8 +5,9 @@ use crate::i18n::t;
 
 use super::common::SEARCH_RESULT_LIMIT;
 use super::types::{
-    SearchField, SearchSourceCoverage, SearchSourceId, SearchSourceKind, SearchSourceSummary,
-    SearchWorkspaceResult, SearchWorkspaceState, TabAction, TabKind,
+    PreviewFetchState, SearchField, SearchResultKey, SearchResultLocator, SearchSourceCoverage,
+    SearchSourceId, SearchSourceKind, SearchSourceSummary, SearchWorkspaceResult,
+    SearchWorkspaceState, TabAction, TabKind,
 };
 
 mod results;
@@ -116,7 +117,7 @@ pub fn search_workspace_ui(
         .map(|(_, results)| results.as_slice())
         .unwrap_or(&[]);
     if let Some(selected) = &state.selected_result
-        && !results.iter().any(|result| &result.identity == selected)
+        && !results.iter().any(|result| &result.key == selected)
         && state.selected_preview.is_none()
     {
         state.selected_result = None;
@@ -183,6 +184,7 @@ fn render_toolbar(
         state.cached_results = None;
         state.selected_result = None;
         state.selected_preview = None;
+        state.preview_fetch = PreviewFetchState::Idle;
     }
 }
 
@@ -222,6 +224,7 @@ fn render_selected_sources(
         {
             state.selected_result = None;
             state.selected_preview = None;
+            state.preview_fetch = PreviewFetchState::Idle;
         }
     }
 }
@@ -335,7 +338,7 @@ fn render_results(
             for source_id in state.selected_sources.clone() {
                 let mut group_results = results
                     .iter()
-                    .filter(|result| result.identity.source_id == source_id);
+                    .filter(|result| result.key.source_id == source_id);
                 let Some(first_result) = group_results.next() else {
                     continue;
                 };
@@ -357,7 +360,7 @@ fn render_result_group_header(
 ) {
     let source = sources
         .iter()
-        .find(|source| source.id == first_result.identity.source_id);
+        .find(|source| source.id == first_result.key.source_id);
     ui.horizontal_wrapped(|ui| {
         ui.label(egui::RichText::new(&first_result.source_label).strong());
         if let Some(source) = source {
@@ -376,7 +379,7 @@ fn render_result_row(
         let selected = state
             .selected_result
             .as_ref()
-            .is_some_and(|identity| identity == &result.identity);
+            .is_some_and(|identity| identity == &result.key);
         let row = format!(
             "{} · {}",
             field_label(result.field),
@@ -387,8 +390,9 @@ fn render_result_row(
             .on_hover_text(&result.snippet)
             .clicked()
         {
-            state.selected_result = Some(result.identity.clone());
+            state.selected_result = Some(result.key.clone());
             state.selected_preview = Some(result.clone());
+            state.preview_fetch = PreviewFetchState::Idle;
         }
     });
 }
@@ -399,30 +403,120 @@ fn render_preview(
     results: &[SearchWorkspaceResult],
     actions: &mut Vec<TabAction>,
 ) {
-    let Some(preview) = state.selected_preview.as_ref() else {
+    let Some(preview_key) = state
+        .selected_preview
+        .as_ref()
+        .map(|preview| preview.key.clone())
+    else {
         ui.centered_and_justified(|ui| {
             ui.label(t("search_workspace.select_result"));
         });
         return;
     };
 
-    let (active_preview, is_stale) = active_preview_result(preview, results);
+    if let Some(active_preview) = results.iter().find(|result| result.key == preview_key) {
+        render_current_preview(ui, state, active_preview, actions);
+    } else {
+        render_stale_preview(ui, state, actions);
+    }
+}
 
-    ui.heading(&active_preview.item_label);
+fn render_current_preview(
+    ui: &mut egui::Ui,
+    state: &mut SearchWorkspaceState,
+    active_preview: &SearchWorkspaceResult,
+    actions: &mut Vec<TabAction>,
+) {
+    render_preview_header(
+        ui,
+        state,
+        actions,
+        PreviewHeader {
+            item_label: &active_preview.item_label,
+            source_label: &active_preview.source_label,
+            field: active_preview.field,
+            locator: Some(&active_preview.locator),
+        },
+    );
+    match &active_preview.preview_bytes {
+        Some(bytes) => {
+            state.preview_fetch = PreviewFetchState::Idle;
+            render_formatted_preview_bytes(ui, bytes, state.preview_format, &state.query);
+        }
+        None => {
+            render_pending_kv_value_preview(ui, state, active_preview, actions);
+        }
+    }
+}
+
+fn render_stale_preview(
+    ui: &mut egui::Ui,
+    state: &mut SearchWorkspaceState,
+    actions: &mut Vec<TabAction>,
+) {
+    let Some(snapshot) = state.selected_preview.as_ref() else {
+        return;
+    };
+    let item_label = snapshot.item_label.clone();
+    let source_label = snapshot.source_label.clone();
+    let field = snapshot.field;
+    let has_preview_bytes = snapshot.preview_bytes.is_some();
+
+    render_preview_header(
+        ui,
+        state,
+        actions,
+        PreviewHeader {
+            item_label: &item_label,
+            source_label: &source_label,
+            field,
+            locator: None,
+        },
+    );
+    state.preview_fetch = PreviewFetchState::Idle;
+    if has_preview_bytes {
+        let selected_format = state.preview_format;
+        let query = state.query.clone();
+        if let Some(bytes) = state
+            .selected_preview
+            .as_ref()
+            .and_then(|preview| preview.preview_bytes.as_deref())
+        {
+            render_formatted_preview_bytes(ui, bytes, selected_format, &query);
+        }
+    } else {
+        ui.weak(t("search_workspace.value_not_found"));
+    }
+}
+
+struct PreviewHeader<'a> {
+    item_label: &'a str,
+    source_label: &'a str,
+    field: SearchField,
+    locator: Option<&'a SearchResultLocator>,
+}
+
+fn render_preview_header(
+    ui: &mut egui::Ui,
+    state: &mut SearchWorkspaceState,
+    actions: &mut Vec<TabAction>,
+    header: PreviewHeader<'_>,
+) {
+    ui.heading(header.item_label);
     ui.horizontal_wrapped(|ui| {
-        ui.label(&active_preview.source_label);
-        ui.weak(field_label(active_preview.field));
-        if is_stale {
+        ui.label(header.source_label);
+        ui.weak(field_label(header.field));
+        if header.locator.is_none() {
             ui.weak(t("search_workspace.stale_result"));
         }
     });
     ui.add_space(4.0);
     ui.horizontal_wrapped(|ui| {
         render_preview_format_selector(ui, &mut state.preview_format);
-        if !is_stale {
+        if let Some(locator) = header.locator {
             if ui.button(t("search_workspace.open_source")).clicked() {
                 actions.push(TabAction::NavigateSearchResult {
-                    locator: active_preview.locator.clone(),
+                    locator: locator.clone(),
                 });
             }
         } else {
@@ -430,7 +524,90 @@ fn render_preview(
         }
     });
     ui.separator();
-    render_formatted_preview(ui, active_preview, state.preview_format, &state.query);
+}
+
+/// Renders the preview area for a KV Key match whose value hasn't been
+/// fetched yet. Manages the `PreviewFetchState` lifecycle: idle triggers a
+/// fetch, loading shows a spinner, failed shows an error with retry.
+fn render_pending_kv_value_preview(
+    ui: &mut egui::Ui,
+    state: &mut SearchWorkspaceState,
+    active_preview: &SearchWorkspaceResult,
+    actions: &mut Vec<TabAction>,
+) {
+    let active_key = active_preview.key.clone();
+    let active_locator = active_preview.locator.clone();
+    // Clone the fetch state so we can read it and then mutate `state`
+    // without a borrow conflict.
+    let fetch_state = state.preview_fetch.clone();
+
+    match &fetch_state {
+        PreviewFetchState::Idle => {
+            state.preview_fetch = PreviewFetchState::Loading(active_key.clone());
+            emit_fetch_action(&active_locator, actions);
+            show_loading(ui);
+        }
+        PreviewFetchState::Loading(expected) if expected == &active_key => {
+            show_loading(ui);
+        }
+        PreviewFetchState::Loading(_) => {
+            // Selection changed to a different key — reset and re-trigger next frame.
+            state.preview_fetch = PreviewFetchState::Idle;
+            show_loading(ui);
+        }
+        PreviewFetchState::Failed { key, message } if key == &active_key => {
+            let message = message.clone();
+            show_error_with_retry(ui, &message, &active_key, &active_locator, state, actions);
+        }
+        PreviewFetchState::Failed { .. } => {
+            // Selection changed — reset and re-trigger next frame.
+            state.preview_fetch = PreviewFetchState::Idle;
+            show_loading(ui);
+        }
+    }
+}
+
+fn emit_fetch_action(locator: &SearchResultLocator, actions: &mut Vec<TabAction>) {
+    if let SearchResultLocator::KvKey {
+        connection_id,
+        bucket_name,
+        key,
+    } = locator
+    {
+        actions.push(TabAction::FetchSearchWorkspaceKvValue {
+            source_id: SearchSourceId::Kv {
+                connection_id: *connection_id,
+                bucket_name: bucket_name.clone(),
+            },
+            key: key.clone(),
+        });
+    }
+}
+
+fn show_loading(ui: &mut egui::Ui) {
+    ui.horizontal(|ui| {
+        ui.spinner();
+        ui.label(t("search_workspace.loading_value"));
+    });
+}
+
+fn show_error_with_retry(
+    ui: &mut egui::Ui,
+    message: &str,
+    active_key: &SearchResultKey,
+    active_locator: &SearchResultLocator,
+    state: &mut SearchWorkspaceState,
+    actions: &mut Vec<TabAction>,
+) {
+    ui.colored_label(
+        ui.visuals().error_fg_color,
+        t("search_workspace.fetch_error"),
+    );
+    ui.weak(message);
+    if ui.button(t("search_workspace.retry")).clicked() {
+        state.preview_fetch = PreviewFetchState::Loading(active_key.clone());
+        emit_fetch_action(active_locator, actions);
+    }
 }
 
 fn render_preview_format_selector(ui: &mut egui::Ui, format: &mut PayloadFormat) {
@@ -447,13 +624,13 @@ fn render_preview_format_selector(ui: &mut egui::Ui, format: &mut PayloadFormat)
         });
 }
 
-fn render_formatted_preview(
+fn render_formatted_preview_bytes(
     ui: &mut egui::Ui,
-    result: &SearchWorkspaceResult,
+    bytes: &[u8],
     selected_format: PayloadFormat,
     query: &str,
 ) {
-    let preview = format::format_read_only_preview(&result.preview_bytes, selected_format);
+    let preview = format::format_read_only_preview(bytes, selected_format);
     let job = format::read_only_preview_layout_job(&preview, ui.style(), query);
     egui::ScrollArea::both()
         .id_salt("search_workspace_preview")
@@ -463,13 +640,14 @@ fn render_formatted_preview(
         });
 }
 
+#[cfg(test)]
 fn active_preview_result<'a>(
     preview: &'a SearchWorkspaceResult,
     results: &'a [SearchWorkspaceResult],
 ) -> (&'a SearchWorkspaceResult, bool) {
     results
         .iter()
-        .find(|result| result.identity == preview.identity)
+        .find(|result| result.key == preview.key)
         .map_or((preview, true), |current| (current, false))
 }
 

--- a/crates/app/src/tabs/search_workspace/results.rs
+++ b/crates/app/src/tabs/search_workspace/results.rs
@@ -3,7 +3,7 @@ use crate::tabs::common::{
     NormalizedSearchQuery, SEARCH_RESULT_LIMIT, format_timestamp, searchable_payload_text,
 };
 use crate::tabs::types::{
-    KvBucketState, ReceivedMessage, SearchField, SearchResultIdentity, SearchResultLocator,
+    KvBucketState, ReceivedMessage, SearchField, SearchResultKey, SearchResultLocator,
     SearchSourceKind, SearchSourceSummary, SearchWorkspaceResult, StreamState, SubscriberState,
     TabKind,
 };
@@ -101,13 +101,14 @@ fn append_kv_results(
             }
             ctx.stats.records_scanned += 1;
             if ctx.query.matches(key) {
+                let preview_bytes = state.fetched_value_bytes.get(key.as_str()).cloned();
                 push_result(
                     &mut ctx,
                     SearchField::Key,
                     key,
                     key,
                     key,
-                    key.as_bytes(),
+                    preview_bytes,
                     SearchResultLocator::KvKey {
                         connection_id,
                         bucket_name: bucket_name.to_string(),
@@ -131,15 +132,15 @@ fn append_kv_results(
                 let preview_bytes = state
                     .fetched_value_bytes
                     .get(key.as_str())
-                    .map(Vec::as_slice)
-                    .unwrap_or_else(|| value.as_bytes());
+                    .cloned()
+                    .unwrap_or_else(|| value.as_bytes().to_vec());
                 push_result(
                     &mut ctx,
                     SearchField::Value,
                     key,
                     key,
                     value,
-                    preview_bytes,
+                    Some(preview_bytes),
                     SearchResultLocator::KvKey {
                         connection_id,
                         bucket_name: bucket_name.to_string(),
@@ -167,6 +168,7 @@ fn append_stream_results(
             }
             ctx.stats.records_scanned += 1;
             if ctx.query.matches(subject) {
+                ctx.stats.payload_value_bytes += msg.payload.len();
                 let item_label = stream_item_label(sequence, subject);
                 push_result(
                     &mut ctx,
@@ -174,7 +176,7 @@ fn append_stream_results(
                     &sequence.to_string(),
                     &item_label,
                     subject,
-                    subject.as_bytes(),
+                    Some(msg.payload.clone()),
                     SearchResultLocator::StreamMessage {
                         connection_id,
                         stream_name: stream_name.to_string(),
@@ -199,7 +201,7 @@ fn append_stream_results(
                     &sequence.to_string(),
                     &item_label,
                     &payload,
-                    &msg.payload,
+                    Some(msg.payload.clone()),
                     SearchResultLocator::StreamMessage {
                         connection_id,
                         stream_name: stream_name.to_string(),
@@ -224,6 +226,7 @@ fn append_subscriber_results(
             }
             ctx.stats.records_scanned += 1;
             if ctx.query.matches(&msg.subject) {
+                ctx.stats.payload_value_bytes += msg.payload.len();
                 let item_label = subscriber_item_label(msg);
                 push_result(
                     &mut ctx,
@@ -231,7 +234,7 @@ fn append_subscriber_results(
                     &msg.id.to_string(),
                     &item_label,
                     &msg.subject,
-                    msg.subject.as_bytes(),
+                    Some(msg.payload.clone()),
                     SearchResultLocator::SubscriberMessage {
                         connection_id,
                         backend_id,
@@ -256,7 +259,7 @@ fn append_subscriber_results(
                     &msg.id.to_string(),
                     &item_label,
                     &payload,
-                    &msg.payload,
+                    Some(msg.payload.clone()),
                     SearchResultLocator::SubscriberMessage {
                         connection_id,
                         backend_id,
@@ -286,13 +289,12 @@ fn push_result(
     item_id: &str,
     item_label: &str,
     text: &str,
-    preview_bytes: &[u8],
+    preview_bytes: Option<Vec<u8>>,
     locator: SearchResultLocator,
 ) {
     ctx.results.push(SearchWorkspaceResult {
-        identity: SearchResultIdentity {
+        key: SearchResultKey {
             source_id: ctx.source.id.clone(),
-            generation: ctx.source.generation,
             field,
             item_id: item_id.to_string(),
         },
@@ -300,7 +302,7 @@ fn push_result(
         field,
         item_label: item_label.to_string(),
         snippet: compact_text(text, 160),
-        preview_bytes: preview_bytes.to_vec(),
+        preview_bytes,
         locator,
     });
 }

--- a/crates/app/src/tabs/search_workspace/tests.rs
+++ b/crates/app/src/tabs/search_workspace/tests.rs
@@ -1,10 +1,12 @@
 use nats_backend::StreamMessageInfo;
 use tokio_util::sync::CancellationToken;
 
-use super::super::types::{SearchResultIdentity, SearchResultLocator};
+use super::super::types::{PreviewFetchState, SearchResultKey, SearchResultLocator};
 use super::*;
 use crate::format::{self, PayloadFormat};
-use crate::tabs::{KvBucketState, NormalizedSearchQuery, StreamState, TabGuard};
+use crate::tabs::{
+    KvBucketState, NormalizedSearchQuery, ReceivedMessage, StreamState, SubscriberState, TabGuard,
+};
 
 fn stream_source_and_tab(
     stream_name: &str,
@@ -204,8 +206,11 @@ fn workspace_payload_preview_keeps_original_bytes_for_formatting() {
 
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].snippet, "abc\u{fffd}");
-    assert_eq!(results[0].preview_bytes, b"abc\xff");
-    let hex = format::format_read_only_preview(&results[0].preview_bytes, PayloadFormat::Hex);
+    assert_eq!(results[0].preview_bytes, Some(b"abc\xff".to_vec()));
+    let hex = format::format_read_only_preview(
+        results[0].preview_bytes.as_deref().unwrap_or(&[]),
+        PayloadFormat::Hex,
+    );
     assert!(hex.text.contains("61 62 63 FF"));
     assert!(!hex.text.contains("EF BF BD"));
 }
@@ -229,8 +234,11 @@ fn workspace_kv_value_preview_keeps_original_bytes_for_formatting() {
 
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].snippet, "abc\u{fffd}");
-    assert_eq!(results[0].preview_bytes, b"abc\xff");
-    let hex = format::format_read_only_preview(&results[0].preview_bytes, PayloadFormat::Hex);
+    assert_eq!(results[0].preview_bytes, Some(b"abc\xff".to_vec()));
+    let hex = format::format_read_only_preview(
+        results[0].preview_bytes.as_deref().unwrap_or(&[]),
+        PayloadFormat::Hex,
+    );
     assert!(hex.text.contains("61 62 63 FF"));
     assert!(!hex.text.contains("EF BF BD"));
 }
@@ -242,12 +250,11 @@ fn workspace_preview_format_defaults_to_auto_and_persists() {
 
     state.preview_format = PayloadFormat::Json;
     state.selected_preview = Some(SearchWorkspaceResult {
-        identity: SearchResultIdentity {
+        key: SearchResultKey {
             source_id: SearchSourceId::Stream {
                 connection_id: 1,
                 stream_name: "orders".to_string(),
             },
-            generation: 1,
             field: SearchField::Payload,
             item_id: "1".to_string(),
         },
@@ -255,7 +262,7 @@ fn workspace_preview_format_defaults_to_auto_and_persists() {
         field: SearchField::Payload,
         item_label: "#1 orders.created".to_string(),
         snippet: "{\"balance\":42}".to_string(),
-        preview_bytes: br#"{"balance":42}"#.to_vec(),
+        preview_bytes: Some(br#"{"balance":42}"#.to_vec()),
         locator: SearchResultLocator::StreamMessage {
             connection_id: 1,
             stream_name: "orders".to_string(),
@@ -286,4 +293,393 @@ fn active_preview_result_prefers_current_result_and_marks_stale_snapshot() {
     let (active, stale) = active_preview_result(&snapshot, &[]);
     assert!(stale);
     assert_eq!(active.snippet, "balance: 42");
+}
+
+fn subscriber_source_and_tab(
+    backend_id: u64,
+    messages: Vec<(&str, &str)>,
+) -> (SearchSourceSummary, TabKind) {
+    let messages: Vec<(&str, Vec<u8>)> = messages
+        .into_iter()
+        .map(|(subject, payload)| (subject, payload.as_bytes().to_vec()))
+        .collect();
+    subscriber_source_and_tab_bytes(backend_id, messages)
+}
+
+fn subscriber_source_and_tab_bytes(
+    backend_id: u64,
+    messages: Vec<(&str, Vec<u8>)>,
+) -> (SearchSourceSummary, TabKind) {
+    let messages: std::collections::VecDeque<ReceivedMessage> = messages
+        .into_iter()
+        .enumerate()
+        .map(|(idx, (subject, payload))| ReceivedMessage {
+            id: idx as u64 + 1,
+            subject: subject.to_string(),
+            reply: None,
+            headers: Vec::new(),
+            payload,
+            timestamp: std::time::SystemTime::now(),
+            reply_state: None,
+            reply_draft: None,
+        })
+        .collect();
+    let tab = TabKind::Subscriber {
+        connection_id: 1,
+        connection_name: "local".to_string(),
+        guard: TabGuard::new_without_id(CancellationToken::new()),
+        backend_id,
+        state: SubscriberState {
+            messages,
+            ..Default::default()
+        },
+    };
+    let source = source_summary_from_tab(&tab).expect("subscriber tab is searchable");
+    (source, tab)
+}
+
+#[test]
+fn stream_subject_match_preview_shows_payload() {
+    let (source, tab) = stream_source_and_tab_bytes(
+        "orders",
+        1,
+        vec![("orders.created", b"balance: 42".to_vec())],
+    );
+    // Search by primary field (Subject) only
+    let state = SearchWorkspaceState {
+        query: "orders".to_string(),
+        selected_sources: vec![source.id.clone()],
+        primary: true,
+        secondary: false,
+        ..Default::default()
+    };
+
+    let results = workspace_results(&state, &[(source, tab)]);
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].field, SearchField::Subject);
+    // Preview should show the message payload, not the subject string
+    assert_eq!(results[0].preview_bytes, Some(b"balance: 42".to_vec()));
+    assert_ne!(
+        results[0].preview_bytes,
+        Some(results[0].item_label.as_bytes().to_vec())
+    );
+}
+
+#[test]
+fn stream_subject_match_preview_keeps_original_bytes_for_formatting() {
+    let (source, tab) =
+        stream_source_and_tab_bytes("orders", 1, vec![("orders.created", b"abc\xff".to_vec())]);
+    let state = SearchWorkspaceState {
+        query: "orders".to_string(),
+        selected_sources: vec![source.id.clone()],
+        primary: true,
+        secondary: false,
+        ..Default::default()
+    };
+
+    let results = workspace_results(&state, &[(source, tab)]);
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].field, SearchField::Subject);
+    assert_eq!(results[0].preview_bytes, Some(b"abc\xff".to_vec()));
+    let hex = format::format_read_only_preview(
+        results[0].preview_bytes.as_deref().unwrap_or(&[]),
+        PayloadFormat::Hex,
+    );
+    assert!(hex.text.contains("61 62 63 FF"));
+}
+
+#[test]
+fn subscriber_subject_match_preview_shows_payload() {
+    let (source, tab) = subscriber_source_and_tab(2, vec![("events.created", "data: hello")]);
+    let state = SearchWorkspaceState {
+        query: "events".to_string(),
+        selected_sources: vec![source.id.clone()],
+        primary: true,
+        secondary: false,
+        ..Default::default()
+    };
+
+    let results = workspace_results(&state, &[(source, tab)]);
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].field, SearchField::Subject);
+    // Preview should show the message payload, not the subject string
+    assert_eq!(results[0].preview_bytes, Some(b"data: hello".to_vec()));
+}
+
+#[test]
+fn subscriber_subject_match_preview_keeps_original_bytes_for_formatting() {
+    let (source, tab) =
+        subscriber_source_and_tab_bytes(2, vec![("events.created", b"abc\xff".to_vec())]);
+    let state = SearchWorkspaceState {
+        query: "events".to_string(),
+        selected_sources: vec![source.id.clone()],
+        primary: true,
+        secondary: false,
+        ..Default::default()
+    };
+
+    let results = workspace_results(&state, &[(source, tab)]);
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].field, SearchField::Subject);
+    assert_eq!(results[0].preview_bytes, Some(b"abc\xff".to_vec()));
+    let hex = format::format_read_only_preview(
+        results[0].preview_bytes.as_deref().unwrap_or(&[]),
+        PayloadFormat::Hex,
+    );
+    assert!(hex.text.contains("61 62 63 FF"));
+}
+
+#[test]
+fn kv_key_match_preview_shows_value_when_available() {
+    let (source, tab) = kv_source_and_tab(
+        "orders",
+        1,
+        vec![("order/1", "some value".to_string(), b"some value".to_vec())],
+    );
+    let state = SearchWorkspaceState {
+        query: "order".to_string(),
+        selected_sources: vec![source.id.clone()],
+        primary: true,
+        secondary: false,
+        ..Default::default()
+    };
+
+    let results = workspace_results(&state, &[(source, tab)]);
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].field, SearchField::Key);
+    // KV Key match: preview shows the value (from fetched_value_bytes), not the key name
+    assert_eq!(results[0].preview_bytes, Some(b"some value".to_vec()));
+    assert_ne!(results[0].preview_bytes, Some(b"order/1".to_vec()));
+}
+
+#[test]
+fn kv_key_match_preview_is_none_when_value_not_fetched() {
+    // Key exists in keys list but value hasn't been fetched yet.
+    let state = KvBucketState {
+        keys: vec!["order/1".to_string()],
+        search_generation: 1,
+        ..Default::default()
+    };
+    let tab = TabKind::KvBucket {
+        connection_id: 1,
+        connection_name: "local".to_string(),
+        bucket_name: "orders".to_string(),
+        guard: TabGuard::new_without_id(CancellationToken::new()),
+        state,
+    };
+    let source = source_summary_from_tab(&tab).expect("KV tab is searchable");
+    let ws_state = SearchWorkspaceState {
+        query: "order".to_string(),
+        selected_sources: vec![source.id.clone()],
+        primary: true,
+        secondary: false,
+        ..Default::default()
+    };
+
+    let results = workspace_results(&ws_state, &[(source, tab)]);
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].field, SearchField::Key);
+    assert_eq!(results[0].preview_bytes, None);
+}
+
+#[test]
+fn stream_subject_match_tracks_payload_value_bytes() {
+    let (source, tab) =
+        stream_source_and_tab_bytes("orders", 1, vec![("orders.created", b"hello".to_vec())]);
+    let state = SearchWorkspaceState {
+        query: "orders".to_string(),
+        selected_sources: vec![source.id.clone()],
+        primary: true,
+        secondary: false,
+        ..Default::default()
+    };
+
+    let mut results = Vec::new();
+    let mut stats = SearchWorkspaceBuildStats::default();
+    let query = NormalizedSearchQuery::new(&state.query).expect("normalized query");
+    append_search_workspace_results(&source, &tab, &query, true, false, &mut results, &mut stats);
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(stats.payload_value_bytes, 5); // "hello" is 5 bytes
+}
+
+#[test]
+fn preview_fetch_state_default_is_idle() {
+    let state = PreviewFetchState::default();
+    assert!(matches!(state, PreviewFetchState::Idle));
+}
+
+#[test]
+fn preview_fetch_state_transition_idle_to_loading_to_idle() {
+    let key = SearchResultKey {
+        source_id: SearchSourceId::Kv {
+            connection_id: 1,
+            bucket_name: "orders".to_string(),
+        },
+        field: SearchField::Key,
+        item_id: "order/1".to_string(),
+    };
+
+    // Idle -> Loading
+    let state = PreviewFetchState::Loading(key.clone());
+    assert!(matches!(&state, PreviewFetchState::Loading(k) if k == &key));
+
+    // Loading -> Idle (value arrived)
+    let state = PreviewFetchState::Idle;
+    assert!(matches!(state, PreviewFetchState::Idle));
+}
+
+#[test]
+fn preview_fetch_state_transition_idle_to_loading_to_failed() {
+    let key = SearchResultKey {
+        source_id: SearchSourceId::Kv {
+            connection_id: 1,
+            bucket_name: "orders".to_string(),
+        },
+        field: SearchField::Key,
+        item_id: "order/1".to_string(),
+    };
+
+    // Idle -> Loading -> Failed (fetch error)
+    let state = PreviewFetchState::Failed {
+        key: key.clone(),
+        message: "connection refused".to_string(),
+    };
+    match &state {
+        PreviewFetchState::Failed { key: k, message } => {
+            assert_eq!(k, &key);
+            assert_eq!(message, "connection refused");
+        }
+        _ => panic!("expected Failed state"),
+    }
+}
+
+#[test]
+fn preview_fetch_state_transition_failed_to_loading_retry() {
+    let key = SearchResultKey {
+        source_id: SearchSourceId::Kv {
+            connection_id: 1,
+            bucket_name: "orders".to_string(),
+        },
+        field: SearchField::Key,
+        item_id: "order/1".to_string(),
+    };
+
+    // Failed -> Loading (user clicks retry)
+    let _before = PreviewFetchState::Failed {
+        key: key.clone(),
+        message: "connection refused".to_string(),
+    };
+    let state = PreviewFetchState::Loading(key.clone());
+    assert!(matches!(&state, PreviewFetchState::Loading(k) if k == &key));
+}
+
+#[test]
+fn search_result_key_equality_ignores_generation() {
+    // SearchResultKey deliberately excludes generation from its identity.
+    // Two keys with identical source_id, field, and item_id must be equal.
+    let key_a = SearchResultKey {
+        source_id: SearchSourceId::Kv {
+            connection_id: 1,
+            bucket_name: "orders".to_string(),
+        },
+        field: SearchField::Key,
+        item_id: "order/1".to_string(),
+    };
+    let key_b = key_a.clone();
+    assert_eq!(key_a, key_b);
+
+    // Different item_id → not equal
+    let key_c = SearchResultKey {
+        item_id: "order/2".to_string(),
+        ..key_a.clone()
+    };
+    assert_ne!(key_a, key_c);
+
+    // Different field → not equal
+    let key_d = SearchResultKey {
+        field: SearchField::Value,
+        ..key_a.clone()
+    };
+    assert_ne!(key_a, key_d);
+
+    // Different source_id → not equal
+    let key_e = SearchResultKey {
+        source_id: SearchSourceId::Kv {
+            connection_id: 2,
+            bucket_name: "orders".to_string(),
+        },
+        ..key_a.clone()
+    };
+    assert_ne!(key_a, key_e);
+}
+
+#[test]
+fn stale_kv_key_match_with_none_preview_does_not_trigger_fetch() {
+    // Simulate: KV Key match selected, value not fetched (preview_bytes = None).
+    // Key is then deleted → results rebuild without it → snapshot is stale.
+    // active_preview_result must return is_stale = true so render_preview
+    // shows "value_not_found" instead of emitting an infinite fetch loop.
+    let (source, _tab) = kv_source_and_tab("orders", 1, Vec::new());
+    let ws_state = SearchWorkspaceState {
+        query: "order".to_string(),
+        selected_sources: vec![source.id.clone()],
+        primary: true,
+        secondary: false,
+        ..Default::default()
+    };
+
+    // Build results with a key that has no fetched value (preview_bytes = None).
+    // We need a key in the keys list but not in fetched_value_bytes.
+    let state_with_key = KvBucketState {
+        keys: vec!["order/1".to_string()],
+        search_generation: 1,
+        ..Default::default()
+    };
+    let tab_with_key = TabKind::KvBucket {
+        connection_id: 1,
+        connection_name: "local".to_string(),
+        bucket_name: "orders".to_string(),
+        guard: TabGuard::new_without_id(CancellationToken::new()),
+        state: state_with_key,
+    };
+    let source_with_key = source_summary_from_tab(&tab_with_key).expect("KV tab is searchable");
+    let results = workspace_results(&ws_state, &[(source_with_key, tab_with_key)]);
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].preview_bytes, None);
+
+    // Snapshot the selected result.
+    let snapshot = results[0].clone();
+
+    // Simulate key deletion: rebuild with empty keys (generation bumped).
+    let state_deleted = KvBucketState {
+        keys: Vec::new(),
+        search_generation: 2,
+        ..Default::default()
+    };
+    let tab_deleted = TabKind::KvBucket {
+        connection_id: 1,
+        connection_name: "local".to_string(),
+        bucket_name: "orders".to_string(),
+        guard: TabGuard::new_without_id(CancellationToken::new()),
+        state: state_deleted,
+    };
+    let source_deleted = source_summary_from_tab(&tab_deleted).expect("KV tab is searchable");
+    let rebuilt_results = workspace_results(&ws_state, &[(source_deleted, tab_deleted)]);
+
+    // The key is gone from rebuilt results.
+    assert!(rebuilt_results.iter().all(|r| r.key != snapshot.key));
+
+    // active_preview_result marks the snapshot as stale.
+    let (active, is_stale) = active_preview_result(&snapshot, &rebuilt_results);
+    assert!(is_stale);
+    assert_eq!(active.preview_bytes, None);
+    // The render_preview guard: is_stale && preview_bytes == None → show "value_not_found",
+    // do NOT emit fetch. This test verifies the precondition for that guard.
 }

--- a/crates/app/src/tabs/types.rs
+++ b/crates/app/src/tabs/types.rs
@@ -136,6 +136,10 @@ pub enum TabAction {
     ScanSearchWorkspaceKvValues {
         source_id: SearchSourceId,
     },
+    FetchSearchWorkspaceKvValue {
+        source_id: SearchSourceId,
+        key: String,
+    },
     NavigateSearchResult {
         locator: SearchResultLocator,
     },
@@ -298,23 +302,43 @@ pub struct SearchSourceSummary {
     pub kind: SearchSourceKind,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SearchResultIdentity {
+/// Stable identity for search result selection and preview matching.
+///
+/// `generation` is intentionally excluded — it lives only in
+/// `SearchWorkspaceCacheKey.sources` for cache invalidation. Genuine
+/// staleness (key deleted, value changed) is still detected because the
+/// result disappears from the rebuilt list.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SearchResultKey {
     pub source_id: SearchSourceId,
-    pub generation: u64,
     pub field: SearchField,
     pub item_id: String,
 }
 
 #[derive(Debug, Clone)]
 pub struct SearchWorkspaceResult {
-    pub identity: SearchResultIdentity,
+    pub key: SearchResultKey,
     pub source_label: String,
     pub field: SearchField,
     pub item_label: String,
     pub snippet: String,
-    pub preview_bytes: Vec<u8>,
+    /// `None` means preview content is not yet materialized (only valid for
+    /// KV Key matches where the value hasn't been fetched).
+    /// `Some(vec![])` means the value exists but is empty.
+    pub preview_bytes: Option<Vec<u8>>,
     pub locator: SearchResultLocator,
+}
+
+/// Tracks the on-demand fetch lifecycle for a KV Key match preview.
+#[derive(Debug, Clone, Default)]
+pub enum PreviewFetchState {
+    #[default]
+    Idle,
+    Loading(SearchResultKey),
+    Failed {
+        key: SearchResultKey,
+        message: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -333,9 +357,10 @@ pub struct SearchWorkspaceState {
     pub primary: bool,
     pub secondary: bool,
     pub selected_sources: Vec<SearchSourceId>,
-    pub selected_result: Option<SearchResultIdentity>,
+    pub selected_result: Option<SearchResultKey>,
     pub selected_preview: Option<SearchWorkspaceResult>,
     pub preview_format: PayloadFormat,
+    pub preview_fetch: PreviewFetchState,
     pub cached_results: Option<CachedSearchWorkspaceResults>,
 }
 
@@ -380,6 +405,7 @@ impl Default for SearchWorkspaceState {
             selected_result: None,
             selected_preview: None,
             preview_format: PayloadFormat::Auto,
+            preview_fetch: PreviewFetchState::default(),
             cached_results: None,
         }
     }

--- a/packaging/flatpak/io.github.mcthesw.easy-nats.metainfo.xml
+++ b/packaging/flatpak/io.github.mcthesw.easy-nats.metainfo.xml
@@ -25,6 +25,11 @@
   <releases>
     <release version="0.1.27" date="2026-06-28">
       <description>
+        <p>Search Workspace preview now shows the value for Key matches and payload for Subject matches.</p>
+      </description>
+    </release>
+    <release version="0.1.27" date="2026-06-28">
+      <description>
         <p>Adds scoped request/reply debugging with subscriber replies.</p>
       </description>
     </release>


### PR DESCRIPTION
Selecting a Key match (KV) or Subject match (Stream/Subscriber) in the Search Workspace now shows the corresponding value/payload in the preview panel, instead of echoing the key name or subject string. KV Key matches fetch the value on-demand with loading and error states.

![preview](docs/pr-screenshots/search-workspace-key-value-preview.png)