### PR TITLE
feat(settings): hide backing streams in sidebar by default

### DIFF
--- a/assets/i18n/settings.yaml
+++ b/assets/i18n/settings.yaml
@@ -55,6 +55,10 @@ pubsub_tab_mode_reuse:
   en: "Reuse existing tab"
   zh: "复用已有标签页"
 
+show_backing_streams:
+  en: "Show KV/Object backing streams"
+  zh: "显示 KV/Object 底层流"
+
 section_message_schemas:
   en: "Message Schemas"
   zh: "消息 Schema"

--- a/crates/app/src/app/sidebar.rs
+++ b/crates/app/src/app/sidebar.rs
@@ -278,6 +278,12 @@ fn render_streams_section(
             if let Some(infos) = app.stream_lists.get(&id) {
                 for info in infos {
                     let stream_name = info.name.as_str();
+                    if !stream_visible_in_sidebar(
+                        stream_name,
+                        app.settings.show_backing_streams_in_sidebar,
+                    ) {
+                        continue;
+                    }
                     if ui.selectable_label(false, stream_name).clicked() {
                         let cancel = CancellationToken::new();
                         let guard = TabGuard::new_without_id(cancel);
@@ -295,6 +301,14 @@ fn render_streams_section(
                 }
             }
         });
+}
+
+fn stream_visible_in_sidebar(stream_name: &str, show_backing_streams: bool) -> bool {
+    show_backing_streams || !is_backing_stream_name(stream_name)
+}
+
+fn is_backing_stream_name(stream_name: &str) -> bool {
+    stream_name.starts_with("KV_") || stream_name.starts_with("OBJ_")
 }
 
 fn render_kv_section(
@@ -460,5 +474,24 @@ fn apply_sidebar_action(app: &mut EasyNatsApp, action: Option<SidebarAction>) {
             app.open_or_focus_clients_tab(id);
         }
         None => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::stream_visible_in_sidebar;
+
+    #[test]
+    fn backing_streams_are_hidden_by_default() {
+        assert!(!stream_visible_in_sidebar("KV_orders", false));
+        assert!(!stream_visible_in_sidebar("OBJ_reports", false));
+        assert!(stream_visible_in_sidebar("ORDERS", false));
+    }
+
+    #[test]
+    fn backing_streams_are_visible_when_opted_in() {
+        assert!(stream_visible_in_sidebar("KV_orders", true));
+        assert!(stream_visible_in_sidebar("OBJ_reports", true));
+        assert!(stream_visible_in_sidebar("ORDERS", true));
     }
 }

--- a/crates/app/src/settings.rs
+++ b/crates/app/src/settings.rs
@@ -36,6 +36,8 @@ pub struct AppSettings {
     #[serde(default)]
     pub pubsub_tab_mode: PubSubTabMode,
     #[serde(default)]
+    pub show_backing_streams_in_sidebar: bool,
+    #[serde(default)]
     pub proto_schema_dir: Option<String>,
     #[serde(default)]
     pub topic_history: Vec<String>,
@@ -52,6 +54,8 @@ struct StoredAppSettings {
     #[serde(default)]
     pubsub_tab_mode: PubSubTabMode,
     #[serde(default)]
+    show_backing_streams_in_sidebar: bool,
+    #[serde(default)]
     proto_schema_dir: Option<String>,
     #[serde(default)]
     topic_history: Vec<String>,
@@ -63,6 +67,7 @@ impl Default for AppSettings {
             language: Language::En,
             theme: None,
             pubsub_tab_mode: PubSubTabMode::NewTab,
+            show_backing_streams_in_sidebar: false,
             proto_schema_dir: None,
             topic_history: Vec::new(),
         }
@@ -99,6 +104,7 @@ impl AppSettings {
                 .theme
                 .or_else(|| stored.dark_mode.map(ThemeId::from_legacy_dark_mode)),
             pubsub_tab_mode: stored.pubsub_tab_mode,
+            show_backing_streams_in_sidebar: stored.show_backing_streams_in_sidebar,
             proto_schema_dir: stored.proto_schema_dir,
             topic_history: stored.topic_history,
         })
@@ -196,6 +202,21 @@ mod tests {
         let settings = AppSettings::parse(r#"{ "pubsub_tab_mode": "reuse-existing" }"#).unwrap();
 
         assert_eq!(settings.pubsub_tab_mode, PubSubTabMode::ReuseExisting);
+    }
+
+    #[test]
+    fn backing_streams_sidebar_visibility_defaults_to_hidden() {
+        let settings = AppSettings::parse(r#"{}"#).unwrap();
+
+        assert!(!settings.show_backing_streams_in_sidebar);
+    }
+
+    #[test]
+    fn backing_streams_sidebar_visibility_parses_opt_in() {
+        let settings =
+            AppSettings::parse(r#"{ "show_backing_streams_in_sidebar": true }"#).unwrap();
+
+        assert!(settings.show_backing_streams_in_sidebar);
     }
 
     #[test]

--- a/crates/app/src/tabs/settings.rs
+++ b/crates/app/src/tabs/settings.rs
@@ -75,6 +75,16 @@ pub fn settings_ui(
             });
     });
 
+    if ui
+        .checkbox(
+            &mut settings.show_backing_streams_in_sidebar,
+            t("settings.show_backing_streams"),
+        )
+        .changed()
+    {
+        settings.save();
+    }
+
     ui.add_space(12.0);
     ui.separator();
     ui.label(egui::RichText::new(t("settings.section_message_schemas")).strong());


### PR DESCRIPTION
Hide KV/Object backing streams from the Streams sidebar by default, with a Settings toggle to show them.