### PR TITLE
ci(web): publish static site branch

### DIFF
--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -1,0 +1,63 @@
+name: Publish Website
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: publish-website
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.1.2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: website/pnpm-lock.yaml
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.15.0
+
+      - name: Install dependencies
+        working-directory: website
+        run: pnpm install --frozen-lockfile
+
+      - name: Check website
+        working-directory: website
+        run: pnpm typecheck
+
+      - name: Build website
+        working-directory: website
+        run: pnpm build
+
+      - name: Publish website branch
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: website
+          publish_dir: website/dist
+          force_orphan: true

--- a/website/README.md
+++ b/website/README.md
@@ -1,14 +1,10 @@
 # Easy NATS website
 
-This directory contains the static Vue shell for the Easy NATS live demo and
-installation page. Vue owns only the public page; the desktop and browser demos
-share the same egui application code.
-
 ## Local development
 
 Requirements:
 
-- Node.js 20 or newer
+- Node.js 22.13 or newer
 - pnpm 11
 - Rust with the `wasm32-unknown-unknown` target
 - `wasm-pack` 0.15 available on `PATH`
@@ -20,40 +16,11 @@ pnpm install --frozen-lockfile
 pnpm dev
 ```
 
-Use `pnpm typecheck` for the Vue/TypeScript check. `pnpm build` rebuilds the
-Rust WASM package and creates the complete static production site in
-`website/dist`. `pnpm preview` serves that output locally after a build.
-
-Screens at least 900 px wide load the interactive WASM demo. Smaller screens
-use the checked-in desktop preview and do not request the WASM runtime. Language
-and theme choices are intentionally in-memory and reset from browser/system
-preferences on refresh.
-
-## Cloudflare Pages
-
-The build assumes deployment at the root of a domain and needs no Pages
-Functions, runtime variables, redirects, or custom headers.
-
-For a Dashboard Direct Upload:
-
-1. Run `pnpm build`.
-2. In Cloudflare, open **Workers & Pages** and create a Direct Upload project.
-3. Upload the `website/dist` directory.
-4. In the Pages project, open **Custom domains**, select **Set up a domain**,
-   and bind the desired domain or subdomain.
-
-For Wrangler Direct Upload from this directory:
-
 ```sh
+pnpm typecheck
 pnpm build
-pnpm dlx wrangler@latest login
-pnpm dlx wrangler@latest pages project create
-pnpm dlx wrangler@latest pages deploy dist --project-name <PROJECT_NAME>
+pnpm preview
 ```
 
-Cloudflare documents both deployment paths in its
-[Direct Upload guide](https://developers.cloudflare.com/pages/get-started/direct-upload/)
-and describes domain binding in
-[Custom domains](https://developers.cloudflare.com/pages/configuration/custom-domains/).
-Choose the project mode deliberately: Cloudflare currently does not allow a
-Direct Upload project to be converted to Git integration later.
+`pnpm build` rebuilds the Rust WASM package and writes the static site to
+`dist`. Run `pnpm preview` after a build to preview that output locally.


### PR DESCRIPTION
Build the website after changes land on main and replace the orphan website branch with the generated static output. Keep the website README focused on local development.