### PR TITLE
feat(theme): add theme-aware payload syntax highlighting

### DIFF
--- a/crates/app/src/format/json.rs
+++ b/crates/app/src/format/json.rs
@@ -1,6 +1,8 @@
 use eframe::egui;
 use egui::text::LayoutJob;
 
+use crate::theme::SyntaxPalette;
+
 use super::format_text;
 
 /// Pretty-print JSON. Returns the formatted string.
@@ -12,31 +14,9 @@ pub fn format_json(data: &[u8]) -> String {
 }
 
 /// Build a `LayoutJob` with basic JSON syntax highlighting.
-pub fn json_syntax_highlight(json: &str, style: &egui::Style) -> LayoutJob {
+pub fn json_syntax_highlight(json: &str, palette: SyntaxPalette) -> LayoutJob {
     let mut job = LayoutJob::default();
     let mono = egui::FontId::monospace(13.0);
-    let base_color = style.visuals.text_color();
-
-    let string_color = if style.visuals.dark_mode {
-        egui::Color32::from_rgb(152, 195, 121)
-    } else {
-        egui::Color32::from_rgb(80, 161, 79)
-    };
-    let number_color = if style.visuals.dark_mode {
-        egui::Color32::from_rgb(209, 154, 102)
-    } else {
-        egui::Color32::from_rgb(152, 104, 1)
-    };
-    let keyword_color = if style.visuals.dark_mode {
-        egui::Color32::from_rgb(86, 182, 194)
-    } else {
-        egui::Color32::from_rgb(1, 132, 188)
-    };
-    let key_color = if style.visuals.dark_mode {
-        egui::Color32::from_rgb(224, 108, 117)
-    } else {
-        egui::Color32::from_rgb(228, 86, 73)
-    };
 
     let chars: Vec<char> = json.chars().collect();
     let mut i = 0;
@@ -60,18 +40,30 @@ pub fn json_syntax_highlight(json: &str, style: &egui::Style) -> LayoutJob {
                     i += 1;
                 }
                 let s: String = chars[start..i].iter().collect();
-                let color = if after_colon { string_color } else { key_color };
+                let color = if after_colon {
+                    palette.string
+                } else {
+                    palette.property
+                };
                 job.append(&s, 0.0, egui::TextFormat::simple(mono.clone(), color));
                 after_colon = false;
             }
             ':' => {
-                job.append(":", 0.0, egui::TextFormat::simple(mono.clone(), base_color));
+                job.append(
+                    ":",
+                    0.0,
+                    egui::TextFormat::simple(mono.clone(), palette.punctuation),
+                );
                 after_colon = true;
                 i += 1;
             }
             ',' | '{' | '}' | '[' | ']' => {
                 let s = String::from(ch);
-                job.append(&s, 0.0, egui::TextFormat::simple(mono.clone(), base_color));
+                job.append(
+                    &s,
+                    0.0,
+                    egui::TextFormat::simple(mono.clone(), palette.punctuation),
+                );
                 after_colon = false;
                 i += 1;
             }
@@ -84,7 +76,7 @@ pub fn json_syntax_highlight(json: &str, style: &egui::Style) -> LayoutJob {
                 job.append(
                     &word,
                     0.0,
-                    egui::TextFormat::simple(mono.clone(), keyword_color),
+                    egui::TextFormat::simple(mono.clone(), palette.language_constant),
                 );
                 after_colon = false;
             }
@@ -104,13 +96,17 @@ pub fn json_syntax_highlight(json: &str, style: &egui::Style) -> LayoutJob {
                 job.append(
                     &num,
                     0.0,
-                    egui::TextFormat::simple(mono.clone(), number_color),
+                    egui::TextFormat::simple(mono.clone(), palette.number),
                 );
                 after_colon = false;
             }
             _ => {
                 let s = String::from(ch);
-                job.append(&s, 0.0, egui::TextFormat::simple(mono.clone(), base_color));
+                job.append(
+                    &s,
+                    0.0,
+                    egui::TextFormat::simple(mono.clone(), palette.plain),
+                );
                 i += 1;
             }
         }

--- a/crates/app/src/format/json.rs
+++ b/crates/app/src/format/json.rs
@@ -113,3 +113,49 @@ pub fn json_syntax_highlight(json: &str, palette: SyntaxPalette) -> LayoutJob {
     }
     job
 }
