### PR TITLE
fix(homebrew): use supported macOS dependency syntax

### DIFF
--- a/packaging/homebrew/easy-nats.rb.tmpl
+++ b/packaging/homebrew/easy-nats.rb.tmpl
@@ -7,7 +7,7 @@ cask "easy-nats" do
   name "Easy NATS"
   desc "Desktop GUI client for NATS servers, JetStream, KV, and Object Store"
   homepage "https://github.com/mcthesw/easy-nats"
-  depends_on macos: ">= :catalina"
+  depends_on macos: :catalina
 
   livecheck do
     url :url


### PR DESCRIPTION
Update the generated Cask dependency syntax.