+
+#[cfg(test)]
+mod tests {
+    use eframe::egui::Color32;
+
+    use super::*;
+
+    const TEST_PALETTE: SyntaxPalette = SyntaxPalette {
+        plain: Color32::from_rgb(1, 2, 3),
+        property: Color32::from_rgb(4, 5, 6),
+        string: Color32::from_rgb(7, 8, 9),
+        number: Color32::from_rgb(10, 11, 12),
+        language_constant: Color32::from_rgb(13, 14, 15),
+        punctuation: Color32::from_rgb(16, 17, 18),
+    };
+
+    fn color_for(job: &LayoutJob, text: &str) -> Color32 {
+        let start = egui::text::ByteIndex(job.text.find(text).expect("token must be present"));
+        job.sections
+            .iter()
+            .find(|section| section.byte_range.contains(&start))
+            .map(|section| section.format.color)
+            .expect("token must belong to a layout section")
+    }
+
+    #[test]
+    fn syntax_highlight_uses_semantic_palette_roles() {
+        let json = r#"{"key":"value","number":-12.5e+2,"boolean":true,"empty":null}"#;
+        let job = json_syntax_highlight(json, TEST_PALETTE);
+
+        assert_eq!(color_for(&job, r#""key""#), TEST_PALETTE.property);
+        assert_eq!(color_for(&job, r#""value""#), TEST_PALETTE.string);
+        assert_eq!(color_for(&job, "-12.5e+2"), TEST_PALETTE.number);
+        assert_eq!(color_for(&job, "true"), TEST_PALETTE.language_constant);
+        assert_eq!(color_for(&job, "null"), TEST_PALETTE.language_constant);
+        assert_eq!(color_for(&job, "{"), TEST_PALETTE.punctuation);
+        assert_eq!(color_for(&job, ":"), TEST_PALETTE.punctuation);
+    }
+
+    #[test]
+    fn syntax_highlight_keeps_whitespace_in_plain_text_color() {
+        let job = json_syntax_highlight("{ \"key\": true }", TEST_PALETTE);
+
+        assert_eq!(color_for(&job, " "), TEST_PALETTE.plain);
+    }
+}

--- a/crates/app/src/format/mod.rs
+++ b/crates/app/src/format/mod.rs
@@ -3,6 +3,7 @@ use eframe::egui;
 
 use crate::proto::{AutoDetectResult, ProtoViewState};
 use crate::schema::{MessageSchemaManager, PayloadSchemaStatus, SchemaStatusLevel};
+use crate::theme::SyntaxPalette;
 
 mod json;
 pub mod msgpack;
@@ -146,12 +147,17 @@ pub fn format_selector(ui: &mut egui::Ui, id_salt: &str, format: &mut PayloadFor
 }
 
 /// Render formatted payload into the UI with appropriate styling.
-pub fn render_payload(ui: &mut egui::Ui, data: &[u8], format: PayloadFormat) {
+pub fn render_payload(
+    ui: &mut egui::Ui,
+    data: &[u8],
+    format: PayloadFormat,
+    syntax_palette: SyntaxPalette,
+) {
     let resolved = resolve_format(format, data);
     match resolved {
         PayloadFormat::Json => {
             let pretty = format_json(data);
-            let job = json_syntax_highlight(&pretty, ui.style());
+            let job = json_syntax_highlight(&pretty, syntax_palette);
             ui.label(job);
         }
         PayloadFormat::Hex => {
@@ -189,12 +195,13 @@ pub fn render_payload_with_proto(
     id_salt: &str,
     proto_state: &mut ProtoViewState,
     manager: &MessageSchemaManager,
+    syntax_palette: SyntaxPalette,
 ) {
     let resolved = resolve_format(format, data);
     if resolved == PayloadFormat::Protobuf {
-        render_protobuf_payload(ui, data, id_salt, proto_state, manager);
+        render_protobuf_payload(ui, data, id_salt, proto_state, manager, syntax_palette);
     } else {
-        render_payload(ui, data, format);
+        render_payload(ui, data, format, syntax_palette);
     }
 }
 
@@ -203,6 +210,7 @@ pub struct SchemaRenderContext<'a> {
     pub manager: &'a MessageSchemaManager,
     pub connection_id: u64,
     pub subject: &'a str,
+    pub syntax_palette: SyntaxPalette,
 }
 
 pub fn render_payload_with_schema(
@@ -222,16 +230,32 @@ pub fn render_payload_with_schema(
         ui.add_space(4.0);
         if format == PayloadFormat::Auto {
             if let Some(json) = rendered.json {
-                let job = json_syntax_highlight(&json, ui.style());
+                let job = json_syntax_highlight(&json, schema.syntax_palette);
                 ui.label(job);
             } else {
-                render_payload(ui, data, PayloadFormat::Auto);
+                render_payload(ui, data, PayloadFormat::Auto, schema.syntax_palette);
             }
         } else {
-            render_payload_with_proto(ui, data, format, id_salt, proto_state, schema.manager);
+            render_payload_with_proto(
+                ui,
+                data,
+                format,
+                id_salt,
+                proto_state,
+                schema.manager,
+                schema.syntax_palette,
+            );
         }
     } else {
-        render_payload_with_proto(ui, data, format, id_salt, proto_state, schema.manager);
+        render_payload_with_proto(
+            ui,
+            data,
+            format,
+            id_salt,
+            proto_state,
+            schema.manager,
+            schema.syntax_palette,
+        );
     }
 }
 
@@ -252,12 +276,13 @@ fn render_protobuf_payload(
     id_salt: &str,
     proto_state: &mut ProtoViewState,
     manager: &MessageSchemaManager,
+    syntax_palette: SyntaxPalette,
 ) {
     let message_types = manager.manual_message_types();
     if !message_types.is_empty() {
         render_proto_type_selector(ui, id_salt, proto_state, &message_types);
         ui.add_space(4.0);
-        render_proto_decoded(ui, data, proto_state, manager);
+        render_proto_decoded(ui, data, proto_state, manager, syntax_palette);
     } else {
         let text = MessageSchemaManager::decode_wire_format(data);
         ui.label(egui::RichText::new(text).monospace());
@@ -317,6 +342,7 @@ fn render_proto_decoded(
     data: &[u8],
     state: &mut ProtoViewState,
     manager: &MessageSchemaManager,
+    syntax_palette: SyntaxPalette,
 ) {
     if data.is_empty() {
         ui.label("(empty payload)");
@@ -331,7 +357,7 @@ fn render_proto_decoded(
                         .small()
                         .weak(),
                 );
-                let job = json_syntax_highlight(&json, ui.style());
+                let job = json_syntax_highlight(&json, syntax_palette);
                 ui.label(job);
             }
             AutoDetectResult::Ambiguous(types) => {
@@ -354,7 +380,7 @@ fn render_proto_decoded(
     } else if !state.selected_type.is_empty() {
         match manager.decode_manual_proto(data, &state.selected_type) {
             Ok(json) => {
-                let job = json_syntax_highlight(&json, ui.style());
+                let job = json_syntax_highlight(&json, syntax_palette);
                 ui.label(job);
             }
             Err(e) => {

--- a/crates/app/src/tabs/kv.rs
+++ b/crates/app/src/tabs/kv.rs
@@ -5,6 +5,7 @@ use crate::format;
 use crate::i18n::t;
 use crate::schema::{MessageSchemaManager, kv_subject};
 use crate::tabs::guard::TabGuard;
+use crate::theme::SyntaxPalette;
 
 use super::common::{
     KV_VALUE_SEARCH_BATCH, SearchStatus, auto_refresh_ui, format_bytes,
@@ -24,6 +25,7 @@ pub fn kv_bucket_ui(
     actions: &mut Vec<TabAction>,
     schema_manager: &MessageSchemaManager,
     guard: &TabGuard,
+    syntax_palette: SyntaxPalette,
 ) {
     ui.horizontal(|ui| {
         ui.heading(bucket_name);
@@ -102,7 +104,14 @@ pub fn kv_bucket_ui(
     // Right panel: detail or history
     egui::CentralPanel::default().show(ui, |ui| {
         if state.show_history {
-            render_history(ui, connection_id, bucket_name, state, schema_manager);
+            render_history(
+                ui,
+                connection_id,
+                bucket_name,
+                state,
+                schema_manager,
+                syntax_palette,
+            );
         } else {
             render_detail_panel(
                 ui,
@@ -111,6 +120,7 @@ pub fn kv_bucket_ui(
                 state,
                 backend,
                 schema_manager,
+                syntax_palette,
             );
         }
     });
@@ -344,6 +354,7 @@ fn render_detail_panel(
     state: &mut KvBucketState,
     backend: &BackendHandle,
     schema_manager: &MessageSchemaManager,
+    syntax_palette: SyntaxPalette,
 ) {
     if state.selected_key.is_none() {
         ui.centered_and_justified(|ui| {
@@ -513,6 +524,7 @@ fn render_detail_panel(
                 "kv_editor_proto",
                 &mut state.editor_proto_view,
                 schema_manager,
+                syntax_palette,
             );
         });
 }
@@ -523,6 +535,7 @@ fn render_history(
     bucket_name: &str,
     state: &mut KvBucketState,
     schema_manager: &MessageSchemaManager,
+    syntax_palette: SyntaxPalette,
 ) {
     ui.horizontal(|ui| {
         if ui.button(t("kv.back_to_detail")).clicked() {
@@ -565,6 +578,7 @@ fn render_history(
                                     manager: schema_manager,
                                     connection_id,
                                     subject: &subject,
+                                    syntax_palette,
                                 },
                             );
                         });

--- a/crates/app/src/tabs/publisher.rs
+++ b/crates/app/src/tabs/publisher.rs
@@ -4,6 +4,7 @@ use nats_backend::{BackendCommand, BackendHandle};
 use crate::format;
 use crate::i18n::t;
 use crate::schema::MessageSchemaManager;
+use crate::theme::SyntaxPalette;
 
 use super::common::{collect_headers, payload_input_format_selector, topic_history_text_edit};
 use super::types::{CurrentRequest, PublisherState, RequestStatus, TabAction};
@@ -18,6 +19,7 @@ pub fn publisher_ui(
     schema_manager: &MessageSchemaManager,
     actions: &mut Vec<TabAction>,
     topic_suggestions: &[&str],
+    syntax_palette: SyntaxPalette,
 ) {
     ui.horizontal(|ui| {
         ui.label(t("publisher.subject"));
@@ -173,7 +175,7 @@ pub fn publisher_ui(
         ui.label(t("publisher.response"));
         format::format_selector(ui, "pub_resp_fmt", &mut state.response_format);
     });
-    render_current_response(ui, connection_id, state, schema_manager);
+    render_current_response(ui, connection_id, state, schema_manager, syntax_palette);
 }
 
 fn render_generate_json_button(
@@ -210,6 +212,7 @@ fn render_current_response(
     connection_id: u64,
     state: &mut PublisherState,
     schema_manager: &MessageSchemaManager,
+    syntax_palette: SyntaxPalette,
 ) {
     let PublisherState {
         current_request,
@@ -228,6 +231,7 @@ fn render_current_response(
         *response_format,
         proto_view,
         schema_manager,
+        syntax_palette,
     );
 }
 
@@ -238,6 +242,7 @@ fn render_request_detail(
     response_format: format::PayloadFormat,
     proto_view: &mut crate::proto::ProtoViewState,
     schema_manager: &MessageSchemaManager,
+    syntax_palette: SyntaxPalette,
 ) {
     match request.status {
         RequestStatus::Waiting => {
@@ -289,6 +294,7 @@ fn render_request_detail(
                         manager: schema_manager,
                         connection_id,
                         subject,
+                        syntax_palette,
                     },
                 );
             });

--- a/crates/app/src/tabs/stream.rs
+++ b/crates/app/src/tabs/stream.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, SystemTime};
 use crate::format::{self, PayloadFormat};
 use crate::i18n::t;
 use crate::schema::MessageSchemaManager;
+use crate::theme::SyntaxPalette;
 
 use super::common::{
     NormalizedSearchQuery, SEARCH_RESULT_LIMIT, SearchStatus, auto_refresh_ui, format_bytes,
@@ -13,6 +14,7 @@ use super::common::{
 use super::stream_consumers::render_consumers;
 use super::types::{SearchCacheKey, StreamState, TabAction};
 
+#[allow(clippy::too_many_arguments)]
 pub fn stream_ui(
     ui: &mut egui::Ui,
     connection_id: u64,
@@ -21,6 +23,7 @@ pub fn stream_ui(
     backend: &BackendHandle,
     actions: &mut Vec<TabAction>,
     schema_manager: &MessageSchemaManager,
+    syntax_palette: SyntaxPalette,
 ) {
     // Auto-refresh toggle
     ui.horizontal(|ui| {
@@ -96,6 +99,7 @@ pub fn stream_ui(
                             &mut state.payload_format,
                             &mut state.proto_view,
                             schema_manager,
+                            syntax_palette,
                         );
                     }
                 } else {
@@ -459,6 +463,7 @@ fn stream_message_detail(
     payload_format: &mut PayloadFormat,
     proto_view: &mut crate::proto::ProtoViewState,
     schema_manager: &MessageSchemaManager,
+    syntax_palette: SyntaxPalette,
 ) {
     ui.horizontal(|ui| {
         ui.label(t("stream.msg_detail"));
@@ -512,6 +517,7 @@ fn stream_message_detail(
                 manager: schema_manager,
                 connection_id,
                 subject: &msg.subject,
+                syntax_palette,
             },
         );
     } else {
@@ -522,6 +528,7 @@ fn stream_message_detail(
             "stream_proto",
             proto_view,
             schema_manager,
+            syntax_palette,
         );
     }
 }

--- a/crates/app/src/tabs/subscriber.rs
+++ b/crates/app/src/tabs/subscriber.rs
@@ -3,6 +3,7 @@ use nats_backend::{BackendCommand, BackendHandle};
 
 use crate::i18n::t;
 use crate::schema::MessageSchemaManager;
+use crate::theme::SyntaxPalette;
 
 use super::common::{
     NormalizedSearchQuery, SEARCH_RESULT_LIMIT, SearchStatus, format_timestamp, render_search_row,
@@ -26,6 +27,7 @@ pub fn subscriber_ui(
     schema_manager: &MessageSchemaManager,
     actions: &mut Vec<TabAction>,
     topic_suggestions: &[&str],
+    syntax_palette: SyntaxPalette,
 ) {
     render_subscription_controls(
         ui,
@@ -59,6 +61,7 @@ pub fn subscriber_ui(
                 state,
                 backend,
                 schema_manager,
+                syntax_palette,
             );
         } else {
             ui.centered_and_justified(|ui| {

--- a/crates/app/src/tabs/subscriber_detail.rs
+++ b/crates/app/src/tabs/subscriber_detail.rs
@@ -81,11 +81,32 @@ pub(super) fn message_detail_ui(
                 });
         }
 
+        if msg.reply.is_some() {
+            egui::Panel::bottom(egui::Id::new(("subscriber_reply", msg.id)))
+                .resizable(true)
+                .default_size(220.0)
+                .size_range(120.0..=f32::INFINITY)
+                .show(ui, |ui| {
+                    egui::ScrollArea::vertical()
+                        .id_salt(("subscriber_reply_scroll", msg.id))
+                        .auto_shrink([false; 2])
+                        .show(ui, |ui| {
+                            render_reply_composer(
+                                ui,
+                                connection_id,
+                                msg,
+                                schema_manager,
+                                &mut pending_reply,
+                            );
+                        });
+                });
+        }
+
         ui.add_space(4.0);
         ui.label(t("subscriber.detail_payload"));
         egui::ScrollArea::vertical()
             .id_salt("msg_detail_payload")
-            .max_height(220.0)
+            .auto_shrink([false; 2])
             .show(ui, |ui| {
                 format::render_payload_with_schema(
                     ui,
@@ -101,8 +122,6 @@ pub(super) fn message_detail_ui(
                     },
                 );
             });
-
-        render_reply_composer(ui, connection_id, msg, schema_manager, &mut pending_reply);
     }
 
     if let Some(reply) = pending_reply {

--- a/crates/app/src/tabs/subscriber_detail.rs
+++ b/crates/app/src/tabs/subscriber_detail.rs
@@ -4,6 +4,7 @@ use nats_backend::{BackendCommand, BackendHandle};
 use crate::format;
 use crate::i18n::t;
 use crate::schema::{MessageSchemaManager, PayloadInputFormat};
+use crate::theme::SyntaxPalette;
 
 use super::common::{collect_headers, format_timestamp, payload_input_format_selector};
 use super::types::{ReceivedMessage, ReplyDraft, ReplyState, SubscriberState};
@@ -17,6 +18,7 @@ struct PendingReply {
     headers: Option<Vec<(String, String)>>,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn message_detail_ui(
     ui: &mut egui::Ui,
     connection_id: u64,
@@ -25,6 +27,7 @@ pub(super) fn message_detail_ui(
     state: &mut SubscriberState,
     backend: &BackendHandle,
     schema_manager: &MessageSchemaManager,
+    syntax_palette: SyntaxPalette,
 ) {
     let mut pending_reply = None;
     {
@@ -94,6 +97,7 @@ pub(super) fn message_detail_ui(
                         manager: schema_manager,
                         connection_id,
                         subject: &msg.subject,
+                        syntax_palette,
                     },
                 );
             });

--- a/crates/app/src/tabs/viewer.rs
+++ b/crates/app/src/tabs/viewer.rs
@@ -5,6 +5,7 @@ use crate::tabs::{
     clients_ui, kv_bucket_ui, message_schemas_ui, metrics_ui, obj_store_bucket_ui, publisher_ui,
     search_workspace_ui, server_info_ui, stream_ui, subscriber_ui,
 };
+use crate::theme::syntax_palette;
 
 use super::log_viewer::log_viewer_ui;
 use super::settings::settings_ui;
@@ -55,6 +56,7 @@ fn tab_scope_id(tab: &TabKind) -> String {
 }
 
 fn render_tab_body(viewer: &mut AppTabViewer<'_>, ui: &mut egui::Ui, tab: &mut TabKind) {
+    let syntax_palette = syntax_palette(*viewer.theme_id);
     match tab {
         TabKind::Welcome => {
             let available = ui.available_size();
@@ -100,6 +102,7 @@ fn render_tab_body(viewer: &mut AppTabViewer<'_>, ui: &mut egui::Ui, tab: &mut T
                 viewer.schema_manager,
                 viewer.actions,
                 &suggestions,
+                syntax_palette,
             );
         }
         TabKind::Subscriber {
@@ -120,6 +123,7 @@ fn render_tab_body(viewer: &mut AppTabViewer<'_>, ui: &mut egui::Ui, tab: &mut T
                 viewer.schema_manager,
                 viewer.actions,
                 &suggestions,
+                syntax_palette,
             );
         }
         TabKind::Stream {
@@ -136,6 +140,7 @@ fn render_tab_body(viewer: &mut AppTabViewer<'_>, ui: &mut egui::Ui, tab: &mut T
                 viewer.backend,
                 viewer.actions,
                 viewer.schema_manager,
+                syntax_palette,
             );
         }
         TabKind::KvBucket {
@@ -154,6 +159,7 @@ fn render_tab_body(viewer: &mut AppTabViewer<'_>, ui: &mut egui::Ui, tab: &mut T
                 viewer.actions,
                 viewer.schema_manager,
                 guard,
+                syntax_palette,
             );
         }
         TabKind::ObjectStoreBucket {

--- a/crates/app/src/theme/catppuccin.rs
+++ b/crates/app/src/theme/catppuccin.rs
@@ -268,3 +268,92 @@ fn make_widget_visual(
         ..old
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn syntax_palettes_use_unmodified_official_colors() {
+        for (theme_id, expected) in [
+            (
+                ThemeId::CatppuccinLatte,
+                (
+                    [76, 79, 105],
+                    [30, 102, 245],
+                    [64, 160, 43],
+                    [254, 100, 11],
+                    [124, 127, 147],
+                ),
+            ),
+            (
+                ThemeId::CatppuccinFrappe,
+                (
+                    [198, 208, 245],
+                    [140, 170, 238],
+                    [166, 209, 137],
+                    [239, 159, 118],
+                    [148, 156, 187],
+                ),
+            ),
+            (
+                ThemeId::CatppuccinMacchiato,
+                (
+                    [202, 211, 245],
+                    [138, 173, 244],
+                    [166, 218, 149],
+                    [245, 169, 127],
+                    [147, 154, 183],
+                ),
+            ),
+            (
+                ThemeId::CatppuccinMocha,
+                (
+                    [205, 214, 244],
+                    [137, 180, 250],
+                    [166, 227, 161],
+                    [250, 179, 135],
+                    [147, 153, 178],
+                ),
+            ),
+        ] {
+            let syntax = syntax_palette(theme_id);
+            let (text, blue, green, peach, overlay2) = expected;
+            assert_eq!(syntax.plain, Color32::from_rgb(text[0], text[1], text[2]));
+            assert_eq!(
+                syntax.property,
+                Color32::from_rgb(blue[0], blue[1], blue[2])
+            );
+            assert_eq!(
+                syntax.string,
+                Color32::from_rgb(green[0], green[1], green[2])
+            );
+            assert_eq!(
+                syntax.number,
+                Color32::from_rgb(peach[0], peach[1], peach[2])
+            );
+            assert_eq!(
+                syntax.language_constant,
+                Color32::from_rgb(peach[0], peach[1], peach[2])
+            );
+            assert_eq!(
+                syntax.punctuation,
+                Color32::from_rgb(overlay2[0], overlay2[1], overlay2[2])
+            );
+        }
+    }
+
+    #[test]
+    fn each_catppuccin_flavor_has_distinct_syntax_colors() {
+        let palettes = [
+            syntax_palette(ThemeId::CatppuccinLatte),
+            syntax_palette(ThemeId::CatppuccinFrappe),
+            syntax_palette(ThemeId::CatppuccinMacchiato),
+            syntax_palette(ThemeId::CatppuccinMocha),
+        ];
+
+        for (index, palette) in palettes.iter().enumerate() {
+            assert!(palettes[index + 1..].iter().all(|other| other != palette));
+        }
+    }
+}

--- a/crates/app/src/theme/catppuccin.rs
+++ b/crates/app/src/theme/catppuccin.rs
@@ -1,6 +1,6 @@
 use eframe::egui::{self, Color32};
 
-use super::ThemeId;
+use super::{SyntaxPalette, ThemeId};
 
 // Portions of the Catppuccin theme implementation below are derived from
 // https://github.com/catppuccin/egui (commit ffb92d2da71b72bde41d83bbc0a46917de97b486),
@@ -173,16 +173,32 @@ const MOCHA: CatppuccinTheme = CatppuccinTheme {
 };
 
 pub(super) fn apply_theme(ctx: &egui::Context, theme_id: ThemeId) {
-    let theme = match theme_id {
+    let theme = resolve_theme(theme_id);
+
+    let old = ctx.global_style().visuals.clone();
+    ctx.set_visuals(make_visuals(theme, old));
+}
+
+pub(super) fn syntax_palette(theme_id: ThemeId) -> SyntaxPalette {
+    let theme = resolve_theme(theme_id);
+    SyntaxPalette {
+        plain: theme.text,
+        property: theme.blue,
+        string: theme.green,
+        number: theme.peach,
+        language_constant: theme.peach,
+        punctuation: theme.overlay2,
+    }
+}
+
+fn resolve_theme(theme_id: ThemeId) -> CatppuccinTheme {
+    match theme_id {
         ThemeId::CatppuccinLatte => LATTE,
         ThemeId::CatppuccinFrappe => FRAPPE,
         ThemeId::CatppuccinMacchiato => MACCHIATO,
         ThemeId::CatppuccinMocha => MOCHA,
         _ => unreachable!("Catppuccin theme provider only handles Catppuccin themes"),
-    };
-
-    let old = ctx.global_style().visuals.clone();
-    ctx.set_visuals(make_visuals(theme, old));
+    }
 }
 
 fn make_visuals(theme: CatppuccinTheme, old: egui::Visuals) -> egui::Visuals {

--- a/crates/app/src/theme/mod.rs
+++ b/crates/app/src/theme/mod.rs
@@ -2,11 +2,13 @@ mod builtin;
 mod catalog;
 mod catppuccin;
 mod id;
+mod syntax;
 
 use eframe::egui;
 
 pub use catalog::{theme_catalog, theme_definition};
 pub use id::ThemeId;
+pub(crate) use syntax::{SyntaxPalette, syntax_palette};
 
 pub fn resolve_theme(saved_theme: Option<ThemeId>, system_prefers_dark: Option<bool>) -> ThemeId {
     saved_theme

--- a/crates/app/src/theme/syntax.rs
+++ b/crates/app/src/theme/syntax.rs
@@ -1,0 +1,100 @@
+use eframe::egui::{Color32, Visuals};
+
+use super::{ThemeId, catppuccin};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SyntaxPalette {
+    pub plain: Color32,
+    pub property: Color32,
+    pub string: Color32,
+    pub number: Color32,
+    pub language_constant: Color32,
+    pub punctuation: Color32,
+}
+
+pub(crate) fn syntax_palette(theme_id: ThemeId) -> SyntaxPalette {
+    match theme_id {
+        ThemeId::EguiDark => builtin_palette(true),
+        ThemeId::EguiLight => builtin_palette(false),
+        ThemeId::CatppuccinLatte
+        | ThemeId::CatppuccinFrappe
+        | ThemeId::CatppuccinMacchiato
+        | ThemeId::CatppuccinMocha => catppuccin::syntax_palette(theme_id),
+    }
+}
+
+fn builtin_palette(dark: bool) -> SyntaxPalette {
+    let plain = if dark {
+        Visuals::dark().text_color()
+    } else {
+        Visuals::light().text_color()
+    };
+    let (property, string, number, language_constant) = if dark {
+        (
+            Color32::from_rgb(224, 108, 117),
+            Color32::from_rgb(152, 195, 121),
+            Color32::from_rgb(209, 154, 102),
+            Color32::from_rgb(86, 182, 194),
+        )
+    } else {
+        (
+            Color32::from_rgb(228, 86, 73),
+            Color32::from_rgb(80, 161, 79),
+            Color32::from_rgb(152, 104, 1),
+            Color32::from_rgb(1, 132, 188),
+        )
+    };
+
+    SyntaxPalette {
+        plain,
+        property,
+        string,
+        number,
+        language_constant,
+        punctuation: plain,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn egui_palettes_preserve_existing_json_colors() {
+        let dark = syntax_palette(ThemeId::EguiDark);
+        assert_eq!(dark.property, Color32::from_rgb(224, 108, 117));
+        assert_eq!(dark.string, Color32::from_rgb(152, 195, 121));
+        assert_eq!(dark.number, Color32::from_rgb(209, 154, 102));
+        assert_eq!(dark.language_constant, Color32::from_rgb(86, 182, 194));
+        assert_eq!(dark.plain, Visuals::dark().text_color());
+        assert_eq!(dark.punctuation, dark.plain);
+
+        let light = syntax_palette(ThemeId::EguiLight);
+        assert_eq!(light.property, Color32::from_rgb(228, 86, 73));
+        assert_eq!(light.string, Color32::from_rgb(80, 161, 79));
+        assert_eq!(light.number, Color32::from_rgb(152, 104, 1));
+        assert_eq!(light.language_constant, Color32::from_rgb(1, 132, 188));
+        assert_eq!(light.plain, Visuals::light().text_color());
+        assert_eq!(light.punctuation, light.plain);
+    }
+
+    #[test]
+    fn every_theme_resolves_to_a_complete_palette() {
+        for theme_id in [
+            ThemeId::EguiDark,
+            ThemeId::EguiLight,
+            ThemeId::CatppuccinLatte,
+            ThemeId::CatppuccinFrappe,
+            ThemeId::CatppuccinMacchiato,
+            ThemeId::CatppuccinMocha,
+        ] {
+            let palette = syntax_palette(theme_id);
+            assert_ne!(palette.plain, Color32::TRANSPARENT);
+            assert_ne!(palette.property, Color32::TRANSPARENT);
+            assert_ne!(palette.string, Color32::TRANSPARENT);
+            assert_ne!(palette.number, Color32::TRANSPARENT);
+            assert_ne!(palette.language_constant, Color32::TRANSPARENT);
+            assert_ne!(palette.punctuation, Color32::TRANSPARENT);
+        }
+    }
+}


### PR DESCRIPTION
Use the active theme’s semantic palette for JSON payload, schema-bound JSON, and Protobuf-decoded JSON. Catppuccin themes use their official unmodified flavor colors, while egui Dark and Light preserve their existing syntax colors.

Also remove the Subscriber Payload preview’s fixed 220pt cap and keep request reply composition in a resizable bottom panel so the preview uses the remaining detail space.